### PR TITLE
Make cutout work with 3-channels images

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -146,8 +146,9 @@ def normalize(img, mean, std, max_pixel_value=255.0):
 def cutout(img, holes, fill_value=0):
     # Make a copy of the input image since we don't want to modify it directly
     img = img.copy()
+    fill_value = np.array(fill_value)[..., None, None]  # for right-size broadcast
     for x1, y1, x2, y2 in holes:
-        img[y1:y2, x1:x2] = fill_value
+        img[:, y1:y2, x1:x2] = fill_value
     return img
 
 

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1554,7 +1554,7 @@ class CoarseDropout(ImageOnlyTransform):
 
     def get_params_dependent_on_targets(self, params):
         img = params["image"]
-        height, width = img.shape[:2]
+        *_, height, width = img.shape
 
         holes = []
         for _n in range(random.randint(self.min_holes, self.max_holes)):


### PR DESCRIPTION
This patch checked inside pytorch pipeline with input shape [3, :, :]

https://github.com/albumentations-team/albumentations/issues/515