### PR TITLE
Implementation of #617. `check_validity` BBox parameter

### DIFF
--- a/albumentations/augmentations/bbox_utils.py
+++ b/albumentations/augmentations/bbox_utils.py
@@ -43,7 +43,7 @@ class BboxProcessor(DataProcessor):
 
     def check(self, data, rows, cols):
         if self.params.check_validity:
-            return check_bboxes(data)
+            check_bboxes(data)
 
     def convert_from_albumentations(self, data, rows, cols):
         return convert_bboxes_from_albumentations(data, self.params.format, rows, cols,
@@ -368,8 +368,7 @@ def filter_bboxes(bboxes, rows, cols, min_area=0.0, min_visibility=0.0):
         clipped_box_area = calculate_bbox_area(bbox, rows, cols)
         if not transformed_box_area or clipped_box_area / transformed_box_area <= min_visibility:
             continue
-        else:
-            bbox = tuple(np.clip(bbox[:4], 0, 1.0))
+        bbox = tuple(np.clip(bbox[:4], 0, 1.0))
         if calculate_bbox_area(bbox, rows, cols) <= min_area:
             continue
         resulting_boxes.append(bbox + tail)

--- a/albumentations/augmentations/bbox_utils.py
+++ b/albumentations/augmentations/bbox_utils.py
@@ -46,12 +46,14 @@ class BboxProcessor(DataProcessor):
             check_bboxes(data)
 
     def convert_from_albumentations(self, data, rows, cols):
-        return convert_bboxes_from_albumentations(data, self.params.format, rows, cols,
-                                                  check_validity=self.params.check_validity)
+        return convert_bboxes_from_albumentations(
+            data, self.params.format, rows, cols, check_validity=self.params.check_validity
+        )
 
     def convert_to_albumentations(self, data, rows, cols):
-        return convert_bboxes_to_albumentations(data, self.params.format, rows, cols,
-                                                check_validity=self.params.check_validity)
+        return convert_bboxes_to_albumentations(
+            data, self.params.format, rows, cols, check_validity=self.params.check_validity
+        )
 
 
 def normalize_bbox(bbox, rows, cols):

--- a/albumentations/augmentations/bbox_utils.py
+++ b/albumentations/augmentations/bbox_utils.py
@@ -42,13 +42,16 @@ class BboxProcessor(DataProcessor):
         )
 
     def check(self, data, rows, cols):
-        return check_bboxes(data)
+        if self.params.check_validity:
+            return check_bboxes(data)
 
     def convert_from_albumentations(self, data, rows, cols):
-        return convert_bboxes_from_albumentations(data, self.params.format, rows, cols, check_validity=True)
+        return convert_bboxes_from_albumentations(data, self.params.format, rows, cols,
+                                                  check_validity=self.params.check_validity)
 
     def convert_to_albumentations(self, data, rows, cols):
-        return convert_bboxes_to_albumentations(data, self.params.format, rows, cols, check_validity=True)
+        return convert_bboxes_to_albumentations(data, self.params.format, rows, cols,
+                                                check_validity=self.params.check_validity)
 
 
 def normalize_bbox(bbox, rows, cols):

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -374,16 +374,20 @@ class BboxParams(Params):
             visible area in pixels is less than this value will be removed. Default: 0.0.
         min_visibility (float): minimum fraction of area for a bounding box
             to remain this box in list. Default: 0.0.
+        check_validity (bool): check validity of input bounding boxes: all corners must be inside an image
+            and left top coordinates must be less or equal than right bottom. Default: True.
     """
 
-    def __init__(self, format, label_fields=None, min_area=0.0, min_visibility=0.0):
+    def __init__(self, format, label_fields=None, min_area=0.0, min_visibility=0.0, check_validity=True):
         super(BboxParams, self).__init__(format, label_fields)
         self.min_area = min_area
         self.min_visibility = min_visibility
+        self.check_validity = check_validity
 
     def _to_dict(self):
         data = super(BboxParams, self)._to_dict()
-        data.update({"min_area": self.min_area, "min_visibility": self.min_visibility})
+        data.update({"min_area": self.min_area, "min_visibility": self.min_visibility,
+                     "check_validity": self.check_validity})
         return data
 
 
@@ -403,8 +407,9 @@ class KeypointParams(Params):
             a - Keypoint orientation in radians or degrees (depending on KeypointParams.angle_in_degrees)
         label_fields (list): list of fields that are joined with keypoints, e.g labels.
             Should be same type as keypoints.
-        remove_invisible (bool): to remove invisible points after transform or not
-        angle_in_degrees (bool): angle in degrees or radians in 'xya', 'xyas', 'xysa' keypoints
+        remove_invisible (bool): to remove invisible points after transform or not. Default: True
+        angle_in_degrees (bool): angle in degrees or radians in 'xya', 'xyas', 'xysa' keypoints.
+            Default: True (i.e. angle in degrees)
     """
 
     def __init__(self, format, label_fields=None, remove_invisible=True, angle_in_degrees=True):

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -386,8 +386,9 @@ class BboxParams(Params):
 
     def _to_dict(self):
         data = super(BboxParams, self)._to_dict()
-        data.update({"min_area": self.min_area, "min_visibility": self.min_visibility,
-                     "check_validity": self.check_validity})
+        data.update(
+            {"min_area": self.min_area, "min_visibility": self.min_visibility, "check_validity": self.check_validity}
+        )
         return data
 
 

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -13,7 +13,7 @@ from albumentations.augmentations.bbox_utils import (
 )
 from albumentations.core.composition import Compose
 from albumentations.core.transforms_interface import NoOp
-from albumentations.augmentations.transforms import RandomSizedCrop, RandomResizedCrop, Rotate
+from albumentations.augmentations.transforms import RandomSizedCrop, RandomResizedCrop, Rotate, Crop
 
 
 @pytest.mark.parametrize(
@@ -213,6 +213,20 @@ def test_compose_with_bbox_noop_label_outside(bboxes, bbox_format, labels):
     assert transformed["bboxes"] == bboxes
     for k, v in labels.items():
         assert transformed[k] == v
+
+
+@pytest.mark.parametrize(
+    ["bboxes", "bbox_format", "result_bboxes"],
+    [
+        [[(-10, -20, 50, 150, 0)], "pascal_voc", [(0, 0, 25, 50, 0)]],
+        [[(-1, -2, 3, 0.5, 1), (-0.5, -1, 0.5, 3, 2)], "albumentations", [(0, 0, 1, 0.5, 1), (0, 0, 0.5, 1, 2)]],
+    ],
+)
+def test_compose_with_bbox_with_check_validity_false(bboxes, bbox_format, result_bboxes):
+    image = np.ones((100, 100, 3))
+    aug = Compose([Crop(25, 25, 75, 75)], bbox_params={"format": bbox_format, "check_validity": False})
+    res = aug(image=image, bboxes=bboxes)["bboxes"]
+    assert np.allclose(res, result_bboxes)
 
 
 def test_random_sized_crop_size():


### PR DESCRIPTION
Fix #617
`check_validity` parameter is added to `BboxParams`. Setting it to `False` gives a way to handle 
bounding boxes extending beyond the image.
See motivation for it in #617.