### PR TITLE
Remove redundant search of first & last dual transform

### DIFF
--- a/albumentations/__init__.py
+++ b/albumentations/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 from .core.composition import *
 from .core.transforms_interface import *

--- a/albumentations/__init__.py
+++ b/albumentations/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 from .core.composition import *
 from .core.transforms_interface import *

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -183,9 +183,6 @@ class Compose(BaseCompose):
             if check_each_transform:
                 data = self._check_data_post_transform(data)
 
-        if not check_each_transform and len(self.processors):
-            data = self._check_data_post_transform(data)
-
         for p in self.processors.values():
             p.postprocess(data)
 

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -13,7 +13,17 @@ from albumentations.core.utils import format_args, Params
 from albumentations.augmentations.bbox_utils import BboxProcessor
 from albumentations.core.serialization import SERIALIZABLE_REGISTRY, instantiate_lambda
 
-__all__ = ["Compose", "SomeOf", "OneOf", "OneOrOther", "BboxParams", "KeypointParams", "ReplayCompose", "Sequential"]
+__all__ = [
+    "BaseCompose",
+    "Compose",
+    "SomeOf",
+    "OneOf",
+    "OneOrOther",
+    "BboxParams",
+    "KeypointParams",
+    "ReplayCompose",
+    "Sequential",
+]
 
 
 REPR_INDENT_STEP = 2

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -169,30 +169,36 @@ class Compose(BaseCompose):
         for p in self.processors.values():
             p.ensure_data_valid(data)
         transforms = self.transforms if need_to_run else self.transforms.get_always_apply(self.transforms)
-        dual_start_end = transforms.start_end if self.processors else None
+
         check_each_transform = any(
             getattr(item.params, "check_each_transform", False) for item in self.processors.values()
         )
 
-        for idx, t in enumerate(transforms):
-            if dual_start_end is not None and idx == dual_start_end[0]:
-                for p in self.processors.values():
-                    p.preprocess(data)
+        for p in self.processors.values():
+            p.preprocess(data)
 
+        for idx, t in enumerate(transforms):
             data = t(force_apply=force_apply, **data)
 
-            if dual_start_end is not None and idx == dual_start_end[1]:
-                for p in self.processors.values():
-                    p.postprocess(data)
-            elif check_each_transform and isinstance(t, DualTransform):
-                rows, cols = data["image"].shape[:2]
-                for p in self.processors.values():
-                    if not getattr(p.params, "check_each_transform", False):
-                        continue
+            if check_each_transform:
+                data = self._check_data_post_transform(data)
 
-                    for data_name in p.data_fields:
-                        data[data_name] = p.filter(data[data_name], rows, cols)
+        if not check_each_transform and len(self.processors):
+            data = self._check_data_post_transform(data)
 
+        for p in self.processors.values():
+            p.postprocess(data)
+
+        return data
+
+    def _check_data_post_transform(self, data):
+        rows, cols = data["image"].shape[:2]
+        for p in self.processors.values():
+            if not getattr(p.params, "check_each_transform", False):
+                continue
+
+            for data_name in p.data_fields:
+                data[data_name] = p.filter(data[data_name], rows, cols)
         return data
 
     def _to_dict(self):


### PR DESCRIPTION
While working on custom bbox augmentation logic I found that logic of searching of the first & last dual augmentations derived from DualTransform is unclear and redundant to my eye. At least I don't see any other reason for having this other than mere speed improvement (By avoiding keypoints conversion back & forth for each transform). 
Removing this logic makes compose logic a bit more clear and allows to modify bboxes in non-DualTransform based augmentations. 