### PR TITLE
Use np.isclose in check_bbox

### DIFF
--- a/albumentations/__init__.py
+++ b/albumentations/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 from .core.composition import *
 from .core.transforms_interface import *

--- a/albumentations/augmentations/bbox_utils.py
+++ b/albumentations/augmentations/bbox_utils.py
@@ -327,7 +327,7 @@ def convert_bboxes_from_albumentations(bboxes, target_format, rows, cols, check_
 def check_bbox(bbox):
     """Check if bbox boundaries are in range 0, 1 and minimums are lesser then maximums"""
     for name, value in zip(["x_min", "y_min", "x_max", "y_max"], bbox[:4]):
-        if not 0 <= value <= 1:
+        if not 0 <= value <= 1 and not np.isclose(value, 0) and not np.isclose(value, 1):
             raise ValueError(
                 "Expected {name} for bbox {bbox} "
                 "to be in the range [0.0, 1.0], got {value}.".format(bbox=bbox, name=name, value=value)


### PR DESCRIPTION
To avoid problems with float numbers, added check that bbox values are close to `0` and `1` if main condition `0 <= value <= 1` is `False`.

Example bbox in albumentations format: `(0.6265270002186298, 0.9481956716626883, 0.700299333781004, 1.000000024214387, 0.0)`
I took example from this discussion: #924