### PR TITLE
YOLO format without normalization and denormalization

### DIFF
--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -77,8 +77,11 @@ def test_calculate_bbox_area(bbox, rows, cols, expected):
         ((20, 30, 40, 50, 99), "coco", (0.2, 0.3, 0.6, 0.8, 99)),
         ((20, 30, 60, 80), "pascal_voc", (0.2, 0.3, 0.6, 0.8)),
         ((20, 30, 60, 80, 99), "pascal_voc", (0.2, 0.3, 0.6, 0.8, 99)),
-        ((0.2, 0.3, 0.4, 0.5), "yolo", (0.01, 0.06, 0.41, 0.56)),
-        ((0.2, 0.3, 0.4, 0.5, 99), "yolo", (0.01, 0.06, 0.41, 0.56, 99)),
+        ((0.2, 0.3, 0.4, 0.5), "yolo", (0.00, 0.05, 0.40, 0.55)),
+        ((0.2, 0.3, 0.4, 0.5, 99), "yolo", (0.00, 0.05, 0.40, 0.55, 99)),
+        ((0.1, 0.1, 0.2, 0.2), "yolo", (0.0, 0.0, 0.2, 0.2)),
+        ((0.99662423, 0.7520255, 0.00675154, 0.01446759), "yolo", (0.99324846, 0.744791705, 1.0, 0.759259295)),
+        ((0.9375, 0.510416, 0.1234375, 0.97638), "yolo", (0.87578125, 0.022226, 0.999218749, 0.998606)),
     ],
 )
 def test_convert_bbox_to_albumentations(bbox, source_format, expected):
@@ -87,7 +90,7 @@ def test_convert_bbox_to_albumentations(bbox, source_format, expected):
     converted_bbox = convert_bbox_to_albumentations(
         bbox, rows=image.shape[0], cols=image.shape[1], source_format=source_format
     )
-    assert converted_bbox == expected
+    assert np.all(np.isclose(converted_bbox, expected))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -100,8 +100,8 @@ def test_convert_bbox_to_albumentations(bbox, source_format, expected):
         ((0.2, 0.3, 0.6, 0.8, 99), "coco", (20, 30, 40, 50, 99)),
         ((0.2, 0.3, 0.6, 0.8), "pascal_voc", (20, 30, 60, 80)),
         ((0.2, 0.3, 0.6, 0.8, 99), "pascal_voc", (20, 30, 60, 80, 99)),
-        ((0.01, 0.06, 0.41, 0.56), "yolo", (0.2, 0.3, 0.4, 0.5)),
-        ((0.01, 0.06, 0.41, 0.56, 99), "yolo", (0.2, 0.3, 0.4, 0.5, 99)),
+        ((0.00, 0.05, 0.40, 0.55), "yolo", (0.2, 0.3, 0.4, 0.5)),
+        ((0.00, 0.05, 0.40, 0.55, 99), "yolo", (0.2, 0.3, 0.4, 0.5, 99)),
     ],
 )
 def test_convert_bbox_from_albumentations(bbox, target_format, expected):


### PR DESCRIPTION
Since `yolo` and `albumentations` are normalized formats, we don't need to normalize and denormalize the values in the conversion step.
The previous approach gave round-off errors.

These changes should fix the following issues:
- #922
- #903
- #862
- #883
- #848
- #679