### PR TITLE
New interface for FDA transform and fix some bugs for HistogramMatching

### DIFF
--- a/albumentations/augmentations/__init__.py
+++ b/albumentations/augmentations/__init__.py
@@ -6,3 +6,5 @@ from .transforms import *
 
 # New transformations goes to individual files listed below
 from .domain_adaptation import *
+
+from .utils import *

--- a/albumentations/augmentations/domain_adaptation.py
+++ b/albumentations/augmentations/domain_adaptation.py
@@ -35,7 +35,7 @@ def fourier_domain_adaptation(img: np.ndarray, target_img: np.ndarray, beta: flo
 
     if target_img.shape != img.shape:
         raise ValueError(
-            "The source and target images must contain the same shape,"
+            "The source and target images must have the same shape,"
             " but got {} and {} respectively.".format(img.shape, target_img.shape)
         )
 

--- a/albumentations/augmentations/domain_adaptation.py
+++ b/albumentations/augmentations/domain_adaptation.py
@@ -9,16 +9,9 @@ from .functional import clipped, preserve_shape
 
 from skimage.exposure import match_histograms
 
-__all__ = ["HistogramMatching", "FDA", "fourier_domain_adaptation", "read_bgr_image", "read_rgb_image"]
+from .utils import read_rgb_image
 
-
-def read_bgr_image(path):
-    return cv2.imread(path, cv2.IMREAD_COLOR)
-
-
-def read_rgb_image(path):
-    image = cv2.imread(path, cv2.IMREAD_COLOR)
-    return cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+__all__ = ["HistogramMatching", "FDA", "fourier_domain_adaptation"]
 
 
 @clipped
@@ -115,7 +108,7 @@ class HistogramMatching(ImageOnlyTransform):
         self,
         reference_images: List[Union[str, np.ndarray]],
         blend_ratio=(0.5, 1.0),
-        read_fn=read_bgr_image,
+        read_fn=read_rgb_image,
         always_apply=False,
         p=0.5,
     ):
@@ -176,7 +169,7 @@ class FDA(ImageOnlyTransform):
         self,
         reference_images: List[Union[str, np.ndarray]],
         beta_limit=0.1,
-        read_fn=read_bgr_image,
+        read_fn=read_rgb_image,
         always_apply=False,
         p=0.5,
     ):

--- a/albumentations/augmentations/domain_adaptation.py
+++ b/albumentations/augmentations/domain_adaptation.py
@@ -1,16 +1,28 @@
-from typing import List
+from typing import List, Union
 import random
 
 import cv2
 import numpy as np
 
 from ..core.transforms_interface import ImageOnlyTransform, to_tuple
-from .functional import clipped
+from .functional import clipped, preserve_shape
 
-__all__ = ["HistogramMatching", "FDA", "fourier_domain_adaptation"]
+from skimage.exposure import match_histograms
+
+__all__ = ["HistogramMatching", "FDA", "fourier_domain_adaptation", "read_bgr_image", "read_rgb_image"]
+
+
+def read_bgr_image(path):
+    return cv2.imread(path, cv2.IMREAD_COLOR)
+
+
+def read_rgb_image(path):
+    image = cv2.imread(path, cv2.IMREAD_COLOR)
+    return cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
 
 @clipped
+@preserve_shape
 def fourier_domain_adaptation(img: np.ndarray, target_img: np.ndarray, beta: float) -> np.ndarray:
     """
     Fourier Domain Adaptation from https://github.com/YanchaoYang/FDA
@@ -24,6 +36,16 @@ def fourier_domain_adaptation(img: np.ndarray, target_img: np.ndarray, beta: flo
         transformed image
 
     """
+
+    img = np.squeeze(img)
+    target_img = np.squeeze(target_img)
+
+    if target_img.shape != img.shape:
+        raise ValueError(
+            "The source and target images must contain the same shape,"
+            " but got {} and {} respectively.".format(img.shape, target_img.shape)
+        )
+
     # get fft of both source and target
     fft_src = np.fft.fft2(img.astype(np.float32), axes=(0, 1))
     fft_trg = np.fft.fft2(target_img.astype(np.float32), axes=(0, 1))
@@ -52,6 +74,14 @@ def fourier_domain_adaptation(img: np.ndarray, target_img: np.ndarray, beta: flo
     return src_image_transformed
 
 
+@preserve_shape
+def apply_histogram(img, reference_image, blend_ratio):
+    reference_image = cv2.resize(reference_image, dsize=(img.shape[1], img.shape[0]))
+    matched = match_histograms(np.squeeze(img), np.squeeze(reference_image), multichannel=True)
+    img = cv2.addWeighted(matched, blend_ratio, img, 1 - blend_ratio, 0)
+    return img
+
+
 class HistogramMatching(ImageOnlyTransform):
     """
     Apply histogram matching. It manipulates the pixels of an input image so that its histogram matches
@@ -66,7 +96,8 @@ class HistogramMatching(ImageOnlyTransform):
         https://scikit-image.org/docs/dev/auto_examples/color_exposure/plot_histogram_matching.html
 
     Args:
-        reference_images (List[str]): List of file paths for reference images.
+        reference_images (List[str] or List(np.ndarray)): List of file paths for reference images
+            or list of reference images.
         blend_ratio (float, float): Tuple of min and max blend ratio. Matched image will be blended with original
             with random blend factor for increased diversity of generated images.
         read_fn (Callable): Used-defined function to read image. Function should get image path and return numpy
@@ -80,21 +111,21 @@ class HistogramMatching(ImageOnlyTransform):
         uint8, uint16, float32
     """
 
-    def __init__(self, reference_images: List[str], blend_ratio=(0.5, 1.0), read_fn=cv2.imread, p=0.5):
-        super().__init__(p=p)
+    def __init__(
+        self,
+        reference_images: List[Union[str, np.ndarray]],
+        blend_ratio=(0.5, 1.0),
+        read_fn=read_bgr_image,
+        always_apply=False,
+        p=0.5,
+    ):
+        super().__init__(always_apply=always_apply, p=p)
         self.reference_images = reference_images
         self.read_fn = read_fn
         self.blend_ratio = blend_ratio
 
     def apply(self, img, reference_image=None, blend_ratio=0.5, **params):
-        from skimage.exposure import match_histograms
-
-        if random.random() < self.p:
-            reference_image = cv2.resize(reference_image, dsize=(img.shape[1], img.shape[0]))
-            matched = match_histograms(img, reference_image, multichannel=True)
-            img = cv2.addWeighted(matched, blend_ratio, img, 1 - blend_ratio, 0)
-
-        return img
+        return apply_histogram(img, reference_image, blend_ratio)
 
     def get_params(self):
         return {
@@ -103,17 +134,23 @@ class HistogramMatching(ImageOnlyTransform):
         }
 
     def get_transform_init_args_names(self):
-        return ("blend_ratio",)
+        return ("reference_images", "blend_ratio", "read_fn")
+
+    def _to_dict(self):
+        raise NotImplementedError("HistogramMatching can not be serialized.")
 
 
 class FDA(ImageOnlyTransform):
     """
     Fourier Domain Adaptation from https://github.com/YanchaoYang/FDA
     Simple "style transfer".
-    Important: you need to pass target image as a parameter `target_image` in __call__, see example
 
     Args:
+        reference_images (List[str] or List(np.ndarray)): List of file paths for reference images
+            or list of reference images.
         beta_limit (float or tuple of float): coefficient beta from paper. Recommended less 0.3.
+        read_fn (Callable): Used-defined function to read image. Function should get image path and return numpy
+            array of image pixels.
 
     Targets:
         image
@@ -130,13 +167,22 @@ class FDA(ImageOnlyTransform):
         >>> import albumentations as A
         >>> image = np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)
         >>> target_image = np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)
-        >>> aug = A.Compose([A.FDA(p=1)])
-        >>> result = aug(image=image, target_image=target_image)
+        >>> aug = A.Compose([A.FDA([target_image], p=1, read_fn=lambda x: x)])
+        >>> result = aug(image=image)
 
     """
 
-    def __init__(self, beta_limit=0.1, always_apply=False, p=0.5):
+    def __init__(
+        self,
+        reference_images: List[Union[str, np.ndarray]],
+        beta_limit=0.1,
+        read_fn=read_bgr_image,
+        always_apply=False,
+        p=0.5,
+    ):
         super(FDA, self).__init__(always_apply=always_apply, p=p)
+        self.reference_images = reference_images
+        self.read_fn = read_fn
         self.beta_limit = to_tuple(beta_limit, low=0)
 
     def apply(self, img, target_image=None, beta=0.1, **params):
@@ -144,14 +190,8 @@ class FDA(ImageOnlyTransform):
 
     def get_params_dependent_on_targets(self, params):
         img = params["image"]
-        target_img = params["target_image"]
+        target_img = self.read_fn(random.choice(self.reference_images))
         target_img = cv2.resize(target_img, dsize=(img.shape[1], img.shape[0]))
-
-        if target_img.shape != img.shape:
-            raise ValueError(
-                "The source and target images must contain the same shape,"
-                " but got {} and {} respectively.".format(img.shape, target_img.shape)
-            )
 
         return {"target_image": target_img}
 
@@ -160,7 +200,10 @@ class FDA(ImageOnlyTransform):
 
     @property
     def targets_as_params(self):
-        return ["image", "target_image"]
+        return ["image"]
 
     def get_transform_init_args_names(self):
-        return ("beta_limit",)
+        return ("reference_images", "beta_limit", "read_fn")
+
+    def _to_dict(self):
+        raise NotImplementedError("FDA can not be serialized.")

--- a/albumentations/augmentations/utils.py
+++ b/albumentations/augmentations/utils.py
@@ -1,0 +1,12 @@
+import cv2
+
+__all__ = ["read_bgr_image", "read_rgb_image"]
+
+
+def read_bgr_image(path):
+    return cv2.imread(path, cv2.IMREAD_COLOR)
+
+
+def read_rgb_image(path):
+    image = cv2.imread(path, cv2.IMREAD_COLOR)
+    return cv2.cvtColor(image, cv2.COLOR_BGR2RGB)

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -310,7 +310,7 @@ class BrightnessContrast(BenchmarkTest):
 
     def augmentor(self, img):
         for operation in self.augmentor_pipeline.operations:
-            (img,) = operation.perform_operation([img])
+            img, = operation.perform_operation([img])
         return np.array(img, np.uint8, copy=False)
 
 
@@ -409,7 +409,7 @@ class RandomSizedCrop_64_512(BenchmarkTest):
 
     def augmentor(self, img):
         for operation in self.augmentor_pipeline.operations:
-            (img,) = operation.perform_operation([img])
+            img, = operation.perform_operation([img])
         return np.array(img, np.uint8, copy=False)
 
     def torchvision_transform(self, img):

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -310,7 +310,7 @@ class BrightnessContrast(BenchmarkTest):
 
     def augmentor(self, img):
         for operation in self.augmentor_pipeline.operations:
-            img, = operation.perform_operation([img])
+            (img,) = operation.perform_operation([img])
         return np.array(img, np.uint8, copy=False)
 
 
@@ -409,7 +409,7 @@ class RandomSizedCrop_64_512(BenchmarkTest):
 
     def augmentor(self, img):
         for operation in self.augmentor_pipeline.operations:
-            img, = operation.perform_operation([img])
+            (img,) = operation.perform_operation([img])
         return np.array(img, np.uint8, copy=False)
 
     def torchvision_transform(self, img):

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -64,6 +64,8 @@ from albumentations import (
     MultiplicativeNoise,
     GridDropout,
     ColorJitter,
+    FDA,
+    HistogramMatching,
 )
 
 
@@ -101,6 +103,14 @@ from albumentations import (
         [MultiplicativeNoise, {}],
         [GridDropout, {}],
         [ColorJitter, {}],
+        [
+            HistogramMatching,
+            {"reference_images": [np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)], "read_fn": lambda x: x},
+        ],
+        [
+            FDA,
+            {"reference_images": [np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)], "read_fn": lambda x: x},
+        ],
     ],
 )
 def test_image_only_augmentations(augmentation_cls, params, image, mask):
@@ -140,6 +150,14 @@ def test_image_only_augmentations(augmentation_cls, params, image, mask):
         [MultiplicativeNoise, {}],
         [GridDropout, {}],
         [ColorJitter, {}],
+        [
+            HistogramMatching,
+            {"reference_images": [np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)], "read_fn": lambda x: x},
+        ],
+        [
+            FDA,
+            {"reference_images": [np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)], "read_fn": lambda x: x},
+        ],
     ],
 )
 def test_image_only_augmentations_with_float_values(augmentation_cls, params, float_image, mask):
@@ -284,6 +302,14 @@ def test_imgaug_dual_augmentations(augmentation_cls, image, mask):
         [MultiplicativeNoise, {}],
         [GridDropout, {}],
         [ColorJitter, {}],
+        [
+            HistogramMatching,
+            {"reference_images": [np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)], "read_fn": lambda x: x},
+        ],
+        [
+            FDA,
+            {"reference_images": [np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)], "read_fn": lambda x: x},
+        ],
     ],
 )
 def test_augmentations_wont_change_input(augmentation_cls, params, image, mask):
@@ -343,6 +369,14 @@ def test_augmentations_wont_change_input(augmentation_cls, params, image, mask):
         [MultiplicativeNoise, {}],
         [GridDropout, {}],
         [ColorJitter, {}],
+        [
+            HistogramMatching,
+            {"reference_images": [np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)], "read_fn": lambda x: x},
+        ],
+        [
+            FDA,
+            {"reference_images": [np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)], "read_fn": lambda x: x},
+        ],
     ],
 )
 def test_augmentations_wont_change_float_input(augmentation_cls, params, float_image):
@@ -386,6 +420,11 @@ def test_augmentations_wont_change_float_input(augmentation_cls, params, float_i
         [GridDropout, {}],
         [HueSaturationValue, {}],
         [ColorJitter, {}],
+        [
+            HistogramMatching,
+            {"reference_images": [np.random.randint(0, 256, [100, 100], dtype=np.uint8)], "read_fn": lambda x: x},
+        ],
+        [FDA, {"reference_images": [np.random.randint(0, 256, [100, 100], dtype=np.uint8)], "read_fn": lambda x: x}],
     ],
 )
 def test_augmentations_wont_change_shape_grayscale(augmentation_cls, params, image, mask):
@@ -405,14 +444,6 @@ def test_augmentations_wont_change_shape_grayscale(augmentation_cls, params, ima
     result = aug(image=image_1ch, mask=mask_1ch)
     assert np.array_equal(image_1ch.shape, result["image"].shape)
     assert np.array_equal(mask_1ch.shape, result["mask"].shape)
-
-    # Test for RGB image
-    image_3ch = np.zeros((224, 224, 3), dtype=np.uint8)
-    mask_3ch = np.zeros((224, 224, 3))
-
-    result = aug(image=image_3ch, mask=mask_3ch)
-    assert np.array_equal(image_3ch.shape, result["image"].shape)
-    assert np.array_equal(mask_3ch.shape, result["mask"].shape)
 
 
 @pytest.mark.parametrize(
@@ -461,6 +492,14 @@ def test_augmentations_wont_change_shape_grayscale(augmentation_cls, params, ima
         [MultiplicativeNoise, {}],
         [GridDropout, {}],
         [ColorJitter, {}],
+        [
+            HistogramMatching,
+            {"reference_images": [np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)], "read_fn": lambda x: x},
+        ],
+        [
+            FDA,
+            {"reference_images": [np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)], "read_fn": lambda x: x},
+        ],
     ],
 )
 def test_augmentations_wont_change_shape_rgb(augmentation_cls, params, image, mask):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -500,14 +500,7 @@ def test_imgaug_augmentations_for_keypoints_serialization(
 
 @pytest.mark.parametrize(
     ["augmentation_cls", "params", "call_params"],
-    [
-        [A.RandomCropNearBBox, {"max_part_shift": 0.15}, {"cropping_bbox": [-59, 77, 177, 231]}],
-        [
-            A.FDA,
-            {"beta_limit": 0.3},
-            {"target_image": np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)},
-        ],
-    ],
+    [[A.RandomCropNearBBox, {"max_part_shift": 0.15}, {"cropping_bbox": [-59, 77, 177, 231]}]],
 )
 @pytest.mark.parametrize("p", [0.5, 1])
 @pytest.mark.parametrize("seed", TEST_SEEDS)


### PR DESCRIPTION
- New interface for FDA transform, equal to `HistogramMatching`
- Fixed problems with grayscale images
- Predefined read functions
- Added transforms to tests
- Added exception on try to serialize this transforms
