### PR TITLE
Fix Cutout bug #418

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1483,9 +1483,15 @@ class Cutout(ImageOnlyTransform):
             x = random.randint(0, width)
 
             y1 = np.clip(y - self.max_h_size // 2, 0, height)
-            y2 = np.clip(y + self.max_h_size // 2, 0, height)
+            if self.max_h_size % 2 == 0:
+                y2 = np.clip(y + self.max_h_size // 2, 0, height)
+            else:
+                y2 = np.clip(y + self.max_h_size // 2 + 1, 0, height)
             x1 = np.clip(x - self.max_w_size // 2, 0, width)
-            x2 = np.clip(x + self.max_w_size // 2, 0, width)
+            if self.max_w_size % 2 == 0:
+                x2 = np.clip(x + self.max_w_size // 2, 0, width)
+            else:
+                x2 = np.clip(x + self.max_w_size // 2 + 1, 0, width)
             holes.append((x1, y1, x2, y2))
 
         return {"holes": holes}

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1483,15 +1483,9 @@ class Cutout(ImageOnlyTransform):
             x = random.randint(0, width)
 
             y1 = np.clip(y - self.max_h_size // 2, 0, height)
-            if self.max_h_size % 2 == 0:
-                y2 = np.clip(y + self.max_h_size // 2, 0, height)
-            else:
-                y2 = np.clip(y + self.max_h_size // 2 + 1, 0, height)
+            y2 = np.clip(y1 + self.max_h_size, 0, height)
             x1 = np.clip(x - self.max_w_size // 2, 0, width)
-            if self.max_w_size % 2 == 0:
-                x2 = np.clip(x + self.max_w_size // 2, 0, width)
-            else:
-                x2 = np.clip(x + self.max_w_size // 2 + 1, 0, width)
+            x2 = np.clip(x1 + self.max_w_size, 0, width)
             holes.append((x1, y1, x2, y2))
 
         return {"holes": holes}


### PR DESCRIPTION
Fix Cutout bug #418.

This bug is caused by rounding down both pos and neg values when adding and subtracting an `odd // 2` from the standard coordinates.

I know this `albumentations.Cutout` has been deprecated, but I think it is a big bug that the box is not displayed when the size is set to 1, so I hope to merge it.