### PR TITLE
Fix wrong varible usage in grid_distortion

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -1069,7 +1069,7 @@ def grid_distortion(
     y_step = height // num_steps
     yy = np.zeros(height, np.float32)
     prev = 0
-    for idx, y in enumerate(np.linspace(0, width, num_steps)):
+    for idx, y in enumerate(np.linspace(0, height, num_steps)):
         start = int(y)
         end = int(y) + y_step
         if end > height:


### PR DESCRIPTION
'width' is used in both directions.
```
for idx, x in enumerate(np.linspace(0, width, num_steps)):
    ...
for idx, y in enumerate(np.linspace(0, width, num_steps)):
    ...
```
It should be `height`  in the row direction.