### PR TITLE
Different input and output formats for bboxes and keypoints

### DIFF
--- a/albumentations/augmentations/bbox_utils.py
+++ b/albumentations/augmentations/bbox_utils.py
@@ -45,7 +45,7 @@ class BboxProcessor(DataProcessor):
         return check_bboxes(data)
 
     def convert_from_albumentations(self, data, rows, cols):
-        return convert_bboxes_from_albumentations(data, self.params.format, rows, cols, check_validity=True)
+        return convert_bboxes_from_albumentations(data, self.params.result_format, rows, cols, check_validity=True)
 
     def convert_to_albumentations(self, data, rows, cols):
         return convert_bboxes_to_albumentations(data, self.params.format, rows, cols, check_validity=True)

--- a/albumentations/augmentations/keypoints_utils.py
+++ b/albumentations/augmentations/keypoints_utils.py
@@ -60,7 +60,7 @@ class KeypointsProcessor(DataProcessor):
     def convert_from_albumentations(self, data, rows, cols):
         return convert_keypoints_from_albumentations(
             data,
-            self.params.format,
+            self.params.result_format,
             rows,
             cols,
             check_validity=self.params.remove_invisible,

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -374,10 +374,11 @@ class BboxParams(Params):
             visible area in pixels is less than this value will be removed. Default: 0.0.
         min_visibility (float): minimum fraction of area for a bounding box
             to remain this box in list. Default: 0.0.
+        result_format (str): result format of bounding box. By default has same value as `format`.
     """
 
-    def __init__(self, format, label_fields=None, min_area=0.0, min_visibility=0.0):
-        super(BboxParams, self).__init__(format, label_fields)
+    def __init__(self, format, label_fields=None, min_area=0.0, min_visibility=0.0, result_format=None):
+        super(BboxParams, self).__init__(format, label_fields, result_format)
         self.min_area = min_area
         self.min_visibility = min_visibility
 
@@ -405,10 +406,11 @@ class KeypointParams(Params):
             Should be same type as keypoints.
         remove_invisible (bool): to remove invisible points after transform or not
         angle_in_degrees (bool): angle in degrees or radians in 'xya', 'xyas', 'xysa' keypoints
+        result_format (str): result format of keypoints. By default has same value as `format`.
     """
 
-    def __init__(self, format, label_fields=None, remove_invisible=True, angle_in_degrees=True):
-        super(KeypointParams, self).__init__(format, label_fields)
+    def __init__(self, format, label_fields=None, remove_invisible=True, angle_in_degrees=True, result_format=None):
+        super(KeypointParams, self).__init__(format, label_fields, result_format)
         self.remove_invisible = remove_invisible
         self.angle_in_degrees = angle_in_degrees
 

--- a/albumentations/core/utils.py
+++ b/albumentations/core/utils.py
@@ -15,12 +15,13 @@ def format_args(args_dict):
 
 @add_metaclass(ABCMeta)
 class Params:
-    def __init__(self, format, label_fields=None):
+    def __init__(self, format, label_fields=None, result_format=None):
         self.format = format
         self.label_fields = label_fields
+        self.result_format = result_format if result_format is not None else format
 
     def _to_dict(self):
-        return {"format": self.format, "label_fields": self.label_fields}
+        return {"format": self.format, "label_fields": self.label_fields, "result_format": self.result_format}
 
 
 @add_metaclass(ABCMeta)
@@ -62,7 +63,9 @@ class DataProcessor:
             data[data_name] = self.check_and_convert(data[data_name], rows, cols, direction="to")
 
     def check_and_convert(self, data, rows, cols, direction="to"):
-        if self.params.format == "albumentations":
+        if (direction == "to" and self.params.format == "albumentations") or (
+            direction == "from" and self.params.result_format == "albumentations"
+        ):
             self.check(data, rows, cols)
             return data
 

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -250,12 +250,12 @@ def test_result_format():
     formats = ["coco", "pascal_voc", "albumentations", "yolo"]
     img = np.empty(image_shape, dtype=np.uint8)
 
-    for format in formats:
+    for in_format in formats:
         tmp_bboxes = convert_bboxes_to_albumentations(bboxes, "pascal_voc", rows, cols)
         in_bboxes = (
             tmp_bboxes
-            if format == "albumentations"
-            else convert_bboxes_from_albumentations(tmp_bboxes, format, rows, cols)
+            if in_format == "albumentations"
+            else convert_bboxes_from_albumentations(tmp_bboxes, in_format, rows, cols)
         )
         for result_format in formats:
             result_bboxes = (
@@ -264,8 +264,8 @@ def test_result_format():
                 else convert_bboxes_from_albumentations(tmp_bboxes, result_format, rows, cols)
             )
             transform = Compose(
-                [RandomResizedCrop(50, 50, p=0)], bbox_params=BboxParams(format, result_format=result_format)
+                [RandomResizedCrop(50, 50, p=0)], bbox_params=BboxParams(in_format, result_format=result_format)
             )
             res = transform(image=img, bboxes=in_bboxes)["bboxes"]
             if not np.allclose(res, result_bboxes, 0.5):
-                raise AssertionError("Format: {} Result format: {}".format(format, result_format))
+                raise AssertionError("Format: {} Result format: {}".format(in_format, result_format))

--- a/tests/test_keypoint.py
+++ b/tests/test_keypoint.py
@@ -332,15 +332,16 @@ def test_result_format():
     formats = ["xy", "yx", "xya", "xys", "xyas", "xysa"]
     img = np.empty(image_shape, dtype=np.uint8)
 
-    for format in formats:
+    for in_format in formats:
         tmp_keypoints = convert_keypoints_to_albumentations(keypoints, "xyas", rows, cols)
-        in_keypoints = convert_keypoints_from_albumentations(tmp_keypoints, format, rows, cols)
+        in_keypoints = convert_keypoints_from_albumentations(tmp_keypoints, in_format, rows, cols)
         for result_format in formats:
-            result_keypoints = convert_keypoints_to_albumentations(in_keypoints, format, rows, cols)
+            result_keypoints = convert_keypoints_to_albumentations(in_keypoints, in_format, rows, cols)
             result_keypoints = convert_keypoints_from_albumentations(result_keypoints, result_format, rows, cols)
             transform = Compose(
-                [RandomResizedCrop(50, 50, p=0)], keypoint_params=KeypointParams(format, result_format=result_format)
+                [RandomResizedCrop(50, 50, p=0)],
+                keypoint_params=KeypointParams(in_format, result_format=result_format),
             )
             res = transform(image=img, keypoints=in_keypoints)["keypoints"]
             if not np.allclose(res, result_keypoints):
-                raise AssertionError("Format: {} Result format: {}".format(format, result_format))
+                raise AssertionError("Format: {} Result format: {}".format(in_format, result_format))


### PR DESCRIPTION
Examples:
```
transform = Compose(bbox_params=BboxParams("coco", result_format="pascal_voc"))
transform = Compose(keypoint_params=KeypointParams("xyas", result_format="xy"))
```