### PR TITLE
fix redundant copy in resize

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -196,6 +196,9 @@ def rotate(img, angle, interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_RE
 
 @preserve_channel_dim
 def resize(img, height, width, interpolation=cv2.INTER_LINEAR):
+    img_height, img_width = img.shape[:2]
+    if height == img_height and width == img_width:
+        return img
     resize_fn = _maybe_process_in_chunks(cv2.resize, dsize=(width, height), interpolation=interpolation)
     return resize_fn(img)
 


### PR DESCRIPTION
Looks like opencv copies the image during resize in case it have the same size.

More details here: https://github.com/opencv/opencv/blob/master/modules/imgproc/src/resize.cpp#L3962

flake8 was already broken before me and going to be fixed in https://github.com/albumentations-team/albumentations/pull/638