### PR TITLE
Add support for grayscale images to ToTensorV2

### DIFF
--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -89,6 +89,12 @@ class ToTensorV2(BasicTransform):
         return {"image": self.apply, "mask": self.apply_to_mask}
 
     def apply(self, img, **params):  # skipcq: PYL-W0613
+        if len(img.shape) not in [2, 3]:
+            raise ValueError("Albumentations only supports images in HW or HWC format")
+
+        if len(img.shape) == 2:
+            img = np.expand_dims(img, 2)
+
         return torch.from_numpy(img.transpose(2, 0, 1))
 
     def apply_to_mask(self, mask, **params):  # skipcq: PYL-W0613

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -32,6 +32,16 @@ def test_additional_targets_for_totensorv2():
         assert np.array_equal(res["mask"], res["mask2"])
 
 
+def test_torch_to_tensor_v2_on_gray_scale_images():
+    aug = ToTensorV2()
+    grayscale_image = np.random.randint(low=0, high=256, size=(100, 100), dtype=np.uint8)
+    data = aug(image=grayscale_image)
+    assert isinstance(data["image"], torch.Tensor)
+    assert len(data["image"].shape) == 3
+    assert data["image"].shape[1:] == grayscale_image.shape
+    assert data["image"].dtype == torch.uint8
+
+
 def test_torch_to_tensor_augmentations(image, mask):
     with pytest.warns(DeprecationWarning):
         aug = ToTensor()


### PR DESCRIPTION
This PR allows ToTensorV2 to automatically add dummy channel dimension to the grayscale image (hopefully, fixes #470).

I know that it can be fixed as part of #528, but it seems to be idle for several months.