### PR TITLE
Add support of [H,W,1] images in CLAHE

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -627,13 +627,14 @@ def linear_transformation_rgb(img, transformation_matrix):
     return result_img
 
 
+@preserve_channel_dim
 def clahe(img, clip_limit=2.0, tile_grid_size=(8, 8)):
     if img.dtype != np.uint8:
         raise TypeError("clahe supports only uint8 inputs")
 
     clahe = cv2.createCLAHE(clipLimit=clip_limit, tileGridSize=tile_grid_size)
 
-    if len(img.shape) == 2:
+    if len(img.shape) == 2 or img.shape[2] == 1:
         img = clahe.apply(img)
     else:
         img = cv2.cvtColor(img, cv2.COLOR_RGB2LAB)


### PR DESCRIPTION
Currently code assumes grayscale image has shape [H,W]. This PR adds support of [H,W,1] shape.