### PR TITLE
Fix Perspective keypoints resize

### DIFF
--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -372,9 +372,11 @@ def perspective_bbox(
         y1 = min(y1, y)
         y2 = max(y2, y)
 
-    x1, x2 = np.clip(np.array([x1, x2]), 0, width if keep_size else max_width)
-    y1, y2 = np.clip(np.array([y1, y2]), 0, height if keep_size else max_height)
-    return normalize_bbox((x1, y1, x2, y2), height if keep_size else max_height, width if keep_size else max_width)
+    x = np.clip([x1, x2], 0, width if keep_size else max_width)
+    y = np.clip([y1, y2], 0, height if keep_size else max_height)
+    return normalize_bbox(
+        (x[0], y[0], x[1], y[1]), height if keep_size else max_height, width if keep_size else max_width
+    )
 
 
 def rotation2DMatrixToEulerAngles(matrix: np.ndarray):

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -372,8 +372,8 @@ def perspective_bbox(
         y1 = min(y1, y)
         y2 = max(y2, y)
 
-    x1, x2 = np.clip([x1, x2], 0, width if keep_size else max_width)
-    y1, y2 = np.clip([y1, y2], 0, height if keep_size else max_height)
+    x1, x2 = np.clip(np.array([x1, x2]), 0, width if keep_size else max_width)
+    y1, y2 = np.clip(np.array([y1, y2]), 0, height if keep_size else max_height)
     return normalize_bbox((x1, y1, x2, y2), height if keep_size else max_height, width if keep_size else max_width)
 
 

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -248,7 +248,7 @@ class Perspective(DualTransform):
         )
 
     def apply_to_bbox(self, bbox, matrix=None, max_height=None, max_width=None, **params):
-        return F.perspective_bbox(bbox, params["rows"], params["cols"], matrix, max_width, max_height)
+        return F.perspective_bbox(bbox, params["rows"], params["cols"], matrix, max_width, max_height, self.keep_size)
 
     def apply_to_keypoint(self, keypoint, matrix=None, max_height=None, max_width=None, **params):
         return F.perspective_keypoint(


### PR DESCRIPTION
- Fixed forgotten keypoints resize for `Perspective` transform when `keep_size=True`.
- Fixed incorrect rescaling of keypoints
Issue: #856