### PR TITLE
Fix #619. If `bbox_params` is set, fails if no bbox is provided

### DIFF
--- a/albumentations/core/utils.py
+++ b/albumentations/core/utils.py
@@ -48,8 +48,9 @@ class DataProcessor:
         rows, cols = data["image"].shape[:2]
 
         for data_name in self.data_fields:
-            data[data_name] = self.filter(data[data_name], rows, cols)
-            data[data_name] = self.check_and_convert(data[data_name], rows, cols, direction="from")
+            if data_name in data:
+                data[data_name] = self.filter(data[data_name], rows, cols)
+                data[data_name] = self.check_and_convert(data[data_name], rows, cols, direction="from")
 
         data = self.remove_label_fields_from_data(data)
         return data
@@ -59,7 +60,8 @@ class DataProcessor:
 
         rows, cols = data["image"].shape[:2]
         for data_name in self.data_fields:
-            data[data_name] = self.check_and_convert(data[data_name], rows, cols, direction="to")
+            if data_name in data:
+                data[data_name] = self.check_and_convert(data[data_name], rows, cols, direction="to")
 
     def check_and_convert(self, data, rows, cols, direction="to"):
         if self.params.format == "albumentations":


### PR DESCRIPTION
Fix #619. If `bbox_params` is set in constructor, processing fails if no bbox data is provided.
The same problem fixed for keypoints and additional targets.