### PR TITLE
Fix Affine args to accept mask interp. method. 

### DIFF
--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -441,7 +441,6 @@ class Affine(DualTransform):
                   Using a dictionary allows to set different values for the two axis and sampling will then happen
                   *independently* per axis, resulting in samples that differ between the axes.
         interpolation (int): OpenCV interpolation flag.
-        mask_interpolation (int): OpenCV interpolation flag.
         cval (number or sequence of number): The constant value to use when filling in newly created pixels.
             (E.g. translating by 1px to the right will create a new 1px-wide column of pixels
             on the left of the image).

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -441,6 +441,7 @@ class Affine(DualTransform):
                   Using a dictionary allows to set different values for the two axis and sampling will then happen
                   *independently* per axis, resulting in samples that differ between the axes.
         interpolation (int): OpenCV interpolation flag.
+        mask_interpolation (int): OpenCV interpolation flag.
         cval (number or sequence of number): The constant value to use when filling in newly created pixels.
             (E.g. translating by 1px to the right will create a new 1px-wide column of pixels
             on the left of the image).

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -472,6 +472,7 @@ class Affine(DualTransform):
         rotate: Optional[Union[float, Sequence[float]]] = None,
         shear: Optional[Union[float, Sequence[float], dict]] = None,
         interpolation: int = cv2.INTER_LINEAR,
+        mask_interpolation: int = cv2.INTER_NEAREST,
         cval: Union[int, float, Sequence[int], Sequence[float]] = 0,
         cval_mask: Union[int, float, Sequence[int], Sequence[float]] = 0,
         mode: int = cv2.BORDER_CONSTANT,
@@ -493,6 +494,7 @@ class Affine(DualTransform):
             shear = shear if shear is not None else 0.0
 
         self.interpolation = interpolation
+        self.mask_interpolation = mask_interpolation
         self.cval = cval
         self.cval_mask = cval_mask
         self.mode = mode
@@ -505,6 +507,7 @@ class Affine(DualTransform):
     def get_transform_init_args_names(self):
         return (
             "interpolation",
+            "mask_interpolation",
             "cval",
             "mode",
             "scale",
@@ -577,7 +580,7 @@ class Affine(DualTransform):
         return F.warp_affine(
             img,
             matrix,
-            interpolation=cv2.INTER_NEAREST,
+            interpolation=self.mask_interpolation,
             cval=self.cval_mask,
             mode=self.mode,
             output_shape=output_shape,


### PR DESCRIPTION
In a doc string of Affine, there is mask_interpolation option but users can not specify that method through args. It seems to be better to remove this part if it is intended.