### PR TITLE
Try to fix non integer values in min_max_height

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -898,7 +898,7 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
         self.w2h_ratio = w2h_ratio
 
     def get_params(self):
-        crop_height = random.randint(self.min_max_height[0], self.min_max_height[1])
+        crop_height = random.randint(round(self.min_max_height[0]), round(self.min_max_height[1]))
         return {
             "h_start": random.random(),
             "w_start": random.random(),


### PR DESCRIPTION
```
  File "/home/xxxx/.local/lib/python3.7/site-packages/albumentations/augmentations/transforms.py", line 901, in get_params
    crop_height = random.randint(self.min_max_height[0], self.min_max_height[1])
  File "/usr/lib/python3.7/random.py", line 222, in randint
    return self.randrange(a, b+1)
  File "/usr/lib/python3.7/random.py", line 186, in randrange
    raise ValueError("non-integer arg 1 for randrange()")
ValueError: non-integer arg 1 for randrange()
```