### PR TITLE
Change DeprecationWarning to FutureWarning everywhere in code

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -642,7 +642,7 @@ class Cutout(ImageOnlyTransform):
         self.fill_value = fill_value
         warnings.warn(
             "This class has been deprecated. Please use CoarseDropout",
-            DeprecationWarning,
+            FutureWarning,
         )
 
     def apply(self, image, fill_value=0, holes=(), **params):
@@ -867,7 +867,7 @@ class JpegCompression(ImageCompression):
         )
         warnings.warn(
             "This class has been deprecated. Please use ImageCompression",
-            DeprecationWarning,
+            FutureWarning,
         )
 
     def get_transform_init_args(self):
@@ -1698,7 +1698,7 @@ class RandomBrightness(RandomBrightnessContrast):
         )
         warnings.warn(
             "This class has been deprecated. Please use RandomBrightnessContrast",
-            DeprecationWarning,
+            FutureWarning,
         )
 
     def get_transform_init_args(self):
@@ -1724,7 +1724,7 @@ class RandomContrast(RandomBrightnessContrast):
         super(RandomContrast, self).__init__(brightness_limit=0, contrast_limit=limit, always_apply=always_apply, p=p)
         warnings.warn(
             "This class has been deprecated. Please use RandomBrightnessContrast",
-            DeprecationWarning,
+            FutureWarning,
         )
 
     def get_transform_init_args(self):

--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -55,7 +55,7 @@ class ToTensor(BasicTransform):
         self.sigmoid = sigmoid
         self.normalize = normalize
         warnings.warn(
-            "ToTensor is deprecated and will be replaced by ToTensorV2 " "in albumentations 0.5.0", DeprecationWarning
+            "ToTensor is deprecated and will be replaced by ToTensorV2 in albumentations 0.7.0", FutureWarning
         )
 
     def __call__(self, *args, force_apply=True, **kwargs):

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -90,7 +90,7 @@ def test_torch_to_tensor_v2_on_gray_scale_images():
 
 
 def test_torch_to_tensor_augmentations(image, mask):
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         aug = ToTensor()
     data = aug(image=image, mask=mask, force_apply=True)
     assert data["image"].dtype == torch.float32
@@ -98,7 +98,7 @@ def test_torch_to_tensor_augmentations(image, mask):
 
 
 def test_additional_targets_for_totensor():
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         aug = A.Compose([ToTensor(num_classes=4)], additional_targets={"image2": "image", "mask2": "mask"})
     for _i in range(10):
         image1 = np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)


### PR DESCRIPTION
## Why

A user will always see a [FutureWarning](https://docs.python.org/3/library/exceptions.html#FutureWarning). In contrast, there are many situations when a user won't see a [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning). In fact, DeprecationWarning is always ignored by default, and it is available in two cases:
- If a user manually changes the default warning filter.
- Beginning with Python 3.7, DeprecationWarnings will be shown in __main__ (see [PEP 565](https://www.python.org/dev/peps/pep-0565/) for a more detailed description). 

So I think now many of our users don't notice the current DeprecationWarnings and are not aware of obsolete augmentations that we plan to remove.

