### PR TITLE
Add Kornia to benchmark

### DIFF
--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -2,12 +2,13 @@ albumentations
 Augmentor
 imgaug
 keras
+kornia==0.4.0
 numpy
 opencv-python
 pandas
 pillow-simd
 pytablewriter
-solt
+solt==0.1.8
 tensorflow # required for keras
 torchvision
 tqdm


### PR DESCRIPTION
Added `kornia` library to benchmark suite, with a few of the augmentations. This was requested in #527.
Kornia operates on PyTorch Tensors, so I introduced a method to read images as tensors.
I'm actually not super familiar with Kornia or albumentations, I hope someone knowledgeable will implement more augmentations for comparison. I also might have used some operations incorrectly.

**Note**: nailed the version of `solt`: the version being installed by default is `0.1.9`, which had breaking changes from `0.1.8`, e.g. removed/renamed `solt.data` subpackage.