### PR TITLE
Fix SmallestMaxSize

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -219,7 +219,7 @@ class SmallestMaxSize(DualTransform):
 
     def __init__(self, max_size=1024, interpolation=cv2.INTER_LINEAR, always_apply=False, p=1):
         super(SmallestMaxSize, self).__init__(always_apply, p)
-        self.inteprolation = interpolation
+        self.interpolation = interpolation
         self.max_size = max_size
 
     def apply(self, img, interpolation=cv2.INTER_LINEAR, **params):


### PR DESCRIPTION
When 1 character makes all the difference. This produces a major F-up on resized masks, as the `interpolation` parameter was not overridden to `INTER_NEAREST` in `DualTransform`