### PR TITLE
Fix lambda inconclusive check

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -2905,7 +2905,7 @@ class Lambda(NoOp):
         self.custom_apply_fns = {target_name: F.noop for target_name in ("image", "mask", "keypoint", "bbox")}
         for target_name, custom_apply_fn in {"image": image, "mask": mask, "keypoint": keypoint, "bbox": bbox}.items():
             if custom_apply_fn is not None:
-                if isinstance(custom_apply_fn, LambdaType):
+                if isinstance(custom_apply_fn, LambdaType) and custom_apply_fn.__name__ == "<lambda>":
                     warnings.warn(
                         "Using lambda is incompatible with multiprocessing. "
                         "Consider using regular functions or partial()."


### PR DESCRIPTION
The condition for checking whether the functions passed into the Lambda() transforms class is not sufficient as a regular function will also be considered an instance of types.LambdaType. See https://stackoverflow.com/a/23852434/1591757.

This adds a secondary check on the object name to help reduce false positives.