### PR TITLE
Allow `opencv-contrib-*` to satisfy opencv requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,13 @@ from pkg_resources import DistributionNotFound, get_distribution
 
 INSTALL_REQUIRES = ["numpy>=1.11.1", "scipy", "scikit-image>=0.16.1", "imgaug>=0.4.0", "PyYAML"]
 
-# If first not installed install second package
-CHOOSE_INSTALL_REQUIRES = [("opencv-python>=4.1.1", "opencv-python-headless>=4.1.1")]
+# If none of packages in first installed, install second package
+CHOOSE_INSTALL_REQUIRES = [
+    (
+        ("opencv-python>=4.1.1", "opencv-contrib-python>=4.1.1", "opencv-contrib-python-headless>=4.1.1"),
+        "opencv-python-headless>=4.1.1",
+    )
+]
 
 
 def get_version():
@@ -24,23 +29,27 @@ def get_long_description():
         return f.read()
 
 
-def choose_requirement(main, secondary):
+def choose_requirement(mains, secondary):
     """If some version version of main requirement installed, return main,
     else return secondary.
 
     """
-    try:
-        name = re.split(r"[!<>=]", main)[0]
-        get_distribution(name)
-    except DistributionNotFound:
-        return secondary
+    chosen = secondary
+    for main in mains:
+        try:
+            name = re.split(r"[!<>=]", main)[0]
+            get_distribution(name)
+            chosen = main
+            break
+        except DistributionNotFound:
+            pass
 
-    return str(main)
+    return str(chosen)
 
 
 def get_install_requirements(install_requires, choose_install_requires):
-    for main, secondary in choose_install_requires:
-        install_requires.append(choose_requirement(main, secondary))
+    for mains, secondary in choose_install_requires:
+        install_requires.append(choose_requirement(mains, secondary))
 
     return install_requires
 


### PR DESCRIPTION
`opencv-contrib-*` is a superset of the `opencv-python-*` API, so this allows dependents to use the contrib variants along with albumentations [1] (see point #3).

I'm working on a project which uses albumentations, but also needs to use `opencv-contrib-python-headless`. Since albumentations doesn't recognize that as satisfying `opencv` (as an abstract dependency), it installs the `opencv-python-headless` version, which causes the `cv2` namespace to be clobbered and no longer recognize modules in contrib.

Note, the `imgaug` dependency also forces an install of `opencv-python` [2] (the non-headless version :(), but this can be worked around with:
```
pip install --no-binary imgaug .
```

[1] https://github.com/aleju/imgaug/issues/473
[2] https://pypi.org/project/opencv-contrib-python-headless/