### PR TITLE
Adds Recursion's logo to the Used By section in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,9 @@ You can find their names and links to the solutions [here](docs/hall_of_fame.rst
 <a href="https://www.lyft.com/" target="_blank"><img src="https://habrastorage.org/webt/ce/bs/sa/cebssajf_5asst5yshmyykqjhcg.png" width="100"/></a>
 <a href="https://www.x5.ru/en" target="_blank"><img src="https://habrastorage.org/webt/9y/dv/f1/9ydvf1fbxotkl6nyhydrn9v8cqw.png" width="100"/></a>
 <a href="https://imedhub.org/" target="_blank"><img src="https://habrastorage.org/webt/eq/8x/m-/eq8xm-fjfx_uqkka4_ekxsdwtiq.png" width="100"/></a>
+<a href="https://recursionpharma.com" target="_blank"><img src="https://pbs.twimg.com/profile_images/925897897165639683/jI8YvBfC_400x400.jpg" width="100"/></a>
+
+
 
 ## Comments
 In some systems, in the multiple GPU regime PyTorch may deadlock the DataLoader if OpenCV was compiled with OpenCL optimizations. Adding the following two lines before the library import may help. For more details [https://github.com/pytorch/pytorch/issues/1355](https://github.com/pytorch/pytorch/issues/1355)


### PR DESCRIPTION
We have been using Albumenations at Recursion and love the library, thanks for all the hard work on it!

Feel free to put the logo in the same storage provider as the other logos, I couldn't see how to do that. Also, if you want to add our logo to your new fancy website that is fine as well.

/cc @ternaus 