### PR TITLE
Cast RandomResizedCrop h/w to int when falling back to center crop

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -772,7 +772,7 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
             w = int(round(math.sqrt(target_area * aspect_ratio)))
             h = int(round(math.sqrt(target_area / aspect_ratio)))
 
-            if w <= img.shape[1] and h <= img.shape[0]:
+            if 0 < w <= img.shape[1] and 0 < h <= img.shape[0]:
                 i = random.randint(0, img.shape[0] - h)
                 j = random.randint(0, img.shape[1] - w)
                 return {
@@ -786,10 +786,10 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
         in_ratio = img.shape[1] / img.shape[0]
         if in_ratio < min(self.ratio):
             w = img.shape[1]
-            h = int(w / min(self.ratio))
+            h = int(round(w / min(self.ratio)))
         elif in_ratio > max(self.ratio):
             h = img.shape[0]
-            w = int(h * max(self.ratio))
+            w = int(round(h * max(self.ratio)))
         else:  # whole image
             w = img.shape[1]
             h = img.shape[0]


### PR DESCRIPTION
I had the following exception when trying to use the new `RandomResizedCrop`. Digging in with the debugger I found that `random_crop` indices were occasionally float. I traced it back to the fallback logic. Casting to `int` had the desired effect.

```
    augmented = self.transforms(image=img_array, mask=mask_array)
  File "/home/aleksey/anaconda3/envs/segmentation/lib/python3.7/site-packages/albumentations-0.3.2-py3.7.egg/albumentations/core/composition.py", line 158, in __call__
    data = t(force_apply=force_apply, **data)
  File "/home/aleksey/anaconda3/envs/segmentation/lib/python3.7/site-packages/albumentations-0.3.2-py3.7.egg/albumentations/core/transforms_interface.py", line 65, in __call__
    res[key] = target_function(arg, **dict(params, **target_dependencies))
  File "/home/aleksey/anaconda3/envs/segmentation/lib/python3.7/site-packages/albumentations-0.3.2-py3.7.egg/albumentations/augmentations/transforms.py", line 680, in apply
    crop = F.random_crop(img, crop_height, crop_width, h_start, w_start)
  File "/home/aleksey/anaconda3/envs/segmentation/lib/python3.7/site-packages/albumentations-0.3.2-py3.7.egg/albumentations/augmentations/functional.py", line 277, in random_crop
    img = img[y1:y2, x1:x2]
TypeError: slice indices must be integers or None or have an __index__ method
```
