### PR TITLE
Update ToTensorV2 in transforms.py

### DIFF
--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -89,7 +89,7 @@ class ToTensorV2(BasicTransform):
         return {"image": self.apply, "mask": self.apply_to_mask}
 
     def apply(self, img, **params):  # skipcq: PYL-W0613
-        return torch.from_numpy(img.transpose(2, 0, 1))
+        return torch.from_numpy(img.transpose(2, 0, 1).copy())
 
     def apply_to_mask(self, mask, **params):  # skipcq: PYL-W0613
         return torch.from_numpy(mask)


### PR DESCRIPTION
ValueError: At least one stride in the given numpy array is negative, and tensors with negative strides are not currently supported. (You can probably work around this by making a copy of your array  with array.copy().)