### PR TITLE
Allow to set a custom mask interpolation method

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -134,9 +134,8 @@ class BaseCompose:
                 f"cv2.INTER_LINEAR_EXACT, cv2.INTER_AREA, cv2.INTER_CUBIC, cv2.INTER_LANCZOS4, cv2.INTER_MAX"
             )
         for t in self.transforms:
-            if not isinstance(t, (DualTransform, BaseCompose)):
-                continue
-            t.set_mask_interpolation(mask_interpolation)
+            if isinstance(t, BaseCompose) or (isinstance(t, DualTransform) and t.mask_interpolation is None):
+                t.set_mask_interpolation(mask_interpolation)
 
 
 class Compose(BaseCompose):

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -202,6 +202,10 @@ class BasicTransform:
 class DualTransform(BasicTransform):
     """Transform for segmentation task."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._mask_interpolation = cv2.INTER_NEAREST
+
     @property
     def targets(self):
         return {
@@ -211,6 +215,10 @@ class DualTransform(BasicTransform):
             "bboxes": self.apply_to_bboxes,
             "keypoints": self.apply_to_keypoints,
         }
+
+    def set_mask_interpolation(self, mask_interpolation):
+        self._mask_interpolation = mask_interpolation
+        return self
 
     def apply_to_bbox(self, bbox, **params):
         raise NotImplementedError("Method apply_to_bbox is not implemented in class " + self.__class__.__name__)
@@ -225,7 +233,9 @@ class DualTransform(BasicTransform):
         return [self.apply_to_keypoint(tuple(keypoint[:4]), **params) + tuple(keypoint[4:]) for keypoint in keypoints]
 
     def apply_to_mask(self, img, **params):
-        return self.apply(img, **{k: cv2.INTER_NEAREST if k == "interpolation" else v for k, v in params.items()})
+        return self.apply(
+            img, **{k: self._mask_interpolation if k == "interpolation" else v for k, v in params.items()}
+        )
 
     def apply_to_masks(self, masks, **params):
         return [self.apply_to_mask(mask, **params) for mask in masks]

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -204,7 +204,7 @@ class DualTransform(BasicTransform):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._mask_interpolation = cv2.INTER_NEAREST
+        self._mask_interpolation = None
 
     @property
     def targets(self):
@@ -215,6 +215,14 @@ class DualTransform(BasicTransform):
             "bboxes": self.apply_to_bboxes,
             "keypoints": self.apply_to_keypoints,
         }
+
+    @property
+    def mask_interpolation(self):
+        return self._mask_interpolation
+
+    @mask_interpolation.setter
+    def mask_interpolation(self, mask_interpolation):
+        self._mask_interpolation = mask_interpolation
 
     def set_mask_interpolation(self, mask_interpolation):
         self._mask_interpolation = mask_interpolation
@@ -233,9 +241,8 @@ class DualTransform(BasicTransform):
         return [self.apply_to_keypoint(tuple(keypoint[:4]), **params) + tuple(keypoint[4:]) for keypoint in keypoints]
 
     def apply_to_mask(self, img, **params):
-        return self.apply(
-            img, **{k: self._mask_interpolation if k == "interpolation" else v for k, v in params.items()}
-        )
+        mask_interpolation = self.mask_interpolation if self.mask_interpolation is not None else cv2.INTER_NEAREST
+        return self.apply(img, **{k: mask_interpolation if k == "interpolation" else v for k, v in params.items()})
 
     def apply_to_masks(self, masks, **params):
         return [self.apply_to_mask(mask, **params) for mask in masks]


### PR DESCRIPTION
This is POC to fix an issue in #850. It supports two styles for setting mask interpolation.

Option 1. Set a global value for mask interpolation through `Compose`:

```
t = A.Compose([
    A.Resize(128, 128),
], mask_interpolation=cv2.INTER_NEAREST)
```

Option 2. Override a value for mask interpolation for a single transform:


```
t = A.Compose([
    A.Resize(128, 128).set_mask_interpolation(cv2.INTER_NEAREST_EXACT),
])
```