### PR TITLE
Add limit_to_bbox option to GridDistortion

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -1065,6 +1065,26 @@ def optical_distortion(
     return img
 
 
+def linear_space(width, xsteps, num_steps):
+    x_step = width / num_steps
+    xx = np.zeros(width, np.float32)
+    prev = 0
+    for idx in range(num_steps):
+        x = idx * x_step
+        start = int(x)
+        end = int(x + x_step)
+        if idx >= num_steps - 1 or end >= width:
+            end = width
+            cur = width
+        else:
+            cur = prev + x_step * xsteps[idx]
+
+        xx[start:end] = np.linspace(prev, cur, end - start)
+        prev = cur
+
+    return xx
+
+
 @preserve_shape
 def grid_distortion(
     img,
@@ -1081,37 +1101,8 @@ def grid_distortion(
     """
     height, width = img.shape[:2]
 
-    x_step = width // num_steps
-    xx = np.zeros(width, np.float32)
-    prev = 0
-    for idx in range(num_steps + 1):
-        x = idx * x_step
-        start = int(x)
-        end = int(x) + x_step
-        if end > width:
-            end = width
-            cur = width
-        else:
-            cur = prev + x_step * xsteps[idx]
-
-        xx[start:end] = np.linspace(prev, cur, end - start)
-        prev = cur
-
-    y_step = height // num_steps
-    yy = np.zeros(height, np.float32)
-    prev = 0
-    for idx in range(num_steps + 1):
-        y = idx * y_step
-        start = int(y)
-        end = int(y) + y_step
-        if end > height:
-            end = height
-            cur = height
-        else:
-            cur = prev + y_step * ysteps[idx]
-
-        yy[start:end] = np.linspace(prev, cur, end - start)
-        prev = cur
+    xx = linear_space(width, xsteps, num_steps)
+    yy = linear_space(height, ysteps, num_steps)
 
     map_x, map_y = np.meshgrid(xx, yy)
     map_x = map_x.astype(np.float32)


### PR DESCRIPTION
Currently GridDistortion produces distortions than can shift content outside of the image bounding box (i.e. after the distortion, parts of the original content might not be visible). This PR adds a new parameter `limit_to_bbox` that restricts this behaviour such that no content ever gets moved outside (by making sure the sum of distortions does not exceed 1 on each axis). It produces a distortion constrained by the bounding box.

Now, to get this to work properly, I realized just now I had to change some underlying stuff in `grid_distortion`, which gets pretty tricky unfortunately.

I tried to isolate the current way (master) and another new way (this PR) of doing things. Currently things are always calculated with `num_steps + 1` internally, but then divided by `num_steps` when it comes to `x_step`. This is the rough code:

```
import numpy as np

# simplified algorithm for demonstration.

def linear_old(width, num_steps):  # current master
	xsteps = [1 for i in range(num_steps + 1)]  # usually random.
	x_step = width // num_steps
	prev = 0
	for idx in range(num_steps + 1):
		x = idx * x_step
		start = int(x)
		end = int(x) + x_step
		if end > width:
			end = width
			cur = width
		else:
			cur = prev + x_step * xsteps[idx]
		yield (start, end, prev, cur)
		prev = cur

def linear_new(width, num_steps):  # this PR
	xsteps = [1 for i in range(num_steps)]  # usually random.
	x_step = width / num_steps
	prev = 0
	for idx in range(num_steps):
		x = idx * x_step
		start = int(x)
		end = int(x + x_step)
		if idx >= num_steps - 1 or end >= width:
			end = width
			cur = width
		else:
			cur = prev + x_step * xsteps[idx]
		yield (start, end, int(prev), int(cur))
		prev = cur

print(list(linear_old(100, 3)))
print(list(linear_new(100, 3)))
```

With outputs:

```
[(0, 33, 0, 33), (33, 66, 33, 66), (66, 99, 66, 99), (99, 100, 99, 100)]
[(0, 33, 0, 33), (33, 66, 33, 66), (66, 100, 66, 100)]
```

The current solution always produces a strange bit at the end (due to the `//` rounding). So, I wonder, due to these changes, whether there could be an all new `ConstrainedGridDistortion`, that does not need to change the existing code base.




