### PR TITLE
Speed up elastic transform

### DIFF
--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -199,6 +199,7 @@ def elastic_transform(
     value=None,
     random_state=None,
     approximate=False,
+    same_dxdy=False,
 ):
     """Elastic deformation of images as described in [Simard2003]_ (with modifications).
     Based on https://gist.github.com/ernestum/601cdf56d2b424757de5
@@ -241,13 +242,20 @@ def elastic_transform(
         dx = random_state.rand(height, width).astype(np.float32) * 2 - 1
         cv2.GaussianBlur(dx, (17, 17), sigma, dst=dx)
         dx *= alpha
-
-        dy = random_state.rand(height, width).astype(np.float32) * 2 - 1
-        cv2.GaussianBlur(dy, (17, 17), sigma, dst=dy)
-        dy *= alpha
+        if same_dxdy:
+            # Speed up even more
+            dy = dx
+        else:
+            dy = random_state.rand(height, width).astype(np.float32) * 2 - 1
+            cv2.GaussianBlur(dy, (17, 17), sigma, dst=dy)
+            dy *= alpha
     else:
         dx = np.float32(gaussian_filter((random_state.rand(height, width) * 2 - 1), sigma) * alpha)
-        dy = np.float32(gaussian_filter((random_state.rand(height, width) * 2 - 1), sigma) * alpha)
+        if same_dxdy:
+            # Speed up
+            dy = dx
+        else:
+            dy = np.float32(gaussian_filter((random_state.rand(height, width) * 2 - 1), sigma) * alpha)
 
     x, y = np.meshgrid(np.arange(width), np.arange(height))
 

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -150,6 +150,7 @@ class ElasticTransform(DualTransform):
         mask_value=None,
         always_apply=False,
         approximate=False,
+        same_dxdy=False,
         p=0.5,
     ):
         super(ElasticTransform, self).__init__(always_apply, p)
@@ -161,6 +162,7 @@ class ElasticTransform(DualTransform):
         self.value = value
         self.mask_value = mask_value
         self.approximate = approximate
+        self.same_dxdy = same_dxdy
 
     def apply(self, img, random_state=None, interpolation=cv2.INTER_LINEAR, **params):
         return F.elastic_transform(
@@ -173,6 +175,7 @@ class ElasticTransform(DualTransform):
             self.value,
             np.random.RandomState(random_state),
             self.approximate,
+            self.same_dxdy,
         )
 
     def apply_to_mask(self, img, random_state=None, **params):
@@ -186,6 +189,7 @@ class ElasticTransform(DualTransform):
             self.mask_value,
             np.random.RandomState(random_state),
             self.approximate,
+            self.same_dxdy,
         )
 
     def get_params(self):

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -131,6 +131,8 @@ class ElasticTransform(DualTransform):
                     list of float): padding value if border_mode is cv2.BORDER_CONSTANT applied for masks.
         approximate (boolean): Whether to smooth displacement map with fixed kernel size.
                                Enabling this option gives ~2X speedup on large images.
+        same_dxdy (boolean): Whether to use same random generated shift for x and y.
+                             Enabling this option gives ~2X speedup.
 
     Targets:
         image, mask
@@ -196,7 +198,17 @@ class ElasticTransform(DualTransform):
         return {"random_state": random.randint(0, 10000)}
 
     def get_transform_init_args_names(self):
-        return ("alpha", "sigma", "alpha_affine", "interpolation", "border_mode", "value", "mask_value", "approximate")
+        return (
+            "alpha",
+            "sigma",
+            "alpha_affine",
+            "interpolation",
+            "border_mode",
+            "value",
+            "mask_value",
+            "approximate",
+            "same_dxdy",
+        )
 
 
 class Perspective(DualTransform):


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27873390/132219695-d42cdf22-cb9a-4035-919a-1e2f92560d75.png)
![image](https://user-images.githubusercontent.com/27873390/132220144-20d25609-abfa-4cc8-b661-4c69bfd7af9a.png)

A bit another way to do elastic transform.
It exploits fact that same random shift can be applied to x and y mapping.