### PR TITLE
Fix collapsed Perspective transform

### DIFF
--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -351,7 +351,7 @@ class Perspective(DualTransform):
 
     @classmethod
     def _order_points(cls, pts: np.ndarray) -> np.ndarray:
-        pts = sorted(pts, key=lambda x: x[0])
+        pts = np.sort(pts, axis=0)
         left = pts[:2]  # points with smallest x coordinate - left points
         right = pts[2:]  # points with greatest x coordinate - right points
 

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -351,7 +351,7 @@ class Perspective(DualTransform):
 
     @classmethod
     def _order_points(cls, pts: np.ndarray) -> np.ndarray:
-        pts = np.sort(pts, axis=0)
+        pts = np.array(sorted(pts, key=lambda x: x[0]))
         left = pts[:2]  # points with smallest x coordinate - left points
         right = pts[2:]  # points with greatest x coordinate - right points
 

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -281,7 +281,7 @@ class Perspective(DualTransform):
         # Warning: don't just do (tl, tr, br, bl) = _order_points(...)
         # here, because the reordered points is used further below.
         points = self._order_points(points)
-        (tl, tr, br, bl) = points
+        tl, tr, br, bl = points
 
         # compute the width of the new image, which will be the
         # maximum distance between bottom-right and bottom-left
@@ -350,24 +350,22 @@ class Perspective(DualTransform):
         return matrix_expanded, int(max_width), int(max_height)
 
     @classmethod
-    def _order_points(cls, pts):
-        # initialize a list of coordinates that will be ordered such that the first entry in the list is the top-left,
-        # the second entry is the top-right, the third is the bottom-right, and the fourth is the bottom-left
-        pts_ordered = np.zeros((4, 2), dtype=np.float32)
+    def _order_points(cls, pts: np.ndarray) -> np.ndarray:
+        pts = sorted(pts, key=lambda x: x[0])
+        left = pts[:2]  # points with smallest x coordinate - left points
+        right = pts[2:]  # points with greatest x coordinate - right points
 
-        # the top-left point will have the smallest sum, whereas the bottom-right point will have the largest sum
-        pointwise_sum = pts.sum(axis=1)
-        pts_ordered[0] = pts[np.argmin(pointwise_sum)]
-        pts_ordered[2] = pts[np.argmax(pointwise_sum)]
+        if left[0][1] < left[1][1]:
+            tl, bl = left
+        else:
+            bl, tl = left
 
-        # now, compute the difference between the points, the top-right point will have the smallest difference,
-        # whereas the bottom-left will have the largest difference
-        diff = np.diff(pts, axis=1)
-        pts_ordered[1] = pts[np.argmin(diff)]
-        pts_ordered[3] = pts[np.argmax(diff)]
+        if right[0][1] < right[1][1]:
+            tr, br = right
+        else:
+            br, tr = right
 
-        # return the ordered coordinates
-        return pts_ordered
+        return np.array([tl, tr, br, bl], dtype=np.float32)
 
     def get_transform_init_args_names(self):
         return ("scale", "keep_size", "pad_mode", "pad_val", "mask_pad_val", "fit_output", "interpolation")

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -352,8 +352,8 @@ class Perspective(DualTransform):
         max_width, max_height = dst.max(axis=0)
         return matrix_expanded, int(max_width), int(max_height)
 
-    @classmethod
-    def _order_points(cls, pts: np.ndarray) -> np.ndarray:
+    @staticmethod
+    def _order_points(pts: np.ndarray) -> np.ndarray:
         pts = np.array(sorted(pts, key=lambda x: x[0]))
         left = pts[:2]  # points with smallest x coordinate - left points
         right = pts[2:]  # points with greatest x coordinate - right points

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -73,6 +73,7 @@ from albumentations import (
     CropAndPad,
     Superpixels,
     Affine,
+    Compose,
 )
 
 
@@ -723,3 +724,72 @@ def test_pad_if_needed(augmentation_cls: Type[PadIfNeeded], params: Dict, image_
         assert image_padded.shape[0] % pad.pad_height_divisor == 0
         assert image_padded.shape[0] >= image.shape[0]
         assert image_padded.shape[0] - image.shape[0] <= pad.pad_height_divisor
+
+
+@pytest.mark.parametrize(
+    ["points"],
+    [
+        [
+            [
+                [37.25756906, 11.0567457],
+                [514.03919117, 9.49484312],
+                [585.66154354, 74.97413793],
+                [63.60979494, 85.39815904],
+            ]
+        ],
+        [
+            [
+                [37, 11],
+                [514, 9],
+                [585, 74],
+                [63, 85],
+            ]
+        ],
+        [
+            [
+                [10, 20],
+                [719, 34],
+                [613, 63],
+                [91, 33],
+            ]
+        ],
+    ],
+)
+def test_perspective_order_points(points):
+    points = np.array(points)
+    res = Perspective._order_points(points)
+    assert len(points) == len(np.unique(res, axis=0))
+
+
+@pytest.mark.parametrize(
+    ["seed", "scale", "h", "w"],
+    [
+        [0, 0.08, 89, 628],
+        [0, 0.15, 89, 628],
+        [0, 0.15, 35, 190],
+    ],
+)
+def test_perspective_valid_keypoints_after_transform(seed: int, scale: float, h: int, w: int):
+    random.seed(seed)
+    np.random.seed(seed)
+
+    image = np.zeros([h, w, 3], dtype=np.uint8)
+    keypoints = [
+        [0, 0],
+        [0, h - 1],
+        [w - 1, h - 1],
+        [w - 1, 0],
+    ]
+
+    transform = Compose(
+        [Perspective(scale=(scale, scale), p=1)], keypoint_params={"format": "xy", "remove_invisible": False}
+    )
+
+    res = transform(image=image, keypoints=keypoints)["keypoints"]
+
+    x1, y1 = res[0]
+    x2, y2 = res[1]
+    x3, y3 = res[2]
+    x4, y4 = res[3]
+
+    assert x1 < x3 and x1 < x4 and x2 < x3 and x2 < x4 and y1 < y2 and y1 < y3 and y4 < y2 and y4 < y3


### PR DESCRIPTION
Sometimes the perspective transformation showed incorrect results because the points were not ordered correctly, and sometimes the two vertices had the same coordinates.

Code to reproduce, original image, wrong transform and fixed transform result:
```python
import numpy as np
import albumentations as A
import matplotlib.pyplot as plt
import random
import cv2 as cv

seed = 0
random.seed(seed)
np.random.seed(seed)

img = cv.imread("D:\\img.png")
img = cv.cvtColor(img, cv.COLOR_BGR2RGB)

scale = 0.08
res = A.Compose([A.Perspective(scale=(scale, scale), p=1)])(image=img)["image"]

plt.suptitle("Fixed branch")
plt.subplot(211, title="original")
plt.imshow(img, vmin=0, vmax=255)
plt.subplot(212, title="res")
plt.imshow(res, vmin=0, vmax=255)

plt.show()
```
![img](https://user-images.githubusercontent.com/7512250/114054571-a7a52100-9898-11eb-838e-3ef78e2af90a.png)
![image](https://user-images.githubusercontent.com/7512250/114054878-e89d3580-9898-11eb-8bf6-4dfe682a7377.png)
![image](https://user-images.githubusercontent.com/7512250/114054936-f8b51500-9898-11eb-83bc-9f970dc34153.png)


