### PR TITLE
Reversible Resize

### DIFF
--- a/albumentations/augmentations/bbox_utils.py
+++ b/albumentations/augmentations/bbox_utils.py
@@ -1,4 +1,7 @@
 from __future__ import division
+
+import typing
+
 from albumentations.core.utils import DataProcessor
 
 import numpy as np

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -1,5 +1,8 @@
 import cv2
 import random
+import typing
+
+import numpy as np
 
 from . import functional as F
 from ...core.transforms_interface import DualTransform, to_tuple
@@ -149,8 +152,18 @@ class Resize(DualTransform):
     def apply(self, img, interpolation=cv2.INTER_LINEAR, **params):
         return F.resize(img, height=self.height, width=self.width, interpolation=interpolation)
 
+    def reverse_image(
+        self, img: np.ndarray, height: int = 0, width: int = 0, interpolation=cv2.INTER_LINEAR, **params
+    ) -> np.ndarray:
+        return F.resize(img, height=height, width=width, interpolation=interpolation)
+
     def apply_to_bbox(self, bbox, **params):
         # Bounding box coordinates are scale invariant
+        return bbox
+
+    def reverse_bbox(
+        self, bbox: typing.Tuple[float, float, float, float], **params
+    ) -> typing.Tuple[float, float, float, float]:
         return bbox
 
     def apply_to_keypoint(self, keypoint, **params):
@@ -160,5 +173,16 @@ class Resize(DualTransform):
         scale_y = self.height / height
         return F.keypoint_scale(keypoint, scale_x, scale_y)
 
+    def reverse_keypoint(
+        self, keypoint: typing.Tuple[float, float, float, float], height: int = 0, width: int = 0, **params
+    ) -> typing.Tuple[float, float, float, float]:
+        scale_x = width / self.width
+        scale_y = height / self.height
+        return F.keypoint_scale(keypoint, scale_x, scale_y)
+
     def get_transform_init_args_names(self):
         return ("height", "width", "interpolation")
+
+    def get_reverse_args(self, image: np.ndarray = np.ndarray([]), **kwargs) -> dict:
+        h, w = image.shape[:2]
+        return {"height": h, "width": w}

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -1,17 +1,23 @@
 from __future__ import absolute_import
 
 import random
+import typing
 from warnings import warn
 from typing import Sequence
 
 import cv2
 from copy import deepcopy
 
+import numpy as np
+
 from albumentations.core.serialization import SerializableMeta, get_shortest_class_fullname
 from albumentations.core.six import add_metaclass
 from albumentations.core.utils import format_args
 
 __all__ = ["to_tuple", "BasicTransform", "DualTransform", "ImageOnlyTransform", "NoOp"]
+
+Bbox = typing.Tuple[float, float, float, float]
+Keypoint = typing.Tuple[float, float, float, float]
 
 
 def to_tuple(param, low=None, bias=None):
@@ -86,10 +92,28 @@ class BasicTransform:
                         self.get_class_fullname() + " could work incorrectly in ReplayMode for other input data"
                         " because its' params depend on targets."
                     )
-                kwargs[self.save_key][id(self)] = deepcopy(params)
+                kwargs[self.save_key][id(self)] = dict(
+                    **deepcopy(params), **{self.save_key: self.get_reverse_args(**kwargs)}
+                )
             return self.apply_with_params(params, **kwargs)
 
         return kwargs
+
+    def reverse(self, data: dict, params: dict) -> typing.Any:
+        reverse_params = params["params"][self.save_key]
+
+        res = {}
+        for key, arg in data.items():
+            if arg is not None:
+                target_function = self._get_target_reverse_function(key)
+                target_dependencies = {k: params[k] for k in self.target_dependence.get(key, [])}
+                res[key] = target_function(arg, **dict(**reverse_params, **target_dependencies))
+            else:
+                res[key] = None
+        return res
+
+    def get_reverse_args(self, **kwargs) -> dict:
+        return {}
 
     def apply_with_params(self, params, force_apply=False, **kwargs):  # skipcq: PYL-W0613
         if params is None:
@@ -124,8 +148,18 @@ class BasicTransform:
         target_function = self.targets.get(transform_key, lambda x, **p: x)
         return target_function
 
+    def _get_target_reverse_function(self, key: str) -> typing.Callable:
+        transform_key = key
+        if key in self._additional_targets:
+            transform_key = self._additional_targets.get(key, None)
+
+        return self.targets_reverse.get(transform_key, lambda x, **p: x)
+
     def apply(self, img, **params):
         raise NotImplementedError
+
+    def reverse_image(self, img: np.ndarray, **params) -> np.ndarray:
+        raise NotImplementedError("Method reverse_image is not implemented in class " + self.__class__.__name__)
 
     def get_params(self):
         return {}
@@ -135,6 +169,10 @@ class BasicTransform:
         # you must specify targets in subclass
         # for example: ('image', 'mask')
         #              ('image', 'boxes')
+        raise NotImplementedError
+
+    @property
+    def targets_reverse(self) -> typing.Dict[str, typing.Callable]:
         raise NotImplementedError
 
     def update_params(self, params, **kwargs):
@@ -212,22 +250,55 @@ class DualTransform(BasicTransform):
             "keypoints": self.apply_to_keypoints,
         }
 
+    @property
+    def targets_reverse(self) -> typing.Dict[str, typing.Callable]:
+        return {
+            "image": self.reverse_image,
+            "mask": self.reverse_mask,
+            "masks": self.reverse_masks,
+            "bboxes": self.reverse_bboxes,
+            "keypoints": self.reverse_keypoints,
+        }
+
     def apply_to_bbox(self, bbox, **params):
         raise NotImplementedError("Method apply_to_bbox is not implemented in class " + self.__class__.__name__)
+
+    def reverse_bbox(self, bbox: Bbox, **params) -> Bbox:
+        raise NotImplementedError("Method reverse_bbox is not implemented in class " + self.__class__.__name__)
 
     def apply_to_keypoint(self, keypoint, **params):
         raise NotImplementedError("Method apply_to_keypoint is not implemented in class " + self.__class__.__name__)
 
+    def reverse_keypoint(self, keypoint: Keypoint, **params) -> Keypoint:
+        raise NotImplementedError("Method reverse_keypoint is not implemented in class " + self.__class__.__name__)
+
     def apply_to_bboxes(self, bboxes, **params):
         return [self.apply_to_bbox(tuple(bbox[:4]), **params) + tuple(bbox[4:]) for bbox in bboxes]
+
+    def reverse_bboxes(self, bboxes: typing.List[typing.Tuple], **params) -> typing.List[typing.Tuple]:
+        return [self.reverse_bbox(typing.cast(Bbox, tuple(bbox[:4])), **params) + tuple(bbox[4:]) for bbox in bboxes]
 
     def apply_to_keypoints(self, keypoints, **params):
         return [self.apply_to_keypoint(tuple(keypoint[:4]), **params) + tuple(keypoint[4:]) for keypoint in keypoints]
 
+    def reverse_keypoints(self, keypoints: typing.List[typing.Tuple], **params) -> typing.List[typing.Tuple]:
+        return [
+            self.reverse_keypoint(typing.cast(Keypoint, tuple(keypoint[:4])), **params) + tuple(keypoint[4:])
+            for keypoint in keypoints
+        ]
+
     def apply_to_mask(self, img, **params):
         return self.apply(img, **{k: cv2.INTER_NEAREST if k == "interpolation" else v for k, v in params.items()})
 
+    def reverse_mask(self, mask: np.ndarray, **params) -> np.ndarray:
+        return self.reverse_image(
+            mask, **{k: cv2.INTER_NEAREST if k == "interpolation" else v for k, v in params.items()}
+        )
+
     def apply_to_masks(self, masks, **params):
+        return [self.apply_to_mask(mask, **params) for mask in masks]
+
+    def reverse_masks(self, masks: typing.List[np.ndarray], **params) -> typing.List[np.ndarray]:
         return [self.apply_to_mask(mask, **params) for mask in masks]
 
 
@@ -237,6 +308,10 @@ class ImageOnlyTransform(BasicTransform):
     @property
     def targets(self):
         return {"image": self.apply}
+
+    @property
+    def targets_reverse(self) -> typing.Dict[str, typing.Callable]:
+        return {"image": self.reverse_image}
 
 
 class NoOp(DualTransform):


### PR DESCRIPTION
I tried to implement the interface for Test Time Augmentations (TTA) using `ReplayCompose` API.

If some transform could support reverse operation we must implement these functions:
- `get_reverse_args` - to save all needed parameters to do reverse transformation
- `reverse_image` - to reverse images and masks
- `reverse_bbox` - to reverse bboxes
- `reverse_keypoint` - to reverse keypoints.

Example:

```python
import numpy as np
import albumentations as A

t = A.ReversibleCompose(
    [A.Resize(512, 512, p=1)], bbox_params=A.BboxParams("pascal_voc"), keypoint_params=A.KeypointParams("xy")
)
img = np.empty([100, 100, 3], dtype=np.uint8)
bboxes = [(0, 0, 10, 10, 1)]
keypoints = [(10, 20)]

res = t(image=img, bboxes=bboxes, keypoints=keypoints, test="test")
res = t.reverse(**res)

assert np.allclose(np.array(bboxes), np.array(res["bboxes"]))
assert np.allclose(np.array(keypoints), np.array(res["keypoints"]))
```