### PR TITLE
Fix RandomSizedBBoxSafeCrop Error

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -996,6 +996,10 @@ class RandomSizedBBoxSafeCrop(DualTransform):
         x, y, x2, y2 = union_of_bboxes(
             width=img_w, height=img_h, bboxes=params["bboxes"], erosion_rate=self.erosion_rate
         )
+        
+        # normalize union
+        x, y, x2, y2 = x/img_w, y/img_h, x2/img_w, y2/img_h
+
         # find bigger region
         bx, by = x * random.random(), y * random.random()
         bx2, by2 = x2 + (1 - x2) * random.random(), y2 + (1 - y2) * random.random()


### PR DESCRIPTION
In this function:
```
    def get_params_dependent_on_targets(self, params):
        img_h, img_w = params["image"].shape[:2]
        if len(params["bboxes"]) == 0:  # less likely, this class is for use with bboxes.
            erosive_h = int(img_h * (1.0 - self.erosion_rate))
            crop_height = img_h if erosive_h >= img_h else random.randint(erosive_h, img_h)
            return {
                "h_start": random.random(),
                "w_start": random.random(),
                "crop_height": crop_height,
                "crop_width": int(crop_height * img_w / img_h),
            }
        # get union of all bboxes
        x, y, x2, y2 = union_of_bboxes(
            width=img_w, height=img_h, bboxes=params["bboxes"], erosion_rate=self.erosion_rate
        )
```
x, y, x2, y2 are all absolute size ,if don't normalize to (0,1),the latter codes will not work like they are desigined to ,and
h_start , w_start,crop_height,crop_width is almost always 0,0,img_h,img_w ,except for some invalid values..

Test results:     print(h_start ,w_start,crop_height,crop_width )
my test images shape are (1020,1980,3)

> No normalize:  (before fixed)
> {'h_start': 0.0, 'w_start': 0.0, 'crop_height': 1020, 'crop_width': 1980}
> {'h_start': 0.0, 'w_start': 0.0, 'crop_height': 1020, 'crop_width': 1980}
> {'h_start': 0.0, 'w_start': 0.0, 'crop_height': 1020, 'crop_width': 1980}
> {'h_start': 0.0, 'w_start': 0.0, 'crop_height': 1020, 'crop_width': 1980}
> {'h_start': 0.0, 'w_start': 0.0, 'crop_height': 1020, 'crop_width': 1980}
> {'h_start': 0.0, 'w_start': 0.0, 'crop_height': 1020, 'crop_width': 1980}
> {'h_start': 0.0, 'w_start': 0.0, 'crop_height': 1020, 'crop_width': 1980}
> {'h_start': 0.0, 'w_start': 0.0, 'crop_height': 1020, 'crop_width': 1980}
> 
> have normalize:  (after fixed)
> {'h_start': 0.664937539886473, 'w_start': 0.34525358203891093, 'crop_height': 794, 'crop_width': 1837}
> {'h_start': 0.13247773024678375, 'w_start': 0.529436157222367, 'crop_height': 758, 'crop_width': 1240}
> {'h_start': 0.2301028492859983, 'w_start': 0.26805136851367783, 'crop_height': 576, 'crop_width': 1782}
> {'h_start': 0.5413715114766734, 'w_start': 0.616703599475326, 'crop_height': 904, 'crop_width': 1129}
> {'h_start': 0.14450245526091324, 'w_start': 0.6991924543440396, 'crop_height': 694, 'crop_width': 1731}
> {'h_start': 0.14997454980016522, 'w_start': 0.5135681339354942, 'crop_height': 463, 'crop_width': 864}
> {'h_start': 0.13653623464037662, 'w_start': 0.05134525365777244, 'crop_height': 521, 'crop_width': 1594}

This pr can also solve this issue's problem :
https://github.com/albumentations-team/albumentations/issues/298
