### PR TITLE
docs: fix simple typo, initialzie -> initialize

### DIFF
--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -351,7 +351,7 @@ class Perspective(DualTransform):
 
     @classmethod
     def _order_points(cls, pts):
-        # initialzie a list of coordinates that will be ordered such that the first entry in the list is the top-left,
+        # initialize a list of coordinates that will be ordered such that the first entry in the list is the top-left,
         # the second entry is the top-right, the third is the bottom-right, and the fourth is the bottom-left
         pts_ordered = np.zeros((4, 2), dtype=np.float32)
 


### PR DESCRIPTION
There is a small typo in albumentations/augmentations/geometric/transforms.py.

Should read `initialize` rather than `initialzie`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md