### PR TITLE
Marked deprecated transforms in README and docstrings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [ChannelDropout](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ChannelDropout)
 - [ChannelShuffle](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ChannelShuffle)
 - [CoarseDropout](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.CoarseDropout)
-- [Cutout](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Cutout)
+- [Cutout](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Cutout)[Deprecated]
 - [Downscale](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Downscale)
 - [Equalize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Equalize)
 - [FromFloat](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.FromFloat)
@@ -132,15 +132,15 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [ISONoise](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ISONoise)
 - [ImageCompression](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ImageCompression)
 - [InvertImg](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.InvertImg)
-- [JpegCompression](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.JpegCompression)
+- [JpegCompression](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.JpegCompression)[Deprecated]
 - [MedianBlur](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.MedianBlur)
 - [MotionBlur](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.MotionBlur)
 - [Normalize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Normalize)
 - [Posterize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Posterize)
 - [RGBShift](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RGBShift)
-- [RandomBrightness](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomBrightness)
+- [RandomBrightness](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomBrightness)[Deprecated]
 - [RandomBrightnessContrast](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomBrightnessContrast)
-- [RandomContrast](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomContrast)
+- [RandomContrast](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomContrast)[Deprecated]
 - [RandomFog](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomFog)
 - [RandomGamma](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomGamma)
 - [RandomRain](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomRain)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1433,7 +1433,9 @@ class Normalize(ImageOnlyTransform):
 
 
 class Cutout(ImageOnlyTransform):
-    """CoarseDropout of the square regions in the image.
+    """Deprecated:: Please use CoarseDropout.
+
+    CoarseDropout of the square regions in the image.
 
     Args:
         num_holes (int): number of regions to zero out
@@ -1629,7 +1631,9 @@ class ImageCompression(ImageOnlyTransform):
 
 
 class JpegCompression(ImageCompression):
-    """Decrease Jpeg compression of an image.
+    """Deprecated:: Please use ImageCompression.
+
+    Decrease Jpeg compression of an image.
 
     Args:
         quality_lower (float): lower bound on the jpeg quality. Should be in [0, 100] range
@@ -2315,7 +2319,9 @@ class RandomBrightnessContrast(ImageOnlyTransform):
 
 
 class RandomBrightness(RandomBrightnessContrast):
-    """Randomly change brightness of the input image.
+    """Deprecated:: Please use RandomBrightnessContrast.
+
+    Randomly change brightness of the input image.
 
     Args:
         limit ((float, float) or float): factor range for changing brightness.
@@ -2340,7 +2346,9 @@ class RandomBrightness(RandomBrightnessContrast):
 
 
 class RandomContrast(RandomBrightnessContrast):
-    """Randomly change contrast of the input image.
+    """Deprecated:: Please use RandomBrightnessContrast.
+
+    Randomly change contrast of the input image.
 
     Args:
         limit ((float, float) or float): factor range for changing contrast.


### PR DESCRIPTION
Fixes issue #427

Added [Deprecated] tags in README and modified the docstrings for deprecated transforms.