### PR TITLE
CoarseDropout can now set height and width of holes based on fraction of original image height and width

### DIFF
--- a/albumentations/augmentations/bbox_utils.py
+++ b/albumentations/augmentations/bbox_utils.py
@@ -38,7 +38,11 @@ class BboxProcessor(DataProcessor):
 
     def filter(self, data, rows, cols):
         return filter_bboxes(
-            data, rows, cols, min_area=self.params.min_area, min_visibility=self.params.min_visibility
+            data,
+            rows,
+            cols,
+            min_area=self.params.min_area,
+            min_visibility=self.params.min_visibility,
         )
 
     def check(self, data, rows, cols):
@@ -158,7 +162,12 @@ def calculate_bbox_area(bbox, rows, cols):
 
 
 def filter_bboxes_by_visibility(
-    original_shape, bboxes, transformed_shape, transformed_bboxes, threshold=0.0, min_area=0.0
+    original_shape,
+    bboxes,
+    transformed_shape,
+    transformed_bboxes,
+    threshold=0.0,
+    min_area=0.0,
 ):
     """Filter bounding boxes and return only those boxes whose visibility after transformation is above
     the threshold and minimal area of bounding box in pixels is more then min_area.

--- a/albumentations/augmentations/crops/functional.py
+++ b/albumentations/augmentations/crops/functional.py
@@ -11,7 +11,14 @@ BboxType = Union[List[int], List[float], Tuple[int, ...], Tuple[float, ...], np.
 KeypointType = Union[List[int], List[float], Tuple[int, ...], Tuple[float, ...], np.ndarray]
 
 
-def get_random_crop_coords(height: int, width: int, crop_height: int, crop_width: int, h_start: float, w_start: float):
+def get_random_crop_coords(
+    height: int,
+    width: int,
+    crop_height: int,
+    crop_width: int,
+    h_start: float,
+    w_start: float,
+):
     y1 = int((height - crop_height) * h_start)
     y2 = y1 + crop_height
     x1 = int((width - crop_width) * w_start)
@@ -25,7 +32,10 @@ def random_crop(img: np.ndarray, crop_height: int, crop_width: int, h_start: flo
         raise ValueError(
             "Requested crop size ({crop_height}, {crop_width}) is "
             "larger than the image size ({height}, {width})".format(
-                crop_height=crop_height, crop_width=crop_width, height=height, width=width
+                crop_height=crop_height,
+                crop_width=crop_width,
+                height=height,
+                width=width,
             )
         )
     x1, y1, x2, y2 = get_random_crop_coords(height, width, crop_height, crop_width, h_start, w_start)
@@ -34,7 +44,12 @@ def random_crop(img: np.ndarray, crop_height: int, crop_width: int, h_start: flo
 
 
 def crop_bbox_by_coords(
-    bbox: BboxType, crop_coords: Tuple[int, int, int, int], crop_height: int, crop_width: int, rows: int, cols: int
+    bbox: BboxType,
+    crop_coords: Tuple[int, int, int, int],
+    crop_height: int,
+    crop_width: int,
+    rows: int,
+    cols: int,
 ):
     """Crop a bounding box using the provided coordinates of bottom-left and top-right corners in pixels and the
     required height and width of the crop.
@@ -59,7 +74,13 @@ def crop_bbox_by_coords(
 
 
 def bbox_random_crop(
-    bbox: BboxType, crop_height: int, crop_width: int, h_start: float, w_start: float, rows: int, cols: int
+    bbox: BboxType,
+    crop_height: int,
+    crop_width: int,
+    h_start: float,
+    w_start: float,
+    rows: int,
+    cols: int,
 ):
     crop_coords = get_random_crop_coords(rows, cols, crop_height, crop_width, h_start, w_start)
     return crop_bbox_by_coords(bbox, crop_coords, crop_height, crop_width, rows, cols)
@@ -83,7 +104,13 @@ def crop_keypoint_by_coords(keypoint: KeypointType, crop_coords: Tuple[int, int,
 
 
 def keypoint_random_crop(
-    keypoint: KeypointType, crop_height: int, crop_width: int, h_start: float, w_start: float, rows: int, cols: int
+    keypoint: KeypointType,
+    crop_height: int,
+    crop_width: int,
+    h_start: float,
+    w_start: float,
+    rows: int,
+    cols: int,
 ):
     """Keypoint random crop.
 
@@ -118,7 +145,10 @@ def center_crop(img: np.ndarray, crop_height: int, crop_width: int):
         raise ValueError(
             "Requested crop size ({crop_height}, {crop_width}) is "
             "larger than the image size ({height}, {width})".format(
-                crop_height=crop_height, crop_width=crop_width, height=height, width=width
+                crop_height=crop_height,
+                crop_width=crop_width,
+                height=height,
+                width=width,
             )
         )
     x1, y1, x2, y2 = get_center_crop_coords(height, width, crop_height, crop_width)
@@ -164,7 +194,12 @@ def crop(img: np.ndarray, x_min: int, y_min: int, x_max: int, y_max: int):
             "Values for crop should be non negative and equal or smaller than image sizes"
             "(x_min = {x_min}, y_min = {y_min}, x_max = {x_max}, y_max = {y_max}, "
             "height = {height}, width = {width})".format(
-                x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max, height=height, width=width
+                x_min=x_min,
+                x_max=x_max,
+                y_min=y_min,
+                y_max=y_max,
+                height=height,
+                width=width,
             )
         )
 

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -153,7 +153,15 @@ class CropNonEmptyMaskIfExists(DualTransform):
         uint8, float32
     """
 
-    def __init__(self, height, width, ignore_values=None, ignore_channels=None, always_apply=False, p=1.0):
+    def __init__(
+        self,
+        height,
+        width,
+        ignore_values=None,
+        ignore_channels=None,
+        always_apply=False,
+        p=1.0,
+    ):
         super(CropNonEmptyMaskIfExists, self).__init__(always_apply, p)
 
         if ignore_values is not None and not isinstance(ignore_values, list):
@@ -171,7 +179,13 @@ class CropNonEmptyMaskIfExists(DualTransform):
 
     def apply_to_bbox(self, bbox, x_min=0, x_max=0, y_min=0, y_max=0, **params):
         return F.bbox_crop(
-            bbox, x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max, rows=params["rows"], cols=params["cols"]
+            bbox,
+            x_min=x_min,
+            x_max=x_max,
+            y_min=y_min,
+            y_max=y_max,
+            rows=params["rows"],
+            cols=params["cols"],
         )
 
     def apply_to_keypoint(self, keypoint, x_min=0, x_max=0, y_min=0, y_max=0, **params):
@@ -278,10 +292,21 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
     """
 
     def __init__(
-        self, min_max_height, height, width, w2h_ratio=1.0, interpolation=cv2.INTER_LINEAR, always_apply=False, p=1.0
+        self,
+        min_max_height,
+        height,
+        width,
+        w2h_ratio=1.0,
+        interpolation=cv2.INTER_LINEAR,
+        always_apply=False,
+        p=1.0,
     ):
         super(RandomSizedCrop, self).__init__(
-            height=height, width=width, interpolation=interpolation, always_apply=always_apply, p=p
+            height=height,
+            width=width,
+            interpolation=interpolation,
+            always_apply=always_apply,
+            p=p,
         )
         self.min_max_height = min_max_height
         self.w2h_ratio = w2h_ratio
@@ -331,7 +356,11 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
     ):
 
         super(RandomResizedCrop, self).__init__(
-            height=height, width=width, interpolation=interpolation, always_apply=always_apply, p=p
+            height=height,
+            width=width,
+            interpolation=interpolation,
+            always_apply=always_apply,
+            p=p,
         )
         self.scale = scale
         self.ratio = ratio
@@ -458,7 +487,15 @@ class RandomSizedBBoxSafeCrop(DualTransform):
         uint8, float32
     """
 
-    def __init__(self, height, width, erosion_rate=0.0, interpolation=cv2.INTER_LINEAR, always_apply=False, p=1.0):
+    def __init__(
+        self,
+        height,
+        width,
+        erosion_rate=0.0,
+        interpolation=cv2.INTER_LINEAR,
+        always_apply=False,
+        p=1.0,
+    ):
         super(RandomSizedBBoxSafeCrop, self).__init__(always_apply, p)
         self.height = height
         self.width = width
@@ -482,7 +519,10 @@ class RandomSizedBBoxSafeCrop(DualTransform):
             }
         # get union of all bboxes
         x, y, x2, y2 = union_of_bboxes(
-            width=img_w, height=img_h, bboxes=params["bboxes"], erosion_rate=self.erosion_rate
+            width=img_w,
+            height=img_h,
+            bboxes=params["bboxes"],
+            erosion_rate=self.erosion_rate,
         )
         # find bigger region
         bx, by = x * random.random(), y * random.random()
@@ -492,7 +532,12 @@ class RandomSizedBBoxSafeCrop(DualTransform):
         crop_width = img_w if bw >= 1.0 else int(img_w * bw)
         h_start = np.clip(0.0 if bh >= 1.0 else by / (1.0 - bh), 0.0, 1.0)
         w_start = np.clip(0.0 if bw >= 1.0 else bx / (1.0 - bw), 0.0, 1.0)
-        return {"h_start": h_start, "w_start": w_start, "crop_height": crop_height, "crop_width": crop_width}
+        return {
+            "h_start": h_start,
+            "w_start": w_start,
+            "crop_height": crop_height,
+            "crop_width": crop_width,
+        }
 
     def apply_to_bbox(self, bbox, crop_height=0, crop_width=0, h_start=0, w_start=0, rows=0, cols=0, **params):
         return F.bbox_random_crop(bbox, crop_height, crop_width, h_start, w_start, rows, cols)
@@ -636,7 +681,15 @@ class CropAndPad(DualTransform):
         **params
     ) -> np.ndarray:
         return F.crop_and_pad(
-            img, crop_params, pad_params, pad_value, rows, cols, interpolation, self.pad_mode, self.keep_size
+            img,
+            crop_params,
+            pad_params,
+            pad_value,
+            rows,
+            cols,
+            interpolation,
+            self.pad_mode,
+            self.keep_size,
         )
 
     def apply_to_mask(
@@ -651,7 +704,15 @@ class CropAndPad(DualTransform):
         **params
     ) -> np.ndarray:
         return F.crop_and_pad(
-            img, crop_params, pad_params, pad_value_mask, rows, cols, interpolation, self.pad_mode, self.keep_size
+            img,
+            crop_params,
+            pad_params,
+            pad_value_mask,
+            rows,
+            cols,
+            interpolation,
+            self.pad_mode,
+            self.keep_size,
         )
 
     def apply_to_bbox(
@@ -665,7 +726,16 @@ class CropAndPad(DualTransform):
         result_cols: int = 0,
         **params
     ) -> Sequence[float]:
-        return F.crop_and_pad_bbox(bbox, crop_params, pad_params, rows, cols, result_rows, result_cols, self.keep_size)
+        return F.crop_and_pad_bbox(
+            bbox,
+            crop_params,
+            pad_params,
+            rows,
+            cols,
+            result_rows,
+            result_cols,
+            self.keep_size,
+        )
 
     def apply_to_keypoint(
         self,
@@ -679,7 +749,14 @@ class CropAndPad(DualTransform):
         **params
     ) -> Sequence[float]:
         return F.crop_and_pad_keypoint(
-            keypoint, crop_params, pad_params, rows, cols, result_rows, result_cols, self.keep_size
+            keypoint,
+            crop_params,
+            pad_params,
+            rows,
+            cols,
+            result_rows,
+            result_cols,
+            self.keep_size,
         )
 
     @property

--- a/albumentations/augmentations/domain_adaptation.py
+++ b/albumentations/augmentations/domain_adaptation.py
@@ -8,7 +8,12 @@ from skimage.exposure import match_histograms
 from sklearn.decomposition import PCA
 from sklearn.preprocessing import MinMaxScaler, StandardScaler
 
-from .functional import clipped, preserve_shape, is_grayscale_image, is_multispectral_image
+from .functional import (
+    clipped,
+    preserve_shape,
+    is_grayscale_image,
+    is_multispectral_image,
+)
 from .utils import read_rgb_image
 from ..core.transforms_interface import ImageOnlyTransform, to_tuple
 

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -1731,7 +1731,11 @@ def adjust_hue_torchvision(img, factor):
 
 @preserve_shape
 def superpixels(
-    image: np.ndarray, n_segments: int, replace_samples: Sequence[bool], max_size: Optional[int], interpolation: int
+    image: np.ndarray,
+    n_segments: int,
+    replace_samples: Sequence[bool],
+    max_size: Optional[int],
+    interpolation: int,
 ) -> np.ndarray:
     if not np.any(replace_samples):
         return image
@@ -1782,7 +1786,9 @@ def superpixels(
 
     if orig_shape != image.shape:
         resize_fn = _maybe_process_in_chunks(
-            cv2.resize, dsize=(orig_shape[1], orig_shape[0]), interpolation=interpolation
+            cv2.resize,
+            dsize=(orig_shape[1], orig_shape[0]),
+            interpolation=interpolation,
         )
         image = resize_fn(image)
 

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -6,7 +6,13 @@ import skimage.transform
 from scipy.ndimage.filters import gaussian_filter
 
 from ..bbox_utils import denormalize_bbox, normalize_bbox
-from ..functional import angle_2pi_range, preserve_channel_dim, _maybe_process_in_chunks, preserve_shape, clipped
+from ..functional import (
+    angle_2pi_range,
+    preserve_channel_dim,
+    _maybe_process_in_chunks,
+    preserve_shape,
+    clipped,
+)
 
 from typing import Union, List, Sequence, Tuple, Optional
 
@@ -69,12 +75,23 @@ def keypoint_rot90(keypoint, factor, rows, cols, **params):
 
 
 @preserve_channel_dim
-def rotate(img, angle, interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_REFLECT_101, value=None):
+def rotate(
+    img,
+    angle,
+    interpolation=cv2.INTER_LINEAR,
+    border_mode=cv2.BORDER_REFLECT_101,
+    value=None,
+):
     height, width = img.shape[:2]
     matrix = cv2.getRotationMatrix2D((width / 2, height / 2), angle, 1.0)
 
     warp_fn = _maybe_process_in_chunks(
-        cv2.warpAffine, M=matrix, dsize=(width, height), flags=interpolation, borderMode=border_mode, borderValue=value
+        cv2.warpAffine,
+        M=matrix,
+        dsize=(width, height),
+        flags=interpolation,
+        borderMode=border_mode,
+        borderValue=value,
     )
     return warp_fn(img)
 
@@ -130,7 +147,14 @@ def keypoint_rotate(keypoint, angle, rows, cols, **params):
 
 @preserve_channel_dim
 def shift_scale_rotate(
-    img, angle, scale, dx, dy, interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_REFLECT_101, value=None
+    img,
+    angle,
+    scale,
+    dx,
+    dy,
+    interpolation=cv2.INTER_LINEAR,
+    border_mode=cv2.BORDER_REFLECT_101,
+    value=None,
 ):
     height, width = img.shape[:2]
     center = (width / 2, height / 2)
@@ -139,7 +163,12 @@ def shift_scale_rotate(
     matrix[1, 2] += dy * height
 
     warp_affine_fn = _maybe_process_in_chunks(
-        cv2.warpAffine, M=matrix, dsize=(width, height), flags=interpolation, borderMode=border_mode, borderValue=value
+        cv2.warpAffine,
+        M=matrix,
+        dsize=(width, height),
+        flags=interpolation,
+        borderMode=border_mode,
+        borderValue=value,
     )
     return warp_affine_fn(img)
 
@@ -231,7 +260,12 @@ def elastic_transform(
     matrix = cv2.getAffineTransform(pts1, pts2)
 
     warp_fn = _maybe_process_in_chunks(
-        cv2.warpAffine, M=matrix, dsize=(width, height), flags=interpolation, borderMode=border_mode, borderValue=value
+        cv2.warpAffine,
+        M=matrix,
+        dsize=(width, height),
+        flags=interpolation,
+        borderMode=border_mode,
+        borderValue=value,
     )
     img = warp_fn(img)
 
@@ -255,7 +289,12 @@ def elastic_transform(
     map_y = np.float32(y + dy)
 
     remap_fn = _maybe_process_in_chunks(
-        cv2.remap, map1=map_x, map2=map_y, interpolation=interpolation, borderMode=border_mode, borderValue=value
+        cv2.remap,
+        map1=map_x,
+        map2=map_y,
+        interpolation=interpolation,
+        borderMode=border_mode,
+        borderValue=value,
     )
     return remap_fn(img)
 
@@ -364,7 +403,15 @@ def perspective_bbox(
 
     x1, y1, x2, y2 = float("inf"), float("inf"), 0, 0
     for pt in points:
-        pt = perspective_keypoint(pt.tolist() + [0, 0], height, width, matrix, max_width, max_height, keep_size)
+        pt = perspective_keypoint(
+            pt.tolist() + [0, 0],
+            height,
+            width,
+            matrix,
+            max_width,
+            max_height,
+            keep_size,
+        )
         x, y = pt[:2]
         x = np.clip(x, 0, width if keep_size else max_width)
         y = np.clip(y, 0, height if keep_size else max_height)
@@ -376,7 +423,9 @@ def perspective_bbox(
     x = np.clip([x1, x2], 0, width if keep_size else max_width)
     y = np.clip([y1, y2], 0, height if keep_size else max_height)
     return normalize_bbox(
-        (x[0], y[0], x[1], y[1]), height if keep_size else max_height, width if keep_size else max_width
+        (x[0], y[0], x[1], y[1]),
+        height if keep_size else max_height,
+        width if keep_size else max_width,
     )
 
 
@@ -431,7 +480,12 @@ def warp_affine(
 
     dsize = int(np.round(output_shape[1])), int(np.round(output_shape[0]))
     warp_fn = _maybe_process_in_chunks(
-        cv2.warpAffine, M=matrix.params[:2], dsize=dsize, flags=interpolation, borderMode=mode, borderValue=cval
+        cv2.warpAffine,
+        M=matrix.params[:2],
+        dsize=dsize,
+        flags=interpolation,
+        borderMode=mode,
+        borderValue=cval,
     )
     tmp = warp_fn(image)
     return tmp
@@ -565,7 +619,12 @@ def keypoint_safe_rotate(keypoint, angle, rows, cols):
     row_diff = int(np.ceil(abs(new_rows - old_rows) / 2))
 
     # Shift keypoint
-    shifted_keypoint = (keypoint[0] + col_diff, keypoint[1] + row_diff, keypoint[2], keypoint[3])
+    shifted_keypoint = (
+        keypoint[0] + col_diff,
+        keypoint[1] + row_diff,
+        keypoint[2],
+        keypoint[3],
+    )
 
     # Rotate keypoint
     rotated_keypoint = keypoint_rotate(shifted_keypoint, angle, rows=new_rows, cols=new_cols)
@@ -603,12 +662,21 @@ def piecewise_affine(
     cval: float,
 ) -> np.ndarray:
     return skimage.transform.warp(
-        img, matrix, order=interpolation, mode=mode, cval=cval, preserve_range=True, output_shape=img.shape
+        img,
+        matrix,
+        order=interpolation,
+        mode=mode,
+        cval=cval,
+        preserve_range=True,
+        output_shape=img.shape,
     )
 
 
 def to_distance_maps(
-    keypoints: Sequence[Sequence[float]], height: int, width: int, inverted: bool = False
+    keypoints: Sequence[Sequence[float]],
+    height: int,
+    width: int,
+    inverted: bool = False,
 ) -> np.ndarray:
     """Generate a ``(H,W,N)`` array of distance maps for ``N`` keypoints.
 

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -47,7 +47,10 @@ class RandomScale(DualTransform):
         return F.keypoint_scale(keypoint, scale, scale)
 
     def get_transform_init_args(self):
-        return {"interpolation": self.interpolation, "scale_limit": to_tuple(self.scale_limit, bias=-1.0)}
+        return {
+            "interpolation": self.interpolation,
+            "scale_limit": to_tuple(self.scale_limit, bias=-1.0),
+        }
 
 
 class LongestMaxSize(DualTransform):

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -151,12 +151,20 @@ class SafeRotate(DualTransform):
 
     def apply(self, img, angle=0, interpolation=cv2.INTER_LINEAR, **params):
         return F.safe_rotate(
-            img=img, value=self.value, angle=angle, interpolation=interpolation, border_mode=self.border_mode
+            img=img,
+            value=self.value,
+            angle=angle,
+            interpolation=interpolation,
+            border_mode=self.border_mode,
         )
 
     def apply_to_mask(self, img, angle=0, **params):
         return F.safe_rotate(
-            img=img, value=self.mask_value, angle=angle, interpolation=cv2.INTER_NEAREST, border_mode=self.border_mode
+            img=img,
+            value=self.mask_value,
+            angle=angle,
+            interpolation=cv2.INTER_NEAREST,
+            border_mode=self.border_mode,
         )
 
     def get_params(self):

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -8,7 +8,13 @@ from typing import Union, Optional, Sequence, Tuple, Dict
 from . import functional as F
 from ...core.transforms_interface import DualTransform, to_tuple
 
-__all__ = ["ShiftScaleRotate", "ElasticTransform", "Perspective", "Affine", "PiecewiseAffine"]
+__all__ = [
+    "ShiftScaleRotate",
+    "ElasticTransform",
+    "Perspective",
+    "Affine",
+    "PiecewiseAffine",
+]
 
 
 class ShiftScaleRotate(DualTransform):
@@ -73,11 +79,29 @@ class ShiftScaleRotate(DualTransform):
         self.value = value
         self.mask_value = mask_value
 
-    def apply(self, img, angle=0, scale=0, dx=0, dy=0, interpolation=cv2.INTER_LINEAR, **params):
+    def apply(
+        self,
+        img,
+        angle=0,
+        scale=0,
+        dx=0,
+        dy=0,
+        interpolation=cv2.INTER_LINEAR,
+        **params,
+    ):
         return F.shift_scale_rotate(img, angle, scale, dx, dy, interpolation, self.border_mode, self.value)
 
     def apply_to_mask(self, img, angle=0, scale=0, dx=0, dy=0, **params):
-        return F.shift_scale_rotate(img, angle, scale, dx, dy, cv2.INTER_NEAREST, self.border_mode, self.mask_value)
+        return F.shift_scale_rotate(
+            img,
+            angle,
+            scale,
+            dx,
+            dy,
+            cv2.INTER_NEAREST,
+            self.border_mode,
+            self.mask_value,
+        )
 
     def apply_to_keypoint(self, keypoint, angle=0, scale=0, dx=0, dy=0, rows=0, cols=0, **params):
         return F.keypoint_shift_scale_rotate(keypoint, angle, scale, dx, dy, rows, cols)
@@ -192,7 +216,16 @@ class ElasticTransform(DualTransform):
         return {"random_state": random.randint(0, 10000)}
 
     def get_transform_init_args_names(self):
-        return ("alpha", "sigma", "alpha_affine", "interpolation", "border_mode", "value", "mask_value", "approximate")
+        return (
+            "alpha",
+            "sigma",
+            "alpha_affine",
+            "interpolation",
+            "border_mode",
+            "value",
+            "mask_value",
+            "approximate",
+        )
 
 
 class Perspective(DualTransform):
@@ -247,15 +280,36 @@ class Perspective(DualTransform):
 
     def apply(self, img, matrix=None, max_height=None, max_width=None, **params):
         return F.perspective(
-            img, matrix, max_width, max_height, self.pad_val, self.pad_mode, self.keep_size, params["interpolation"]
+            img,
+            matrix,
+            max_width,
+            max_height,
+            self.pad_val,
+            self.pad_mode,
+            self.keep_size,
+            params["interpolation"],
         )
 
     def apply_to_bbox(self, bbox, matrix=None, max_height=None, max_width=None, **params):
-        return F.perspective_bbox(bbox, params["rows"], params["cols"], matrix, max_width, max_height, self.keep_size)
+        return F.perspective_bbox(
+            bbox,
+            params["rows"],
+            params["cols"],
+            matrix,
+            max_width,
+            max_height,
+            self.keep_size,
+        )
 
     def apply_to_keypoint(self, keypoint, matrix=None, max_height=None, max_width=None, **params):
         return F.perspective_keypoint(
-            keypoint, params["rows"], params["cols"], matrix, max_width, max_height, self.keep_size
+            keypoint,
+            params["rows"],
+            params["cols"],
+            matrix,
+            max_width,
+            max_height,
+            self.keep_size,
         )
 
     @property
@@ -325,7 +379,10 @@ class Perspective(DualTransform):
         # in the top-left, top-right, bottom-right, and bottom-left order
         # do not use width-1 or height-1 here, as for e.g. width=3, height=2
         # the bottom right coordinate is at (3.0, 2.0) and not (2.0, 1.0)
-        dst = np.array([[0, 0], [max_width, 0], [max_width, max_height], [0, max_height]], dtype=np.float32)
+        dst = np.array(
+            [[0, 0], [max_width, 0], [max_width, max_height], [0, max_height]],
+            dtype=np.float32,
+        )
 
         # compute the perspective transform matrix and then apply it
         m = cv2.getPerspectiveTransform(points, dst)
@@ -333,7 +390,12 @@ class Perspective(DualTransform):
         if self.fit_output:
             m, max_width, max_height = self._expand_transform(m, (h, w))
 
-        return {"matrix": m, "max_height": max_height, "max_width": max_width, "interpolation": self.interpolation}
+        return {
+            "matrix": m,
+            "max_height": max_height,
+            "max_width": max_width,
+            "interpolation": self.interpolation,
+        }
 
     @classmethod
     def _expand_transform(cls, matrix, shape):
@@ -371,7 +433,15 @@ class Perspective(DualTransform):
         return np.array([tl, tr, br, bl], dtype=np.float32)
 
     def get_transform_init_args_names(self):
-        return ("scale", "keep_size", "pad_mode", "pad_val", "mask_pad_val", "fit_output", "interpolation")
+        return (
+            "scale",
+            "keep_size",
+            "pad_mode",
+            "pad_val",
+            "mask_pad_val",
+            "fit_output",
+            "interpolation",
+        )
 
 
 class Affine(DualTransform):
@@ -547,7 +617,10 @@ class Affine(DualTransform):
 
         if translate_percent is not None:
             # translate by percent
-            return cls._handle_dict_arg(translate_percent, "translate_percent"), translate_px
+            return (
+                cls._handle_dict_arg(translate_percent, "translate_percent"),
+                translate_px,
+            )
 
         if translate_px is None:
             raise ValueError("translate_px is None.")
@@ -559,7 +632,7 @@ class Affine(DualTransform):
         img: np.ndarray,
         matrix: skimage.transform.ProjectiveTransform = None,
         output_shape: Sequence[int] = None,
-        **params
+        **params,
     ) -> np.ndarray:
         return F.warp_affine(
             img,
@@ -575,7 +648,7 @@ class Affine(DualTransform):
         img: np.ndarray,
         matrix: skimage.transform.ProjectiveTransform = None,
         output_shape: Sequence[int] = None,
-        **params
+        **params,
     ) -> np.ndarray:
         return F.warp_affine(
             img,
@@ -593,7 +666,7 @@ class Affine(DualTransform):
         rows: int = 0,
         cols: int = 0,
         output_shape: Sequence[int] = (),
-        **params
+        **params,
     ) -> Sequence[float]:
         return F.bbox_affine(bbox, matrix, rows, cols, output_shape)
 
@@ -602,7 +675,7 @@ class Affine(DualTransform):
         keypoint: Sequence[float],
         matrix: skimage.transform.ProjectiveTransform = None,
         scale: dict = None,
-        **params
+        **params,
     ) -> Sequence[float]:
         return F.keypoint_affine(keypoint, matrix=matrix, scale=scale)
 
@@ -847,12 +920,18 @@ class PiecewiseAffine(DualTransform):
         }
 
     def apply(
-        self, img: np.ndarray, matrix: skimage.transform.PiecewiseAffineTransform = None, **params
+        self,
+        img: np.ndarray,
+        matrix: skimage.transform.PiecewiseAffineTransform = None,
+        **params,
     ) -> np.ndarray:
         return F.piecewise_affine(img, matrix, self.interpolation, self.mode, self.cval)
 
     def apply_to_mask(
-        self, img: np.ndarray, matrix: skimage.transform.PiecewiseAffineTransform = None, **params
+        self,
+        img: np.ndarray,
+        matrix: skimage.transform.PiecewiseAffineTransform = None,
+        **params,
     ) -> np.ndarray:
         return F.piecewise_affine(img, matrix, self.mask_interpolation, self.mode, self.cval_mask)
 
@@ -862,7 +941,7 @@ class PiecewiseAffine(DualTransform):
         rows: int = 0,
         cols: int = 0,
         matrix: skimage.transform.PiecewiseAffineTransform = None,
-        **params
+        **params,
     ) -> Sequence[float]:
         return F.bbox_piecewise_affine(bbox, matrix, rows, cols, self.keypoints_threshold)
 
@@ -872,6 +951,6 @@ class PiecewiseAffine(DualTransform):
         rows: int = 0,
         cols: int = 0,
         matrix: skimage.transform.PiecewiseAffineTransform = None,
-        **params
+        **params,
     ):
         return F.keypoint_piecewise_affine(keypoint, matrix, rows, cols, self.keypoints_threshold)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -813,8 +813,9 @@ class CoarseDropout(DualTransform):
                     isinstance(self.max_width, float),
                 ]
             ):
-                hole_height = random.randint(round(self.min_height * height), round(self.max_height * height))
-                hole_width = random.randint(round(self.min_width * width), round(self.max_width * width))
+                hole_height = int(height * random.uniform(self.min_height, self.max_height))
+                hole_width = int(width * random.uniform(self.min_width, self.max_width))
+
             else:
                 raise ValueError(
                     "Min width, max width, \

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -243,7 +243,6 @@ class Compose(BaseCompose):
     def _check_args(self, **kwargs):
         checked_single = ["image", "mask"]
         checked_multi = ["masks"]
-        check_bbox_param = ["bboxes"]
         # ["bboxes", "keypoints"] could be almost any type, no need to check them
         for data_name, data in kwargs.items():
             internal_data_name = self.additional_targets.get(data_name, data_name)
@@ -254,8 +253,6 @@ class Compose(BaseCompose):
                 if data:
                     if not isinstance(data[0], np.ndarray):
                         raise TypeError("{} must be list of numpy arrays".format(data_name))
-            if internal_data_name in check_bbox_param and self.processors.get("bboxes") is None:
-                raise Exception("bbox_params must be specified for bbox transformations")
 
 
 class OneOf(BaseCompose):

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -6,7 +6,10 @@ import random
 import numpy as np
 
 from albumentations.augmentations.keypoints_utils import KeypointsProcessor
-from albumentations.core.serialization import SerializableMeta, get_shortest_class_fullname
+from albumentations.core.serialization import (
+    SerializableMeta,
+    get_shortest_class_fullname,
+)
 from albumentations.core.six import add_metaclass
 from albumentations.core.transforms_interface import DualTransform
 from albumentations.core.utils import format_args, Params, get_shape
@@ -138,7 +141,14 @@ class Compose(BaseCompose):
         p (float): probability of applying all list of transforms. Default: 1.0.
     """
 
-    def __init__(self, transforms, bbox_params=None, keypoint_params=None, additional_targets=None, p=1.0):
+    def __init__(
+        self,
+        transforms,
+        bbox_params=None,
+        keypoint_params=None,
+        additional_targets=None,
+        p=1.0,
+    ):
         super(Compose, self).__init__([t for t in transforms if t is not None], p)
 
         self.processors = {}
@@ -173,7 +183,6 @@ class Compose(BaseCompose):
     def __call__(self, *args, force_apply=False, **data):
         if args:
             raise KeyError("You have to pass data to augmentations as named arguments, for example: aug(image=image)")
-        self._check_args(**data)
         assert isinstance(force_apply, (bool, int)), "force_apply must have bool or int type"
         need_to_run = force_apply or random.random() < self.p
         for p in self.processors.values():
@@ -311,7 +320,10 @@ class SomeOf(BaseCompose):
         if self.transforms_ps and (force_apply or random.random() < self.p):
             random_state = np.random.RandomState(random.randint(0, 2 ** 32 - 1))
             transforms = random_state.choice(
-                self.transforms.transforms, size=self.n, replace=self.replace, p=self.transforms_ps
+                self.transforms.transforms,
+                size=self.n,
+                replace=self.replace,
+                p=self.transforms_ps,
             )
             for t in transforms:
                 data = t(force_apply=True, **data)
@@ -380,7 +392,13 @@ class PerChannel(BaseCompose):
 
 class ReplayCompose(Compose):
     def __init__(
-        self, transforms, bbox_params=None, keypoint_params=None, additional_targets=None, p=1.0, save_key="replay"
+        self,
+        transforms,
+        bbox_params=None,
+        keypoint_params=None,
+        additional_targets=None,
+        p=1.0,
+        save_key="replay",
     ):
         super(ReplayCompose, self).__init__(transforms, bbox_params, keypoint_params, additional_targets, p)
         self.set_deterministic(True, save_key=save_key)
@@ -481,7 +499,14 @@ class BboxParams(Params):
             Default: `True`
     """
 
-    def __init__(self, format, label_fields=None, min_area=0.0, min_visibility=0.0, check_each_transform=True):
+    def __init__(
+        self,
+        format,
+        label_fields=None,
+        min_area=0.0,
+        min_visibility=0.0,
+        check_each_transform=True,
+    ):
         super(BboxParams, self).__init__(format, label_fields)
         self.min_area = min_area
         self.min_visibility = min_visibility

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -243,6 +243,7 @@ class Compose(BaseCompose):
     def _check_args(self, **kwargs):
         checked_single = ["image", "mask"]
         checked_multi = ["masks"]
+        check_bbox_param = ["bboxes"]
         # ["bboxes", "keypoints"] could be almost any type, no need to check them
         for data_name, data in kwargs.items():
             internal_data_name = self.additional_targets.get(data_name, data_name)
@@ -253,6 +254,8 @@ class Compose(BaseCompose):
                 if data:
                     if not isinstance(data[0], np.ndarray):
                         raise TypeError("{} must be list of numpy arrays".format(data_name))
+            if internal_data_name in check_bbox_param and self.processors.get("bboxes") is None:
+                raise Exception("bbox_params must be specified for bbox transformations")
 
 
 class OneOf(BaseCompose):

--- a/albumentations/imgaug/transforms.py
+++ b/albumentations/imgaug/transforms.py
@@ -12,9 +12,20 @@ except ImportError:
     import imgaug.imgaug.augmenters as iaa
 
 from ..augmentations import Emboss, Perspective, Sharpen
-from ..augmentations.bbox_utils import convert_bboxes_from_albumentations, convert_bboxes_to_albumentations
-from ..augmentations.keypoints_utils import convert_keypoints_from_albumentations, convert_keypoints_to_albumentations
-from ..core.transforms_interface import BasicTransform, DualTransform, ImageOnlyTransform, to_tuple
+from ..augmentations.bbox_utils import (
+    convert_bboxes_from_albumentations,
+    convert_bboxes_to_albumentations,
+)
+from ..augmentations.keypoints_utils import (
+    convert_keypoints_from_albumentations,
+    convert_keypoints_to_albumentations,
+)
+from ..core.transforms_interface import (
+    BasicTransform,
+    DualTransform,
+    ImageOnlyTransform,
+    to_tuple,
+)
 
 import warnings
 
@@ -96,7 +107,14 @@ class IAACropAndPad(DualIAATransform):
     """This augmentation is deprecated. Please use CropAndPad instead."""
 
     def __init__(
-        self, px=None, percent=None, pad_mode="constant", pad_cval=0, keep_size=True, always_apply=False, p=1
+        self,
+        px=None,
+        percent=None,
+        pad_mode="constant",
+        pad_cval=0,
+        keep_size=True,
+        always_apply=False,
+        p=1,
     ):
         super(IAACropAndPad, self).__init__(always_apply, p)
         self.px = px
@@ -192,7 +210,10 @@ class IAASuperpixels(ImageOnlyIAATransform):
         super(IAASuperpixels, self).__init__(always_apply, p)
         self.p_replace = p_replace
         self.n_segments = n_segments
-        warnings.warn("IAASuperpixels is deprecated. Please use Superpixels instead.", FutureWarning)
+        warnings.warn(
+            "IAASuperpixels is deprecated. Please use Superpixels instead.",
+            FutureWarning,
+        )
 
     @property
     def processor(self):
@@ -244,12 +265,22 @@ class IAAAdditiveGaussianNoise(ImageOnlyIAATransform):
         image
     """
 
-    def __init__(self, loc=0, scale=(0.01 * 255, 0.05 * 255), per_channel=False, always_apply=False, p=0.5):
+    def __init__(
+        self,
+        loc=0,
+        scale=(0.01 * 255, 0.05 * 255),
+        per_channel=False,
+        always_apply=False,
+        p=0.5,
+    ):
         super(IAAAdditiveGaussianNoise, self).__init__(always_apply, p)
         self.loc = loc
         self.scale = to_tuple(scale, 0.0)
         self.per_channel = per_channel
-        warnings.warn("IAAAdditiveGaussianNoise is deprecated. Please use GaussNoise instead", FutureWarning)
+        warnings.warn(
+            "IAAAdditiveGaussianNoise is deprecated. Please use GaussNoise instead",
+            FutureWarning,
+        )
 
     @property
     def processor(self):
@@ -278,7 +309,15 @@ class IAAPiecewiseAffine(DualIAATransform):
     """
 
     def __init__(
-        self, scale=(0.03, 0.05), nb_rows=4, nb_cols=4, order=1, cval=0, mode="constant", always_apply=False, p=0.5
+        self,
+        scale=(0.03, 0.05),
+        nb_rows=4,
+        nb_cols=4,
+        order=1,
+        cval=0,
+        mode="constant",
+        always_apply=False,
+        p=0.5,
     ):
         super(IAAPiecewiseAffine, self).__init__(always_apply, p)
         self.scale = to_tuple(scale, 0.0)
@@ -287,7 +326,10 @@ class IAAPiecewiseAffine(DualIAATransform):
         self.order = order
         self.cval = cval
         self.mode = mode
-        warnings.warn("This IAAPiecewiseAffine is deprecated. Please use PiecewiseAffine instead", FutureWarning)
+        warnings.warn(
+            "This IAAPiecewiseAffine is deprecated. Please use PiecewiseAffine instead",
+            FutureWarning,
+        )
 
     @property
     def processor(self):
@@ -350,7 +392,16 @@ class IAAAffine(DualIAATransform):
         )
 
     def get_transform_init_args_names(self):
-        return ("scale", "translate_percent", "translate_px", "rotate", "shear", "order", "cval", "mode")
+        return (
+            "scale",
+            "translate_percent",
+            "translate_px",
+            "rotate",
+            "shear",
+            "order",
+            "cval",
+            "mode",
+        )
 
 
 class IAAPerspective(Perspective):
@@ -372,7 +423,10 @@ class IAAPerspective(Perspective):
         super(IAAPerspective, self).__init__(always_apply, p)
         self.scale = to_tuple(scale, 1.0)
         self.keep_size = keep_size
-        warnings.warn("This IAAPerspective is deprecated. Please use Perspective instead", FutureWarning)
+        warnings.warn(
+            "This IAAPerspective is deprecated. Please use Perspective instead",
+            FutureWarning,
+        )
 
     @property
     def processor(self):

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -27,7 +27,11 @@ import solt.utils as slu
 
 import albumentations.augmentations.functional as albumentations
 import albumentations as A
-from albumentations.augmentations.geometric.functional import rotate, resize, shift_scale_rotate
+from albumentations.augmentations.geometric.functional import (
+    rotate,
+    resize,
+    shift_scale_rotate,
+)
 from albumentations.augmentations.crops.functional import random_crop
 
 cv2.setNumThreads(0)  # noqa E402
@@ -40,28 +44,66 @@ os.environ["VECLIB_MAXIMUM_THREADS"] = "1"  # noqa E402
 os.environ["NUMEXPR_NUM_THREADS"] = "1"  # noqa E402
 
 
-DEFAULT_BENCHMARKING_LIBRARIES = ["albumentations", "imgaug", "torchvision", "keras", "augmentor", "solt"]
+DEFAULT_BENCHMARKING_LIBRARIES = [
+    "albumentations",
+    "imgaug",
+    "torchvision",
+    "keras",
+    "augmentor",
+    "solt",
+]
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Augmentation libraries performance benchmark")
     parser.add_argument(
-        "-d", "--data-dir", metavar="DIR", default=os.environ.get("DATA_DIR"), help="path to a directory with images"
+        "-d",
+        "--data-dir",
+        metavar="DIR",
+        default=os.environ.get("DATA_DIR"),
+        help="path to a directory with images",
     )
     parser.add_argument(
-        "-i", "--images", default=2000, type=int, metavar="N", help="number of images for benchmarking (default: 2000)"
+        "-i",
+        "--images",
+        default=2000,
+        type=int,
+        metavar="N",
+        help="number of images for benchmarking (default: 2000)",
     )
     parser.add_argument(
-        "-l", "--libraries", default=DEFAULT_BENCHMARKING_LIBRARIES, nargs="+", help="list of libraries to benchmark"
+        "-l",
+        "--libraries",
+        default=DEFAULT_BENCHMARKING_LIBRARIES,
+        nargs="+",
+        help="list of libraries to benchmark",
     )
     parser.add_argument(
-        "-r", "--runs", default=5, type=int, metavar="N", help="number of runs for each benchmark (default: 5)"
+        "-r",
+        "--runs",
+        default=5,
+        type=int,
+        metavar="N",
+        help="number of runs for each benchmark (default: 5)",
     )
     parser.add_argument(
-        "--show-std", dest="show_std", action="store_true", help="show standard deviation for benchmark runs"
+        "--show-std",
+        dest="show_std",
+        action="store_true",
+        help="show standard deviation for benchmark runs",
     )
-    parser.add_argument("-p", "--print-package-versions", action="store_true", help="print versions of packages")
-    parser.add_argument("-m", "--markdown", action="store_true", help="print benchmarking results as a markdown table")
+    parser.add_argument(
+        "-p",
+        "--print-package-versions",
+        action="store_true",
+        help="print versions of packages",
+    )
+    parser.add_argument(
+        "-m",
+        "--markdown",
+        action="store_true",
+        help="print benchmarking results as a markdown table",
+    )
     return parser.parse_args()
 
 
@@ -128,9 +170,19 @@ class MarkdownGenerator:
         return value_matrix
 
     def _make_versions_text(self):
-        libraries = ["Python", "numpy", "pillow-simd", "opencv-python", "scikit-image", "scipy"]
+        libraries = [
+            "Python",
+            "numpy",
+            "pillow-simd",
+            "opencv-python",
+            "scikit-image",
+            "scipy",
+        ]
         libraries_with_versions = [
-            "{library} {version}".format(library=library, version=self._package_versions[library].replace("\n", ""))
+            "{library} {version}".format(
+                library=library,
+                version=self._package_versions[library].replace("\n", ""),
+            )
             for library in libraries
         ]
         return "Python and library versions: {}.".format(", ".join(libraries_with_versions))
@@ -291,7 +343,10 @@ class Contrast(BenchmarkTest):
 class BrightnessContrast(BenchmarkTest):
     def __init__(self):
         self.imgaug_transform = iaa.Sequential(
-            [iaa.Multiply((1.5, 1.5), per_channel=False), iaa.Add((127, 127), per_channel=False)]
+            [
+                iaa.Multiply((1.5, 1.5), per_channel=False),
+                iaa.Add((127, 127), per_channel=False),
+            ]
         )
         self.augmentor_pipeline = Pipeline()
         self.augmentor_pipeline.add_operation(
@@ -299,7 +354,10 @@ class BrightnessContrast(BenchmarkTest):
         )
         self.augmentor_pipeline.add_operation(Operations.RandomContrast(probability=1, min_factor=1.5, max_factor=1.5))
         self.solt_stream = slc.Stream(
-            [slt.Brightness(p=1, brightness_range=(127, 127)), slt.Contrast(p=1, contrast_range=(1.5, 1.5))]
+            [
+                slt.Brightness(p=1, brightness_range=(127, 127)),
+                slt.Contrast(p=1, contrast_range=(1.5, 1.5)),
+            ]
         )
 
     def albumentations(self, img):
@@ -319,7 +377,11 @@ class BrightnessContrast(BenchmarkTest):
 class ShiftScaleRotate(BenchmarkTest):
     def __init__(self):
         self.imgaug_transform = iaa.Affine(
-            scale=(2, 2), rotate=(45, 45), translate_px=(50, 50), order=1, mode="reflect"
+            scale=(2, 2),
+            rotate=(45, 45),
+            translate_px=(50, 50),
+            order=1,
+            mode="reflect",
         )
 
     def albumentations(self, img):
@@ -401,9 +463,17 @@ class RandomSizedCrop_64_512(BenchmarkTest):
             Operations.Resize(probability=1, width=512, height=512, resample_filter="BILINEAR")
         )
         self.imgaug_transform = iaa.Sequential(
-            [iaa.CropToFixedSize(width=64, height=64), iaa.Scale(size=512, interpolation="linear")]
+            [
+                iaa.CropToFixedSize(width=64, height=64),
+                iaa.Scale(size=512, interpolation="linear"),
+            ]
         )
-        self.solt_stream = slc.Stream([slt.Crop(crop_to=(64, 64), crop_mode="r"), slt.Resize(resize_to=(512, 512))])
+        self.solt_stream = slc.Stream(
+            [
+                slt.Crop(crop_to=(64, 64), crop_mode="r"),
+                slt.Resize(resize_to=(512, 512)),
+            ]
+        )
 
     def albumentations(self, img):
         img = random_crop(img, crop_height=64, crop_width=64, h_start=0, w_start=0)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,11 @@ class Mock(MagicMock):
         return MagicMock()
 
 
-MOCK_MODULES = ["pytorch", "torchvision.transforms", "torchvision.transforms.functional"]
+MOCK_MODULES = [
+    "pytorch",
+    "torchvision.transforms",
+    "torchvision.transforms.functional",
+]
 for module_name in MOCK_MODULES:
     sys.modules[module_name] = Mock()
 
@@ -39,7 +43,12 @@ def get_version():
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode", "sphinx.ext.mathjax", "sphinx.ext.napoleon"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -135,7 +144,15 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
-latex_documents = [(master_doc, "albumentations.tex", "albumentations Documentation", authors, "manual")]
+latex_documents = [
+    (
+        master_doc,
+        "albumentations.tex",
+        "albumentations Documentation",
+        authors,
+        "manual",
+    )
+]
 
 
 # -- Options for manual page output ---------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,22 @@ from setuptools import setup, find_packages
 from pkg_resources import DistributionNotFound, get_distribution
 
 
-INSTALL_REQUIRES = ["numpy>=1.11.1", "scipy", "scikit-image>=0.16.1", "PyYAML", "qudida>=0.0.4"]
+INSTALL_REQUIRES = [
+    "numpy>=1.11.1",
+    "scipy",
+    "scikit-image>=0.16.1",
+    "PyYAML",
+    "qudida>=0.0.4",
+]
 
 # If none of packages in first installed, install second package
 CHOOSE_INSTALL_REQUIRES = [
     (
-        ("opencv-python>=4.1.1", "opencv-contrib-python>=4.1.1", "opencv-contrib-python-headless>=4.1.1"),
+        (
+            "opencv-python>=4.1.1",
+            "opencv-contrib-python>=4.1.1",
+            "opencv-contrib-python-headless>=4.1.1",
+        ),
         "opencv-python-headless>=4.1.1",
     )
 ]
@@ -66,7 +76,11 @@ setup(
     packages=find_packages(exclude=["tests"]),
     python_requires=">=3.6",
     install_requires=get_install_requirements(INSTALL_REQUIRES, CHOOSE_INSTALL_REQUIRES),
-    extras_require={"tests": ["pytest"], "imgaug": ["imgaug>=0.4.0"], "develop": ["pytest", "imgaug>=0.4.0"]},
+    extras_require={
+        "tests": ["pytest"],
+        "imgaug": ["imgaug>=0.4.0"],
+        "develop": ["pytest", "imgaug>=0.4.0"],
+    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: MIT License",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,8 @@ skipif_no_imgaug = pytest.mark.skipif(
     not imgaug_available, reason="The test was skipped because imgaug is not installed"
 )
 skipif_no_torch = pytest.mark.skipif(
-    not torch_available, reason="The test was skipped because PyTorch and torchvision are not installed"
+    not torch_available,
+    reason="The test was skipped because PyTorch and torchvision are not installed",
 )
 
 

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -333,14 +333,35 @@ def test_image_only_crop_around_bbox_augmentation(augmentation_cls, params, imag
     [
         [
             A.PadIfNeeded,
-            {"min_height": 514, "min_width": 514, "border_mode": cv2.BORDER_CONSTANT, "value": 100, "mask_value": 1},
+            {
+                "min_height": 514,
+                "min_width": 514,
+                "border_mode": cv2.BORDER_CONSTANT,
+                "value": 100,
+                "mask_value": 1,
+            },
         ],
         [A.Rotate, {"border_mode": cv2.BORDER_CONSTANT, "value": 100, "mask_value": 1}],
-        [A.SafeRotate, {"border_mode": cv2.BORDER_CONSTANT, "value": 100, "mask_value": 1}],
-        [A.ShiftScaleRotate, {"border_mode": cv2.BORDER_CONSTANT, "value": 100, "mask_value": 1}],
-        [A.OpticalDistortion, {"border_mode": cv2.BORDER_CONSTANT, "value": 100, "mask_value": 1}],
-        [A.ElasticTransform, {"border_mode": cv2.BORDER_CONSTANT, "value": 100, "mask_value": 1}],
-        [A.GridDistortion, {"border_mode": cv2.BORDER_CONSTANT, "value": 100, "mask_value": 1}],
+        [
+            A.SafeRotate,
+            {"border_mode": cv2.BORDER_CONSTANT, "value": 100, "mask_value": 1},
+        ],
+        [
+            A.ShiftScaleRotate,
+            {"border_mode": cv2.BORDER_CONSTANT, "value": 100, "mask_value": 1},
+        ],
+        [
+            A.OpticalDistortion,
+            {"border_mode": cv2.BORDER_CONSTANT, "value": 100, "mask_value": 1},
+        ],
+        [
+            A.ElasticTransform,
+            {"border_mode": cv2.BORDER_CONSTANT, "value": 100, "mask_value": 1},
+        ],
+        [
+            A.GridDistortion,
+            {"border_mode": cv2.BORDER_CONSTANT, "value": 100, "mask_value": 1},
+        ],
         [A.Affine, {"mode": cv2.BORDER_CONSTANT, "cval_mask": 1, "cval": 100}],
         [A.PiecewiseAffine, {"mode": "constant", "cval_mask": 1, "cval": 100}],
     ],
@@ -348,7 +369,10 @@ def test_image_only_crop_around_bbox_augmentation(augmentation_cls, params, imag
 def test_mask_fill_value(augmentation_cls, params):
     random.seed(42)
     aug = augmentation_cls(p=1, **params)
-    input = {"image": np.zeros((512, 512), dtype=np.uint8) + 100, "mask": np.ones((512, 512))}
+    input = {
+        "image": np.zeros((512, 512), dtype=np.uint8) + 100,
+        "mask": np.ones((512, 512)),
+    }
     output = aug(**input)
     assert (output["image"] == 100).all()
     assert (output["mask"] == 1).all()
@@ -574,31 +598,64 @@ def test_float_multichannel_image_augmentations_diff_channels(augmentation_cls, 
         [A.PadIfNeeded, {"min_height": 514, "min_width": 516}, (600, 600)],
         [
             A.PadIfNeeded,
-            {"min_height": None, "min_width": None, "pad_height_divisor": 128, "pad_width_divisor": 128},
+            {
+                "min_height": None,
+                "min_width": None,
+                "pad_height_divisor": 128,
+                "pad_width_divisor": 128,
+            },
             (300, 200),
         ],
         [
             A.PadIfNeeded,
-            {"min_height": None, "min_width": None, "pad_height_divisor": 72, "pad_width_divisor": 128},
+            {
+                "min_height": None,
+                "min_width": None,
+                "pad_height_divisor": 72,
+                "pad_width_divisor": 128,
+            },
             (72, 128),
         ],
         [
             A.PadIfNeeded,
-            {"min_height": None, "min_width": None, "pad_height_divisor": 72, "pad_width_divisor": 128},
+            {
+                "min_height": None,
+                "min_width": None,
+                "pad_height_divisor": 72,
+                "pad_width_divisor": 128,
+            },
             (15, 15),
         ],
         [
             A.PadIfNeeded,
-            {"min_height": None, "min_width": None, "pad_height_divisor": 72, "pad_width_divisor": 128},
+            {
+                "min_height": None,
+                "min_width": None,
+                "pad_height_divisor": 72,
+                "pad_width_divisor": 128,
+            },
             (144, 256),
         ],
         [
             A.PadIfNeeded,
-            {"min_height": None, "min_width": None, "pad_height_divisor": 72, "pad_width_divisor": 128},
+            {
+                "min_height": None,
+                "min_width": None,
+                "pad_height_divisor": 72,
+                "pad_width_divisor": 128,
+            },
             (200, 300),
         ],
-        [A.PadIfNeeded, {"min_height": 512, "min_width": None, "pad_width_divisor": 128}, (300, 200)],
-        [A.PadIfNeeded, {"min_height": None, "min_width": 512, "pad_height_divisor": 128}, (300, 200)],
+        [
+            A.PadIfNeeded,
+            {"min_height": 512, "min_width": None, "pad_width_divisor": 128},
+            (300, 200),
+        ],
+        [
+            A.PadIfNeeded,
+            {"min_height": None, "min_width": 512, "pad_height_divisor": 128},
+            (300, 200),
+        ],
     ],
 )
 def test_pad_if_needed(augmentation_cls: Type[A.PadIfNeeded], params: Dict, image_shape: Tuple[int, int]):
@@ -627,11 +684,56 @@ def test_pad_if_needed(augmentation_cls: Type[A.PadIfNeeded], params: Dict, imag
 @pytest.mark.parametrize(
     ["params", "image_shape"],
     [
-        [{"min_height": 10, "min_width": 12, "border_mode": 0, "value": 1, "position": "center"}, (5, 6)],
-        [{"min_height": 10, "min_width": 12, "border_mode": 0, "value": 1, "position": "top_left"}, (5, 6)],
-        [{"min_height": 10, "min_width": 12, "border_mode": 0, "value": 1, "position": "top_right"}, (5, 6)],
-        [{"min_height": 10, "min_width": 12, "border_mode": 0, "value": 1, "position": "bottom_left"}, (5, 6)],
-        [{"min_height": 10, "min_width": 12, "border_mode": 0, "value": 1, "position": "bottom_right"}, (5, 6)],
+        [
+            {
+                "min_height": 10,
+                "min_width": 12,
+                "border_mode": 0,
+                "value": 1,
+                "position": "center",
+            },
+            (5, 6),
+        ],
+        [
+            {
+                "min_height": 10,
+                "min_width": 12,
+                "border_mode": 0,
+                "value": 1,
+                "position": "top_left",
+            },
+            (5, 6),
+        ],
+        [
+            {
+                "min_height": 10,
+                "min_width": 12,
+                "border_mode": 0,
+                "value": 1,
+                "position": "top_right",
+            },
+            (5, 6),
+        ],
+        [
+            {
+                "min_height": 10,
+                "min_width": 12,
+                "border_mode": 0,
+                "value": 1,
+                "position": "bottom_left",
+            },
+            (5, 6),
+        ],
+        [
+            {
+                "min_height": 10,
+                "min_width": 12,
+                "border_mode": 0,
+                "value": 1,
+                "position": "bottom_right",
+            },
+            (5, 6),
+        ],
     ],
 )
 def test_pad_if_needed_position(params, image_shape):
@@ -639,7 +741,12 @@ def test_pad_if_needed_position(params, image_shape):
     pad = A.PadIfNeeded(**params)
     image_padded = pad(image=image)["image"]
 
-    true_result = np.ones((max(image_shape[0], params["min_height"]), max(image_shape[1], params["min_width"])))
+    true_result = np.ones(
+        (
+            max(image_shape[0], params["min_height"]),
+            max(image_shape[1], params["min_width"]),
+        )
+    )
 
     if params["position"] == "center":
         x_start = image_shape[0] // 2
@@ -720,7 +827,8 @@ def test_perspective_valid_keypoints_after_transform(seed: int, scale: float, h:
     ]
 
     transform = A.Compose(
-        [A.Perspective(scale=(scale, scale), p=1)], keypoint_params={"format": "xy", "remove_invisible": False}
+        [A.Perspective(scale=(scale, scale), p=1)],
+        keypoint_params={"format": "xy", "remove_invisible": False},
     )
 
     res = transform(image=image, keypoints=keypoints)["keypoints"]

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -18,7 +18,10 @@ from albumentations import RandomSizedCrop, RandomResizedCrop, Rotate, RandomCro
 
 @pytest.mark.parametrize(
     ["bbox", "expected"],
-    [((15, 25, 100, 200), (0.0375, 0.125, 0.25, 1.0)), ((15, 25, 100, 200, 99), (0.0375, 0.125, 0.25, 1.0, 99))],
+    [
+        ((15, 25, 100, 200), (0.0375, 0.125, 0.25, 1.0)),
+        ((15, 25, 100, 200, 99), (0.0375, 0.125, 0.25, 1.0, 99)),
+    ],
 )
 def test_normalize_bbox(bbox, expected):
     normalized_bbox = normalize_bbox(bbox, 200, 400)
@@ -27,7 +30,10 @@ def test_normalize_bbox(bbox, expected):
 
 @pytest.mark.parametrize(
     ["bbox", "expected"],
-    [((0.0375, 0.125, 0.25, 1.0), (15, 25, 100, 200)), ((0.0375, 0.125, 0.25, 1.0, 99), (15, 25, 100, 200, 99))],
+    [
+        ((0.0375, 0.125, 0.25, 1.0), (15, 25, 100, 200)),
+        ((0.0375, 0.125, 0.25, 1.0, 99), (15, 25, 100, 200, 99)),
+    ],
 )
 def test_denormalize_bbox(bbox, expected):
     denormalized_bbox = denormalize_bbox(bbox, 200, 400)
@@ -51,19 +57,26 @@ def test_denormalize_normalize_bbox(bbox):
 def test_normalize_bboxes():
     bboxes = [(15, 25, 100, 200), (15, 25, 100, 200, 99)]
     normalized_bboxes_1 = normalize_bboxes(bboxes, 200, 400)
-    normalized_bboxes_2 = [normalize_bbox(bboxes[0], 200, 400), normalize_bbox(bboxes[1], 200, 400)]
+    normalized_bboxes_2 = [
+        normalize_bbox(bboxes[0], 200, 400),
+        normalize_bbox(bboxes[1], 200, 400),
+    ]
     assert normalized_bboxes_1 == normalized_bboxes_2
 
 
 def test_denormalize_bboxes():
     bboxes = [(0.0375, 0.125, 0.25, 1.0), (0.0375, 0.125, 0.25, 1.0, 99)]
     denormalized_bboxes_1 = denormalize_bboxes(bboxes, 200, 400)
-    denormalized_bboxes_2 = [denormalize_bbox(bboxes[0], 200, 400), denormalize_bbox(bboxes[1], 200, 400)]
+    denormalized_bboxes_2 = [
+        denormalize_bbox(bboxes[0], 200, 400),
+        denormalize_bbox(bboxes[1], 200, 400),
+    ]
     assert denormalized_bboxes_1 == denormalized_bboxes_2
 
 
 @pytest.mark.parametrize(
-    ["bbox", "rows", "cols", "expected"], [((0, 0, 1, 1), 50, 100, 5000), ((0.2, 0.2, 1, 1, 99), 50, 50, 1600)]
+    ["bbox", "rows", "cols", "expected"],
+    [((0, 0, 1, 1), 50, 100, 5000), ((0.2, 0.2, 1, 1, 99), 50, 50, 1600)],
 )
 def test_calculate_bbox_area(bbox, rows, cols, expected):
     area = calculate_bbox_area(bbox, rows, cols)
@@ -80,8 +93,16 @@ def test_calculate_bbox_area(bbox, rows, cols, expected):
         ((0.2, 0.3, 0.4, 0.5), "yolo", (0.00, 0.05, 0.40, 0.55)),
         ((0.2, 0.3, 0.4, 0.5, 99), "yolo", (0.00, 0.05, 0.40, 0.55, 99)),
         ((0.1, 0.1, 0.2, 0.2), "yolo", (0.0, 0.0, 0.2, 0.2)),
-        ((0.99662423, 0.7520255, 0.00675154, 0.01446759), "yolo", (0.99324846, 0.744791705, 1.0, 0.759259295)),
-        ((0.9375, 0.510416, 0.1234375, 0.97638), "yolo", (0.87578125, 0.022226, 0.999218749, 0.998606)),
+        (
+            (0.99662423, 0.7520255, 0.00675154, 0.01446759),
+            "yolo",
+            (0.99324846, 0.744791705, 1.0, 0.759259295),
+        ),
+        (
+            (0.9375, 0.510416, 0.1234375, 0.97638),
+            "yolo",
+            (0.87578125, 0.022226, 0.999218749, 0.998606),
+        ),
     ],
 )
 def test_convert_bbox_to_albumentations(bbox, source_format, expected):
@@ -138,7 +159,10 @@ def test_convert_bbox_to_albumentations_and_back(bbox, bbox_format):
         bbox, rows=image.shape[0], cols=image.shape[1], source_format=bbox_format
     )
     converted_back_bbox = convert_bbox_from_albumentations(
-        converted_bbox, rows=image.shape[0], cols=image.shape[1], target_format=bbox_format
+        converted_bbox,
+        rows=image.shape[0],
+        cols=image.shape[1],
+        target_format=bbox_format,
     )
     assert np.all(np.isclose(converted_back_bbox, bbox))
 
@@ -187,7 +211,10 @@ def test_convert_bboxes_from_albumentations():
 def test_compose_with_bbox_noop(bboxes, bbox_format, labels):
     image = np.ones((100, 100, 3))
     if labels is not None:
-        aug = Compose([NoOp(p=1.0)], bbox_params={"format": bbox_format, "label_fields": ["labels"]})
+        aug = Compose(
+            [NoOp(p=1.0)],
+            bbox_params={"format": bbox_format, "label_fields": ["labels"]},
+        )
         transformed = aug(image=image, bboxes=bboxes, labels=labels)
     else:
         aug = Compose([NoOp(p=1.0)], bbox_params={"format": bbox_format})
@@ -212,14 +239,25 @@ def test_compose_with_bbox_noop_error_label_fields(bboxes, bbox_format):
         [[], "pascal_voc", {"label": []}],
         [[(20, 30, 60, 80)], "pascal_voc", {"id": [3]}],
         [[(20, 30, 60, 80), (30, 40, 40, 50)], "pascal_voc", {"id": [3, 1]}],
-        [[(20, 30, 60, 80, 1, 11), (30, 40, 40, 50, 2, 22)], "pascal_voc", {"id": [3, 1]}],
+        [
+            [(20, 30, 60, 80, 1, 11), (30, 40, 40, 50, 2, 22)],
+            "pascal_voc",
+            {"id": [3, 1]},
+        ],
         [[(20, 30, 60, 80, 1, 11), (30, 40, 40, 50, 2, 22)], "pascal_voc", {}],
-        [[(20, 30, 60, 80, 1, 11), (30, 40, 40, 50, 2, 21)], "pascal_voc", {"id": [31, 32], "subclass": [311, 321]}],
+        [
+            [(20, 30, 60, 80, 1, 11), (30, 40, 40, 50, 2, 21)],
+            "pascal_voc",
+            {"id": [31, 32], "subclass": [311, 321]},
+        ],
     ],
 )
 def test_compose_with_bbox_noop_label_outside(bboxes, bbox_format, labels):
     image = np.ones((100, 100, 3))
-    aug = Compose([NoOp(p=1.0)], bbox_params={"format": bbox_format, "label_fields": list(labels.keys())})
+    aug = Compose(
+        [NoOp(p=1.0)],
+        bbox_params={"format": bbox_format, "label_fields": list(labels.keys())},
+    )
     transformed = aug(image=image, bboxes=bboxes, **labels)
     assert np.array_equal(transformed["image"], image)
     assert transformed["bboxes"] == bboxes

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,11 @@ import cv2
 import numpy as np
 import pytest
 
-from albumentations.core.transforms_interface import to_tuple, ImageOnlyTransform, DualTransform
+from albumentations.core.transforms_interface import (
+    to_tuple,
+    ImageOnlyTransform,
+    DualTransform,
+)
 from albumentations.augmentations.bbox_utils import check_bboxes
 from albumentations.core.composition import (
     OneOrOther,
@@ -101,7 +105,11 @@ def test_to_tuple():
 def test_image_only_transform(image, mask):
     height, width = image.shape[:2]
     with mock.patch.object(ImageOnlyTransform, "apply") as mocked_apply:
-        with mock.patch.object(ImageOnlyTransform, "get_params", return_value={"interpolation": cv2.INTER_LINEAR}):
+        with mock.patch.object(
+            ImageOnlyTransform,
+            "get_params",
+            return_value={"interpolation": cv2.INTER_LINEAR},
+        ):
             aug = ImageOnlyTransform(p=1)
             data = aug(image=image, mask=mask)
             mocked_apply.assert_called_once_with(image, interpolation=cv2.INTER_LINEAR, cols=width, rows=height)
@@ -112,7 +120,11 @@ def test_dual_transform(image, mask):
     image_call = call(image, interpolation=cv2.INTER_LINEAR, cols=image.shape[1], rows=image.shape[0])
     mask_call = call(mask, interpolation=cv2.INTER_NEAREST, cols=mask.shape[1], rows=mask.shape[0])
     with mock.patch.object(DualTransform, "apply") as mocked_apply:
-        with mock.patch.object(DualTransform, "get_params", return_value={"interpolation": cv2.INTER_LINEAR}):
+        with mock.patch.object(
+            DualTransform,
+            "get_params",
+            return_value={"interpolation": cv2.INTER_LINEAR},
+        ):
             aug = DualTransform(p=1)
             aug(image=image, mask=mask)
             mocked_apply.assert_has_calls([image_call, mask_call], any_order=True)
@@ -122,7 +134,11 @@ def test_additional_targets(image, mask):
     image_call = call(image, interpolation=cv2.INTER_LINEAR, cols=image.shape[1], rows=image.shape[0])
     image2_call = call(mask, interpolation=cv2.INTER_LINEAR, cols=mask.shape[1], rows=mask.shape[0])
     with mock.patch.object(DualTransform, "apply") as mocked_apply:
-        with mock.patch.object(DualTransform, "get_params", return_value={"interpolation": cv2.INTER_LINEAR}):
+        with mock.patch.object(
+            DualTransform,
+            "get_params",
+            return_value={"interpolation": cv2.INTER_LINEAR},
+        ):
             aug = DualTransform(p=1)
             aug.add_targets({"image2": "image"})
             aug(image=image, image2=mask)
@@ -221,7 +237,11 @@ def test_named_args():
     ["targets", "additional_targets", "err_message"],
     [
         [{"image": None}, None, "image must be numpy array type"],
-        [{"image": np.empty([100, 100, 3], np.uint8), "mask": None}, None, "mask must be numpy array type"],
+        [
+            {"image": np.empty([100, 100, 3], np.uint8), "mask": None},
+            None,
+            "mask must be numpy array type",
+        ],
         [
             {"image": np.empty([100, 100, 3], np.uint8), "image1": None},
             {"image1": "image"},
@@ -276,7 +296,10 @@ def test_targets_type_check(targets, additional_targets, err_message):
             },
             BboxParams("pascal_voc", check_each_transform=True),
             KeypointParams("xy", check_each_transform=True),
-            {"bboxes": [[25, 25, 35, 35, 0], [30, 30, 75, 75, 0]], "keypoints": np.array([[10, 10]]) + 25},
+            {
+                "bboxes": [[25, 25, 35, 35, 0], [30, 30, 75, 75, 0]],
+                "keypoints": np.array([[10, 10]]) + 25,
+            },
         ],
         [
             {
@@ -286,7 +309,11 @@ def test_targets_type_check(targets, additional_targets, err_message):
             BboxParams("pascal_voc", check_each_transform=False),
             KeypointParams("xy", check_each_transform=True),
             {
-                "bboxes": [[25, 25, 35, 35, 0], [30, 30, 95, 95, 0], [85, 85, 95, 95, 0]],
+                "bboxes": [
+                    [25, 25, 35, 35, 0],
+                    [30, 30, 95, 95, 0],
+                    [85, 85, 95, 95, 0],
+                ],
                 "keypoints": np.array([[10, 10]]) + 25,
             },
         ],
@@ -310,7 +337,11 @@ def test_targets_type_check(targets, additional_targets, err_message):
             BboxParams("pascal_voc", check_each_transform=False),
             KeypointParams("xy", check_each_transform=False),
             {
-                "bboxes": [[25, 25, 35, 35, 0], [30, 30, 95, 95, 0], [85, 85, 95, 95, 0]],
+                "bboxes": [
+                    [25, 25, 35, 35, 0],
+                    [30, 30, 95, 95, 0],
+                    [85, 85, 95, 95, 0],
+                ],
                 "keypoints": np.array([[10, 10], [70, 70], [10, 70], [70, 10]]) + 25,
             },
         ],
@@ -319,7 +350,9 @@ def test_targets_type_check(targets, additional_targets, err_message):
 def test_check_each_transform(targets, bbox_params, keypoint_params, expected):
     image = np.empty([100, 100], dtype=np.uint8)
     augs = Compose(
-        [Crop(0, 0, 50, 50), PadIfNeeded(100, 100)], bbox_params=bbox_params, keypoint_params=keypoint_params
+        [Crop(0, 0, 50, 50), PadIfNeeded(100, 100)],
+        bbox_params=bbox_params,
+        keypoint_params=keypoint_params,
     )
     res = augs(image=image, **targets)
 

--- a/tests/test_find_dual_start_end.py
+++ b/tests/test_find_dual_start_end.py
@@ -1,4 +1,11 @@
-from albumentations import HorizontalFlip, OneOf, PiecewiseAffine, Affine, OpticalDistortion, GridDistortion
+from albumentations import (
+    HorizontalFlip,
+    OneOf,
+    PiecewiseAffine,
+    Affine,
+    OpticalDistortion,
+    GridDistortion,
+)
 from albumentations.core.composition import Transforms
 import pytest
 
@@ -54,6 +61,9 @@ def empty_aug3():
     ]
 
 
-@pytest.mark.parametrize(["aug", "start_end"], [[empty_aug1, [0, 1]], [empty_aug2, [0, 2]], [empty_aug3, [0, 0]]])
+@pytest.mark.parametrize(
+    ["aug", "start_end"],
+    [[empty_aug1, [0, 1]], [empty_aug2, [0, 2]], [empty_aug3, [0, 0]]],
+)
 def test_strong_aug(aug, start_end):
     assert Transforms(aug()).start_end == start_end

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -49,7 +49,10 @@ def test_hflip_float(target):
 
 
 @pytest.mark.parametrize("target", ["image", "mask"])
-@pytest.mark.parametrize(["code", "func"], [[0, F.vflip], [1, F.hflip], [-1, lambda img: F.vflip(F.hflip(img))]])
+@pytest.mark.parametrize(
+    ["code", "func"],
+    [[0, F.vflip], [1, F.hflip], [-1, lambda img: F.vflip(F.hflip(img))]],
+)
 def test_random_flip(code, func, target):
     img = np.array([[1, 1, 1], [0, 1, 1], [0, 0, 1]], dtype=np.uint8)
     img = convert_2d_to_target_format([img], target=target)
@@ -57,21 +60,30 @@ def test_random_flip(code, func, target):
 
 
 @pytest.mark.parametrize("target", ["image", "image_4_channels"])
-@pytest.mark.parametrize(["code", "func"], [[0, F.vflip], [1, F.hflip], [-1, lambda img: F.vflip(F.hflip(img))]])
+@pytest.mark.parametrize(
+    ["code", "func"],
+    [[0, F.vflip], [1, F.hflip], [-1, lambda img: F.vflip(F.hflip(img))]],
+)
 def test_random_flip_float(code, func, target):
     img = np.array([[0.4, 0.4, 0.4], [0.0, 0.4, 0.4], [0.0, 0.0, 0.4]], dtype=np.float32)
     img = convert_2d_to_target_format([img], target=target)
     assert_array_almost_equal_nulp(F.random_flip(img, code), func(img))
 
 
-@pytest.mark.parametrize(["input_shape", "expected_shape"], [[(128, 64), (64, 128)], [(128, 64, 3), (64, 128, 3)]])
+@pytest.mark.parametrize(
+    ["input_shape", "expected_shape"],
+    [[(128, 64), (64, 128)], [(128, 64, 3), (64, 128, 3)]],
+)
 def test_transpose(input_shape, expected_shape):
     img = np.random.randint(low=0, high=256, size=input_shape, dtype=np.uint8)
     transposed = F.transpose(img)
     assert transposed.shape == expected_shape
 
 
-@pytest.mark.parametrize(["input_shape", "expected_shape"], [[(128, 64), (64, 128)], [(128, 64, 3), (64, 128, 3)]])
+@pytest.mark.parametrize(
+    ["input_shape", "expected_shape"],
+    [[(128, 64), (64, 128)], [(128, 64, 3), (64, 128, 3)]],
+)
 def test_transpose_float(input_shape, expected_shape):
     img = np.random.uniform(low=0.0, high=1.0, size=input_shape).astype("float32")
     transposed = F.transpose(img)
@@ -134,7 +146,13 @@ def test_center_crop(target):
 @pytest.mark.parametrize("target", ["image", "image_4_channels"])
 def test_center_crop_float(target):
     img = np.array(
-        [[0.4, 0.4, 0.4, 0.4], [0.0, 0.4, 0.4, 0.4], [0.0, 0.0, 0.4, 0.4], [0.0, 0.0, 0.0, 0.4]], dtype=np.float32
+        [
+            [0.4, 0.4, 0.4, 0.4],
+            [0.0, 0.4, 0.4, 0.4],
+            [0.0, 0.0, 0.4, 0.4],
+            [0.0, 0.0, 0.0, 0.4],
+        ],
+        dtype=np.float32,
     )
     expected = np.array([[0.4, 0.4], [0.0, 0.4]], dtype=np.float32)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
@@ -161,7 +179,12 @@ def test_random_crop(target):
 @pytest.mark.parametrize("target", ["image", "image_4_channels"])
 def test_random_crop_float(target):
     img = np.array(
-        [[0.01, 0.02, 0.03, 0.04], [0.05, 0.06, 0.07, 0.08], [0.09, 0.10, 0.11, 0.12], [0.13, 0.14, 0.15, 0.16]],
+        [
+            [0.01, 0.02, 0.03, 0.04],
+            [0.05, 0.06, 0.07, 0.08],
+            [0.09, 0.10, 0.11, 0.12],
+            [0.13, 0.14, 0.15, 0.16],
+        ],
         dtype=np.float32,
     )
     expected = np.array([[0.05, 0.06], [0.09, 0.10]], dtype=np.float32)
@@ -204,7 +227,13 @@ def test_pad(target):
 def test_pad_float(target):
     img = np.array([[0.1, 0.2], [0.3, 0.4]], dtype=np.float32)
     expected = np.array(
-        [[0.4, 0.3, 0.4, 0.3], [0.2, 0.1, 0.2, 0.1], [0.4, 0.3, 0.4, 0.3], [0.2, 0.1, 0.2, 0.1]], dtype=np.float32
+        [
+            [0.4, 0.3, 0.4, 0.3],
+            [0.2, 0.1, 0.2, 0.1],
+            [0.4, 0.3, 0.4, 0.3],
+            [0.2, 0.1, 0.2, 0.1],
+        ],
+        dtype=np.float32,
     )
     img, expected = convert_2d_to_target_format([img, expected], target=target)
     padded_img = F.pad(img, min_height=4, min_width=4)
@@ -217,7 +246,13 @@ def test_rotate_from_shift_scale_rotate(target):
     expected = np.array([[0, 0, 0, 0], [4, 8, 12, 16], [3, 7, 11, 15], [2, 6, 10, 14]], dtype=np.uint8)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
     rotated_img = FGeometric.shift_scale_rotate(
-        img, angle=90, scale=1, dx=0, dy=0, interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_CONSTANT
+        img,
+        angle=90,
+        scale=1,
+        dx=0,
+        dy=0,
+        interpolation=cv2.INTER_NEAREST,
+        border_mode=cv2.BORDER_CONSTANT,
     )
     assert np.array_equal(rotated_img, expected)
 
@@ -225,16 +260,32 @@ def test_rotate_from_shift_scale_rotate(target):
 @pytest.mark.parametrize("target", ["image", "image_4_channels"])
 def test_rotate_float_from_shift_scale_rotate(target):
     img = np.array(
-        [[0.01, 0.02, 0.03, 0.04], [0.05, 0.06, 0.07, 0.08], [0.09, 0.10, 0.11, 0.12], [0.13, 0.14, 0.15, 0.16]],
+        [
+            [0.01, 0.02, 0.03, 0.04],
+            [0.05, 0.06, 0.07, 0.08],
+            [0.09, 0.10, 0.11, 0.12],
+            [0.13, 0.14, 0.15, 0.16],
+        ],
         dtype=np.float32,
     )
     expected = np.array(
-        [[0.00, 0.00, 0.00, 0.00], [0.04, 0.08, 0.12, 0.16], [0.03, 0.07, 0.11, 0.15], [0.02, 0.06, 0.10, 0.14]],
+        [
+            [0.00, 0.00, 0.00, 0.00],
+            [0.04, 0.08, 0.12, 0.16],
+            [0.03, 0.07, 0.11, 0.15],
+            [0.02, 0.06, 0.10, 0.14],
+        ],
         dtype=np.float32,
     )
     img, expected = convert_2d_to_target_format([img, expected], target=target)
     rotated_img = FGeometric.shift_scale_rotate(
-        img, angle=90, scale=1, dx=0, dy=0, interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_CONSTANT
+        img,
+        angle=90,
+        scale=1,
+        dx=0,
+        dy=0,
+        interpolation=cv2.INTER_NEAREST,
+        border_mode=cv2.BORDER_CONSTANT,
     )
     assert_array_almost_equal_nulp(rotated_img, expected)
 
@@ -242,10 +293,19 @@ def test_rotate_float_from_shift_scale_rotate(target):
 @pytest.mark.parametrize("target", ["image", "mask"])
 def test_scale_from_shift_scale_rotate(target):
     img = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], dtype=np.uint8)
-    expected = np.array([[6, 7, 7, 8], [10, 11, 11, 12], [10, 11, 11, 12], [14, 15, 15, 16]], dtype=np.uint8)
+    expected = np.array(
+        [[6, 7, 7, 8], [10, 11, 11, 12], [10, 11, 11, 12], [14, 15, 15, 16]],
+        dtype=np.uint8,
+    )
     img, expected = convert_2d_to_target_format([img, expected], target=target)
     scaled_img = FGeometric.shift_scale_rotate(
-        img, angle=0, scale=2, dx=0, dy=0, interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_CONSTANT
+        img,
+        angle=0,
+        scale=2,
+        dx=0,
+        dy=0,
+        interpolation=cv2.INTER_NEAREST,
+        border_mode=cv2.BORDER_CONSTANT,
     )
     assert np.array_equal(scaled_img, expected)
 
@@ -253,16 +313,32 @@ def test_scale_from_shift_scale_rotate(target):
 @pytest.mark.parametrize("target", ["image", "image_4_channels"])
 def test_scale_float_from_shift_scale_rotate(target):
     img = np.array(
-        [[0.01, 0.02, 0.03, 0.04], [0.05, 0.06, 0.07, 0.08], [0.09, 0.10, 0.11, 0.12], [0.13, 0.14, 0.15, 0.16]],
+        [
+            [0.01, 0.02, 0.03, 0.04],
+            [0.05, 0.06, 0.07, 0.08],
+            [0.09, 0.10, 0.11, 0.12],
+            [0.13, 0.14, 0.15, 0.16],
+        ],
         dtype=np.float32,
     )
     expected = np.array(
-        [[0.06, 0.07, 0.07, 0.08], [0.10, 0.11, 0.11, 0.12], [0.10, 0.11, 0.11, 0.12], [0.14, 0.15, 0.15, 0.16]],
+        [
+            [0.06, 0.07, 0.07, 0.08],
+            [0.10, 0.11, 0.11, 0.12],
+            [0.10, 0.11, 0.11, 0.12],
+            [0.14, 0.15, 0.15, 0.16],
+        ],
         dtype=np.float32,
     )
     img, expected = convert_2d_to_target_format([img, expected], target=target)
     scaled_img = FGeometric.shift_scale_rotate(
-        img, angle=0, scale=2, dx=0, dy=0, interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_CONSTANT
+        img,
+        angle=0,
+        scale=2,
+        dx=0,
+        dy=0,
+        interpolation=cv2.INTER_NEAREST,
+        border_mode=cv2.BORDER_CONSTANT,
     )
     assert_array_almost_equal_nulp(scaled_img, expected)
 
@@ -273,7 +349,13 @@ def test_shift_x_from_shift_scale_rotate(target):
     expected = np.array([[0, 0, 1, 2], [0, 0, 5, 6], [0, 0, 9, 10], [0, 0, 13, 14]], dtype=np.uint8)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
     shifted_along_x_img = FGeometric.shift_scale_rotate(
-        img, angle=0, scale=1, dx=0.5, dy=0, interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_CONSTANT
+        img,
+        angle=0,
+        scale=1,
+        dx=0.5,
+        dy=0,
+        interpolation=cv2.INTER_NEAREST,
+        border_mode=cv2.BORDER_CONSTANT,
     )
     assert np.array_equal(shifted_along_x_img, expected)
 
@@ -281,16 +363,32 @@ def test_shift_x_from_shift_scale_rotate(target):
 @pytest.mark.parametrize("target", ["image", "image_4_channels"])
 def test_shift_x_float_from_shift_scale_rotate(target):
     img = np.array(
-        [[0.01, 0.02, 0.03, 0.04], [0.05, 0.06, 0.07, 0.08], [0.09, 0.10, 0.11, 0.12], [0.13, 0.14, 0.15, 0.16]],
+        [
+            [0.01, 0.02, 0.03, 0.04],
+            [0.05, 0.06, 0.07, 0.08],
+            [0.09, 0.10, 0.11, 0.12],
+            [0.13, 0.14, 0.15, 0.16],
+        ],
         dtype=np.float32,
     )
     expected = np.array(
-        [[0.00, 0.00, 0.01, 0.02], [0.00, 0.00, 0.05, 0.06], [0.00, 0.00, 0.09, 0.10], [0.00, 0.00, 0.13, 0.14]],
+        [
+            [0.00, 0.00, 0.01, 0.02],
+            [0.00, 0.00, 0.05, 0.06],
+            [0.00, 0.00, 0.09, 0.10],
+            [0.00, 0.00, 0.13, 0.14],
+        ],
         dtype=np.float32,
     )
     img, expected = convert_2d_to_target_format([img, expected], target=target)
     shifted_along_x_img = FGeometric.shift_scale_rotate(
-        img, angle=0, scale=1, dx=0.5, dy=0, interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_CONSTANT
+        img,
+        angle=0,
+        scale=1,
+        dx=0.5,
+        dy=0,
+        interpolation=cv2.INTER_NEAREST,
+        border_mode=cv2.BORDER_CONSTANT,
     )
     assert_array_almost_equal_nulp(shifted_along_x_img, expected)
 
@@ -301,7 +399,13 @@ def test_shift_y_from_shift_scale_rotate(target):
     expected = np.array([[0, 0, 0, 0], [0, 0, 0, 0], [1, 2, 3, 4], [5, 6, 7, 8]], dtype=np.uint8)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
     shifted_along_y_img = FGeometric.shift_scale_rotate(
-        img, angle=0, scale=1, dx=0, dy=0.5, interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_CONSTANT
+        img,
+        angle=0,
+        scale=1,
+        dx=0,
+        dy=0.5,
+        interpolation=cv2.INTER_NEAREST,
+        border_mode=cv2.BORDER_CONSTANT,
     )
     assert np.array_equal(shifted_along_y_img, expected)
 
@@ -309,22 +413,39 @@ def test_shift_y_from_shift_scale_rotate(target):
 @pytest.mark.parametrize("target", ["image", "image_4_channels"])
 def test_shift_y_float_from_shift_scale_rotate(target):
     img = np.array(
-        [[0.01, 0.02, 0.03, 0.04], [0.05, 0.06, 0.07, 0.08], [0.09, 0.10, 0.11, 0.12], [0.13, 0.14, 0.15, 0.16]],
+        [
+            [0.01, 0.02, 0.03, 0.04],
+            [0.05, 0.06, 0.07, 0.08],
+            [0.09, 0.10, 0.11, 0.12],
+            [0.13, 0.14, 0.15, 0.16],
+        ],
         dtype=np.float32,
     )
     expected = np.array(
-        [[0.00, 0.00, 0.00, 0.00], [0.00, 0.00, 0.00, 0.00], [0.01, 0.02, 0.03, 0.04], [0.05, 0.06, 0.07, 0.08]],
+        [
+            [0.00, 0.00, 0.00, 0.00],
+            [0.00, 0.00, 0.00, 0.00],
+            [0.01, 0.02, 0.03, 0.04],
+            [0.05, 0.06, 0.07, 0.08],
+        ],
         dtype=np.float32,
     )
     img, expected = convert_2d_to_target_format([img, expected], target=target)
     shifted_along_y_img = FGeometric.shift_scale_rotate(
-        img, angle=0, scale=1, dx=0, dy=0.5, interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_CONSTANT
+        img,
+        angle=0,
+        scale=1,
+        dx=0,
+        dy=0.5,
+        interpolation=cv2.INTER_NEAREST,
+        border_mode=cv2.BORDER_CONSTANT,
     )
     assert_array_almost_equal_nulp(shifted_along_y_img, expected)
 
 
 @pytest.mark.parametrize(
-    ["shift_params", "expected"], [[(-10, 0, 10), (117, 127, 137)], [(-200, 0, 200), (0, 127, 255)]]
+    ["shift_params", "expected"],
+    [[(-10, 0, 10), (117, 127, 137)], [(-200, 0, 200), (0, 127, 255)]],
 )
 def test_shift_rgb(shift_params, expected):
     img = np.ones((100, 100, 3), dtype=np.uint8) * 127
@@ -338,7 +459,8 @@ def test_shift_rgb(shift_params, expected):
 
 
 @pytest.mark.parametrize(
-    ["shift_params", "expected"], [[(-0.1, 0, 0.1), (0.3, 0.4, 0.5)], [(-0.6, 0, 0.6), (0, 0.4, 1.0)]]
+    ["shift_params", "expected"],
+    [[(-0.1, 0, 0.1), (0.3, 0.4, 0.5)], [(-0.6, 0, 0.6), (0, 0.4, 1.0)]],
 )
 def test_shift_rgb_float(shift_params, expected):
     img = np.ones((100, 100, 3), dtype=np.float32) * 0.4
@@ -449,7 +571,10 @@ def test_to_float_unknown_dtype_with_max_value(max_value):
     assert_array_almost_equal_nulp(F.to_float(img, max_value=max_value), expected)
 
 
-@pytest.mark.parametrize(["dtype", "multiplier"], [(np.uint8, 255), (np.uint16, 65535), (np.uint32, 4294967295)])
+@pytest.mark.parametrize(
+    ["dtype", "multiplier"],
+    [(np.uint8, 255), (np.uint16, 65535), (np.uint32, 4294967295)],
+)
 def test_from_float_without_max_value_specified(dtype, multiplier):
     img = np.ones((100, 100, 3), dtype=np.float32)
     expected = (img * multiplier).astype(dtype)
@@ -498,7 +623,13 @@ def test_longest_max_size(target):
 @pytest.mark.parametrize("target", ["image", "mask"])
 def test_smallest_max_size(target):
     img = np.array(
-        [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12], [12, 13, 14, 15, 16, 17], [18, 19, 20, 21, 22, 23]], dtype=np.uint8
+        [
+            [1, 2, 3, 4, 5, 6],
+            [7, 8, 9, 10, 11, 12],
+            [12, 13, 14, 15, 16, 17],
+            [18, 19, 20, 21, 22, 23],
+        ],
+        dtype=np.uint8,
     )
     expected = np.array([[2, 4, 5, 7], [10, 11, 13, 14], [17, 19, 20, 22]], dtype=np.uint8)
 
@@ -557,7 +688,13 @@ def test_resize_different_height_and_width(target):
 @pytest.mark.parametrize("target", ["image", "mask"])
 def test_resize_default_interpolation_float(target):
     img = np.array(
-        [[0.1, 0.1, 0.1, 0.1], [0.2, 0.2, 0.2, 0.2], [0.3, 0.3, 0.3, 0.3], [0.4, 0.4, 0.4, 0.4]], dtype=np.float32
+        [
+            [0.1, 0.1, 0.1, 0.1],
+            [0.2, 0.2, 0.2, 0.2],
+            [0.3, 0.3, 0.3, 0.3],
+            [0.4, 0.4, 0.4, 0.4],
+        ],
+        dtype=np.float32,
     )
     expected = np.array([[0.15, 0.15], [0.35, 0.35]], dtype=np.float32)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
@@ -571,7 +708,13 @@ def test_resize_default_interpolation_float(target):
 @pytest.mark.parametrize("target", ["image", "mask"])
 def test_resize_nearest_interpolation_float(target):
     img = np.array(
-        [[0.1, 0.1, 0.1, 0.1], [0.2, 0.2, 0.2, 0.2], [0.3, 0.3, 0.3, 0.3], [0.4, 0.4, 0.4, 0.4]], dtype=np.float32
+        [
+            [0.1, 0.1, 0.1, 0.1],
+            [0.2, 0.2, 0.2, 0.2],
+            [0.3, 0.3, 0.3, 0.3],
+            [0.4, 0.4, 0.4, 0.4],
+        ],
+        dtype=np.float32,
     )
     expected = np.array([[0.1, 0.1], [0.3, 0.3]], dtype=np.float32)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
@@ -595,7 +738,10 @@ def test_bbox_hflip():
     [
         [0, F.bbox_vflip],
         [1, F.bbox_hflip],
-        [-1, lambda bbox, rows, cols: F.bbox_vflip(F.bbox_hflip(bbox, rows, cols), rows, cols)],
+        [
+            -1,
+            lambda bbox, rows, cols: F.bbox_vflip(F.bbox_hflip(bbox, rows, cols), rows, cols),
+        ],
     ],
 )
 def test_bbox_flip(code, func):
@@ -625,10 +771,30 @@ def test_bbox_random_crop():
 
 
 def test_bbox_rot90():
-    assert FGeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 0, 100, 200) == (0.1, 0.2, 0.3, 0.4)
-    assert FGeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 1, 100, 200) == (0.2, 0.7, 0.4, 0.9)
-    assert FGeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 2, 100, 200) == (0.7, 0.6, 0.9, 0.8)
-    assert FGeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 3, 100, 200) == (0.6, 0.1, 0.8, 0.3)
+    assert FGeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 0, 100, 200) == (
+        0.1,
+        0.2,
+        0.3,
+        0.4,
+    )
+    assert FGeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 1, 100, 200) == (
+        0.2,
+        0.7,
+        0.4,
+        0.9,
+    )
+    assert FGeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 2, 100, 200) == (
+        0.7,
+        0.6,
+        0.9,
+        0.8,
+    )
+    assert FGeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 3, 100, 200) == (
+        0.6,
+        0.1,
+        0.8,
+        0.3,
+    )
 
 
 def test_bbox_transpose():
@@ -647,7 +813,12 @@ def test_bbox_transpose():
         ),
         ([(0.1, 0.5, 0.8, 0.9), (0.4, 0.5, 0.5, 0.6)], 150, 0, [(0.1, 0.5, 0.8, 0.9)]),
         ([(0.1, 0.5, 0.8, 0.9), (0.4, 0.9, 0.5, 1.6)], 0, 0.75, [(0.1, 0.5, 0.8, 0.9)]),
-        ([(0.1, 0.5, 0.8, 0.9), (0.4, 0.7, 0.5, 1.1)], 0, 0.7, [(0.1, 0.5, 0.8, 0.9), (0.4, 0.7, 0.5, 1.0)]),
+        (
+            [(0.1, 0.5, 0.8, 0.9), (0.4, 0.7, 0.5, 1.1)],
+            0,
+            0.7,
+            [(0.1, 0.5, 0.8, 0.9), (0.4, 0.7, 0.5, 1.0)],
+        ),
     ],
 )
 def test_filter_bboxes(bboxes, min_area, min_visibility, target):
@@ -713,10 +884,14 @@ def test_brightness_contrast():
 
     image_uint8 = np.random.randint(min_value, max_value, size=(5, 5, 3), dtype=dtype)
 
-    assert np.array_equal(F.brightness_contrast_adjust(image_uint8), F._brightness_contrast_adjust_uint(image_uint8))
+    assert np.array_equal(
+        F.brightness_contrast_adjust(image_uint8),
+        F._brightness_contrast_adjust_uint(image_uint8),
+    )
 
     assert np.array_equal(
-        F._brightness_contrast_adjust_non_uint(image_uint8), F._brightness_contrast_adjust_uint(image_uint8)
+        F._brightness_contrast_adjust_non_uint(image_uint8),
+        F._brightness_contrast_adjust_uint(image_uint8),
     )
 
     dtype = np.uint16
@@ -726,7 +901,8 @@ def test_brightness_contrast():
     image_uint16 = np.random.randint(min_value, max_value, size=(5, 5, 3), dtype=dtype)
 
     assert np.array_equal(
-        F.brightness_contrast_adjust(image_uint16), F._brightness_contrast_adjust_non_uint(image_uint16)
+        F.brightness_contrast_adjust(image_uint16),
+        F._brightness_contrast_adjust_non_uint(image_uint16),
     )
 
     F.brightness_contrast_adjust(image_uint16)
@@ -738,13 +914,15 @@ def test_brightness_contrast():
     image_uint32 = np.random.randint(min_value, max_value, size=(5, 5, 3), dtype=dtype)
 
     assert np.array_equal(
-        F.brightness_contrast_adjust(image_uint32), F._brightness_contrast_adjust_non_uint(image_uint32)
+        F.brightness_contrast_adjust(image_uint32),
+        F._brightness_contrast_adjust_non_uint(image_uint32),
     )
 
     image_float = np.random.random((5, 5, 3))
 
     assert np.array_equal(
-        F.brightness_contrast_adjust(image_float), F._brightness_contrast_adjust_non_uint(image_float)
+        F.brightness_contrast_adjust(image_float),
+        F._brightness_contrast_adjust_non_uint(image_float),
     )
 
 
@@ -940,7 +1118,11 @@ def test_multiply_uint8_optimized():
 
 
 @pytest.mark.parametrize(
-    "img", [np.random.randint(0, 256, [100, 100], dtype=np.uint8), np.random.random([100, 100]).astype(np.float32)]
+    "img",
+    [
+        np.random.randint(0, 256, [100, 100], dtype=np.uint8),
+        np.random.random([100, 100]).astype(np.float32),
+    ],
 )
 def test_shift_hsv_gray(img):
     F.shift_hsv(img, 0.5, 0.5, 0.5)

--- a/tests/test_imgaug.py
+++ b/tests/test_imgaug.py
@@ -99,7 +99,10 @@ def test_keypoint_transform_format_xy(aug, keypoints, expected):
 
 @pytest.mark.parametrize(["aug", "keypoints", "expected"], [[IAAFliplr, [[20, 30, 0, 0]], [[79, 30, 0, 0]]]])
 def test_iaa_transforms_emit_warning(aug, keypoints, expected):
-    with pytest.warns(UserWarning, match="IAAFliplr transformation supports only 'xy' keypoints augmentation"):
+    with pytest.warns(
+        UserWarning,
+        match="IAAFliplr transformation supports only 'xy' keypoints augmentation",
+    ):
         Compose([aug(p=1)], keypoint_params={"format": "xyas", "label_fields": ["labels"]})
 
 
@@ -296,7 +299,16 @@ def test_compare_crop_and_pad(img_dtype, px, percent, pad_mode, pad_cval, keep_s
         keypoint_params=keypoint_params,
     )
     transform_iaa = A.Compose(
-        [IAACropAndPad(px=px, percent=percent, pad_mode=pad_mode_iaa, pad_cval=pad_cval, keep_size=keep_size, p=1)],
+        [
+            IAACropAndPad(
+                px=px,
+                percent=percent,
+                pad_mode=pad_mode_iaa,
+                pad_cval=pad_cval,
+                keep_size=keep_size,
+                p=1,
+            )
+        ],
         bbox_params=bbox_params,
         keypoint_params=keypoint_params,
     )

--- a/tests/test_keypoint.py
+++ b/tests/test_keypoint.py
@@ -75,7 +75,10 @@ def test_convert_keypoint_to_albumentations_and_back(kp, keypoint_format):
         kp, rows=image.shape[0], cols=image.shape[1], source_format=keypoint_format
     )
     converted_back_kp = convert_keypoint_from_albumentations(
-        converted_kp, rows=image.shape[0], cols=image.shape[1], target_format=keypoint_format
+        converted_kp,
+        rows=image.shape[0],
+        cols=image.shape[1],
+        target_format=keypoint_format,
     )
     assert converted_back_kp == kp
 
@@ -122,7 +125,10 @@ def test_convert_keypoints_from_albumentations():
 def test_compose_with_keypoint_noop(keypoints, keypoint_format, labels):
     image = np.ones((100, 100, 3))
     if labels is not None:
-        aug = Compose([NoOp(p=1.0)], keypoint_params={"format": keypoint_format, "label_fields": ["labels"]})
+        aug = Compose(
+            [NoOp(p=1.0)],
+            keypoint_params={"format": keypoint_format, "label_fields": ["labels"]},
+        )
         transformed = aug(image=image, keypoints=keypoints, labels=labels)
     else:
         aug = Compose([NoOp(p=1.0)], keypoint_params={"format": keypoint_format})
@@ -134,7 +140,10 @@ def test_compose_with_keypoint_noop(keypoints, keypoint_format, labels):
 @pytest.mark.parametrize(["keypoints", "keypoint_format"], [[[[20, 30, 40, 50]], "xyas"]])
 def test_compose_with_keypoint_noop_error_label_fields(keypoints, keypoint_format):
     image = np.ones((100, 100, 3))
-    aug = Compose([NoOp(p=1.0)], keypoint_params={"format": keypoint_format, "label_fields": "class_id"})
+    aug = Compose(
+        [NoOp(p=1.0)],
+        keypoint_params={"format": keypoint_format, "label_fields": "class_id"},
+    )
     with pytest.raises(Exception):
         aug(image=image, keypoints=keypoints, cls_id=[0])
 
@@ -151,7 +160,13 @@ def test_compose_with_keypoint_noop_error_label_fields(keypoints, keypoint_forma
 )
 def test_compose_with_keypoint_noop_label_outside(keypoints, keypoint_format, labels):
     image = np.ones((100, 100, 3))
-    aug = Compose([NoOp(p=1.0)], keypoint_params={"format": keypoint_format, "label_fields": list(labels.keys())})
+    aug = Compose(
+        [NoOp(p=1.0)],
+        keypoint_params={
+            "format": keypoint_format,
+            "label_fields": list(labels.keys()),
+        },
+    )
     transformed = aug(image=image, keypoints=keypoints, **labels)
     assert np.array_equal(transformed["image"], image)
     assert transformed["keypoints"] == keypoints
@@ -216,7 +231,12 @@ def test_keypoint_flips_transform_3x3(aug, keypoints, expected):
 )
 def test_keypoint_transform_format_xyas(aug, keypoints, expected):
     transform = Compose(
-        [aug(p=1)], keypoint_params={"format": "xyas", "angle_in_degrees": True, "label_fields": ["labels"]}
+        [aug(p=1)],
+        keypoint_params={
+            "format": "xyas",
+            "angle_in_degrees": True,
+            "label_fields": ["labels"],
+        },
     )
 
     image = np.ones((100, 100, 3))
@@ -280,7 +300,11 @@ def test_compose_with_additional_targets():
     image = np.ones((100, 100, 3))
     keypoints = [(10, 10), (50, 50)]
     kp1 = [(15, 15), (55, 55)]
-    aug = Compose([CenterCrop(50, 50)], keypoint_params={"format": "xy"}, additional_targets={"kp1": "keypoints"})
+    aug = Compose(
+        [CenterCrop(50, 50)],
+        keypoint_params={"format": "xy"},
+        additional_targets={"kp1": "keypoints"},
+    )
     transformed = aug(image=image, keypoints=keypoints, kp1=kp1)
     assert transformed["keypoints"] == [(25, 25)]
     assert transformed["kp1"] == [(30, 30)]

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -13,7 +13,11 @@ def test_torch_to_tensor_v2_augmentations(image, mask):
     aug = ToTensorV2()
     data = aug(image=image, mask=mask, force_apply=True)
     height, width, num_channels = image.shape
-    assert isinstance(data["image"], torch.Tensor) and data["image"].shape == (num_channels, height, width)
+    assert isinstance(data["image"], torch.Tensor) and data["image"].shape == (
+        num_channels,
+        height,
+        width,
+    )
     assert isinstance(data["mask"], torch.Tensor) and data["mask"].shape == mask.shape
     assert data["image"].dtype == torch.uint8
     assert data["mask"].dtype == torch.uint8
@@ -29,7 +33,10 @@ def test_torch_to_tensor_v2_augmentations_with_transpose_2d_mask(image, mask):
         image_height,
         image_width,
     )
-    assert isinstance(data["mask"], torch.Tensor) and data["mask"].shape == (mask_height, mask_width)
+    assert isinstance(data["mask"], torch.Tensor) and data["mask"].shape == (
+        mask_height,
+        mask_width,
+    )
     assert data["image"].dtype == torch.uint8
     assert data["mask"].dtype == torch.uint8
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -72,7 +72,10 @@ AUGMENTATION_CLS_PARAMS = [
         },
     ],
     [A.JpegCompression, {"quality_lower": 10, "quality_upper": 80}],
-    [A.HueSaturationValue, {"hue_shift_limit": 70, "sat_shift_limit": 95, "val_shift_limit": 55}],
+    [
+        A.HueSaturationValue,
+        {"hue_shift_limit": 70, "sat_shift_limit": 95, "val_shift_limit": 55},
+    ],
     [A.RGBShift, {"r_shift_limit": 70, "g_shift_limit": 80, "b_shift_limit": 40}],
     [A.RandomBrightnessContrast, {"brightness_limit": 0.5, "contrast_limit": 0.8}],
     [A.Blur, {"blur_limit": 3}],
@@ -84,7 +87,10 @@ AUGMENTATION_CLS_PARAMS = [
     [A.RandomGamma, {"gamma_limit": (10, 90)}],
     [A.Cutout, {"num_holes": 4, "max_h_size": 4, "max_w_size": 4}],
     [A.CoarseDropout, {"max_holes": 4, "max_height": 4, "max_width": 4}],
-    [A.RandomSnow, {"snow_point_lower": 0.2, "snow_point_upper": 0.4, "brightness_coeff": 4}],
+    [
+        A.RandomSnow,
+        {"snow_point_lower": 0.2, "snow_point_upper": 0.4, "brightness_coeff": 4},
+    ],
     [
         A.RandomRain,
         {
@@ -122,7 +128,12 @@ AUGMENTATION_CLS_PARAMS = [
     ],
     [
         A.PadIfNeeded,
-        {"min_height": 512, "min_width": 512, "border_mode": cv2.BORDER_CONSTANT, "value": (10, 10, 10)},
+        {
+            "min_height": 512,
+            "min_width": 512,
+            "border_mode": cv2.BORDER_CONSTANT,
+            "value": (10, 10, 10),
+        },
     ],
     [
         A.Rotate,
@@ -202,7 +213,14 @@ AUGMENTATION_CLS_PARAMS = [
     [A.RandomSizedCrop, {"min_max_height": (4, 8), "height": 10, "width": 10}],
     [A.Crop, {"x_max": 64, "y_max": 64}],
     [A.ToFloat, {"max_value": 16536}],
-    [A.Normalize, {"mean": (0.385, 0.356, 0.306), "std": (0.129, 0.124, 0.125), "max_pixel_value": 100.0}],
+    [
+        A.Normalize,
+        {
+            "mean": (0.385, 0.356, 0.306),
+            "std": (0.129, 0.124, 0.125),
+            "max_pixel_value": 100.0,
+        },
+    ],
     [A.RandomBrightness, {"limit": 0.4}],
     [A.RandomContrast, {"limit": 0.4}],
     [A.RandomScale, {"scale_limit": 0.2, "interpolation": cv2.INTER_CUBIC}],
@@ -213,10 +231,18 @@ AUGMENTATION_CLS_PARAMS = [
     [A.Solarize, {"threshold": 32}],
     [A.Posterize, {"num_bits": 1}],
     [A.Equalize, {"mode": "pil", "by_channels": False}],
-    [A.MultiplicativeNoise, {"multiplier": (0.7, 2.3), "per_channel": True, "elementwise": True}],
+    [
+        A.MultiplicativeNoise,
+        {"multiplier": (0.7, 2.3), "per_channel": True, "elementwise": True},
+    ],
     [
         A.ColorJitter,
-        {"brightness": [0.2, 0.3], "contrast": [0.7, 0.9], "saturation": [1.2, 1.7], "hue": [-0.2, 0.1]},
+        {
+            "brightness": [0.2, 0.3],
+            "contrast": [0.7, 0.9],
+            "saturation": [1.2, 1.7],
+            "hue": [-0.2, 0.1],
+        },
     ],
     [
         A.Perspective,
@@ -247,7 +273,12 @@ AUGMENTATION_CLS_PARAMS = [
     ],
     [
         A.Superpixels,
-        {"p_replace": (0.5, 0.7), "n_segments": (20, 30), "max_size": 25, "interpolation": cv2.INTER_CUBIC},
+        {
+            "p_replace": (0.5, 0.7),
+            "n_segments": (20, 30),
+            "max_size": 25,
+            "interpolation": cv2.INTER_CUBIC,
+        },
     ],
     [
         A.Affine,
@@ -304,7 +335,10 @@ AUGMENTATION_CLS_PARAMS = [
     [A.InvertImg, {}],
     [A.MaskDropout, dict(max_objects=2, image_fill_value=10, mask_fill_value=20)],
     [A.NoOp, {}],
-    [A.RandomResizedCrop, dict(height=20, width=30, scale=(0.5, 0.6), ratio=(0.8, 0.9))],
+    [
+        A.RandomResizedCrop,
+        dict(height=20, width=30, scale=(0.5, 0.6), ratio=(0.8, 0.9)),
+    ],
     [A.FancyPCA, dict(alpha=0.3)],
     [A.RandomRotate90, {}],
     [A.ToGray, {}],
@@ -326,7 +360,8 @@ AUGMENTATION_CLS_EXCEPT = {
 
 
 @pytest.mark.parametrize(
-    ["augmentation_cls", "params"], check_all_augs_exists(AUGMENTATION_CLS_PARAMS, AUGMENTATION_CLS_EXCEPT)
+    ["augmentation_cls", "params"],
+    check_all_augs_exists(AUGMENTATION_CLS_PARAMS, AUGMENTATION_CLS_EXCEPT),
 )
 @pytest.mark.parametrize("p", [0.5, 1])
 @pytest.mark.parametrize("seed", TEST_SEEDS)
@@ -346,7 +381,8 @@ def test_augmentations_serialization_with_custom_parameters(
 
 
 @pytest.mark.parametrize(
-    ["augmentation_cls", "params"], check_all_augs_exists(AUGMENTATION_CLS_PARAMS, AUGMENTATION_CLS_EXCEPT)
+    ["augmentation_cls", "params"],
+    check_all_augs_exists(AUGMENTATION_CLS_PARAMS, AUGMENTATION_CLS_EXCEPT),
 )
 @pytest.mark.parametrize("p", [0.5, 1])
 @pytest.mark.parametrize("seed", TEST_SEEDS)
@@ -464,7 +500,13 @@ def test_augmentations_for_keypoints_serialization(augmentation_cls, params, p, 
 
 @pytest.mark.parametrize(
     ["augmentation_cls", "params", "call_params"],
-    [[A.RandomCropNearBBox, {"max_part_shift": 0.15}, {"cropping_bbox": [-59, 77, 177, 231]}]],
+    [
+        [
+            A.RandomCropNearBBox,
+            {"max_part_shift": 0.15},
+            {"cropping_bbox": [-59, 77, 177, 231]},
+        ]
+    ],
 )
 @pytest.mark.parametrize("p", [0.5, 1])
 @pytest.mark.parametrize("seed", TEST_SEEDS)
@@ -503,8 +545,18 @@ def test_transform_pipeline_serialization(seed, image, mask):
                         A.RandomSizedCrop(min_max_height=(256, 1024), height=512, width=512, p=1),
                         A.OneOf(
                             [
-                                A.RandomSizedCrop(min_max_height=(256, 512), height=384, width=384, p=0.5),
-                                A.RandomSizedCrop(min_max_height=(256, 512), height=512, width=512, p=0.5),
+                                A.RandomSizedCrop(
+                                    min_max_height=(256, 512),
+                                    height=384,
+                                    width=384,
+                                    p=0.5,
+                                ),
+                                A.RandomSizedCrop(
+                                    min_max_height=(256, 512),
+                                    height=512,
+                                    width=512,
+                                    p=0.5,
+                                ),
                             ]
                         ),
                     ]
@@ -555,8 +607,18 @@ def test_transform_pipeline_serialization_with_bboxes(seed, image, bboxes, bbox_
     aug = A.Compose(
         [
             A.OneOrOther(
-                A.Compose([A.RandomRotate90(), A.OneOf([A.HorizontalFlip(p=0.5), A.VerticalFlip(p=0.5)])]),
-                A.Compose([A.Rotate(p=0.5), A.OneOf([A.HueSaturationValue(p=0.5), A.RGBShift(p=0.7)], p=1)]),
+                A.Compose(
+                    [
+                        A.RandomRotate90(),
+                        A.OneOf([A.HorizontalFlip(p=0.5), A.VerticalFlip(p=0.5)]),
+                    ]
+                ),
+                A.Compose(
+                    [
+                        A.Rotate(p=0.5),
+                        A.OneOf([A.HueSaturationValue(p=0.5), A.RGBShift(p=0.7)], p=1),
+                    ]
+                ),
             ),
             A.SomeOf(
                 [
@@ -594,8 +656,18 @@ def test_transform_pipeline_serialization_with_keypoints(seed, image, keypoints,
     aug = A.Compose(
         [
             A.OneOrOther(
-                A.Compose([A.RandomRotate90(), A.OneOf([A.HorizontalFlip(p=0.5), A.VerticalFlip(p=0.5)])]),
-                A.Compose([A.Rotate(p=0.5), A.OneOf([A.HueSaturationValue(p=0.5), A.RGBShift(p=0.7)], p=1)]),
+                A.Compose(
+                    [
+                        A.RandomRotate90(),
+                        A.OneOf([A.HorizontalFlip(p=0.5), A.VerticalFlip(p=0.5)]),
+                    ]
+                ),
+                A.Compose(
+                    [
+                        A.Rotate(p=0.5),
+                        A.OneOf([A.HueSaturationValue(p=0.5), A.RGBShift(p=0.7)], p=1),
+                    ]
+                ),
             ),
             A.SomeOf(
                 n=2,
@@ -623,12 +695,19 @@ def test_transform_pipeline_serialization_with_keypoints(seed, image, keypoints,
 @pytest.mark.parametrize(
     ["augmentation_cls", "params"],
     get_image_only_transforms(
-        except_augmentations={A.HistogramMatching, A.FDA, A.PixelDistributionAdaptation},
+        except_augmentations={
+            A.HistogramMatching,
+            A.FDA,
+            A.PixelDistributionAdaptation,
+        },
     ),
 )
 @pytest.mark.parametrize("seed", TEST_SEEDS)
 def test_additional_targets_for_image_only_serialization(augmentation_cls, params, image, seed):
-    aug = A.Compose([augmentation_cls(always_apply=True, **params)], additional_targets={"image2": "image"})
+    aug = A.Compose(
+        [augmentation_cls(always_apply=True, **params)],
+        additional_targets={"image2": "image"},
+    )
     image2 = image.copy()
 
     serialized_aug = A.to_dict(aug)
@@ -656,7 +735,14 @@ def test_lambda_serialization(image, mask, albumentations_bboxes, keypoints, see
     def vflip_keypoint(keypoint, **kwargs):
         return F.keypoint_vflip(keypoint, **kwargs)
 
-    aug = A.Lambda(name="vflip", image=vflip_image, mask=vflip_mask, bbox=vflip_bbox, keypoint=vflip_keypoint, p=p)
+    aug = A.Lambda(
+        name="vflip",
+        image=vflip_image,
+        mask=vflip_mask,
+        bbox=vflip_bbox,
+        keypoint=vflip_keypoint,
+        p=p,
+    )
 
     serialized_aug = A.to_dict(aug)
     deserialized_aug = A.from_dict(serialized_aug, lambda_transforms={"vflip": aug})

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -57,14 +57,30 @@ def test_shift_scale_rotate_interpolation(interpolation):
     image = np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
     mask = np.random.randint(low=0, high=2, size=(100, 100), dtype=np.uint8)
     aug = A.ShiftScaleRotate(
-        shift_limit=(0.2, 0.2), scale_limit=(1.1, 1.1), rotate_limit=(45, 45), interpolation=interpolation, p=1
+        shift_limit=(0.2, 0.2),
+        scale_limit=(1.1, 1.1),
+        rotate_limit=(45, 45),
+        interpolation=interpolation,
+        p=1,
     )
     data = aug(image=image, mask=mask)
     expected_image = FGeometric.shift_scale_rotate(
-        image, angle=45, scale=2.1, dx=0.2, dy=0.2, interpolation=interpolation, border_mode=cv2.BORDER_REFLECT_101
+        image,
+        angle=45,
+        scale=2.1,
+        dx=0.2,
+        dy=0.2,
+        interpolation=interpolation,
+        border_mode=cv2.BORDER_REFLECT_101,
     )
     expected_mask = FGeometric.shift_scale_rotate(
-        mask, angle=45, scale=2.1, dx=0.2, dy=0.2, interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_REFLECT_101
+        mask,
+        angle=45,
+        scale=2.1,
+        dx=0.2,
+        dy=0.2,
+        interpolation=cv2.INTER_NEAREST,
+        border_mode=cv2.BORDER_REFLECT_101,
     )
     assert np.array_equal(data["image"], expected_image)
     assert np.array_equal(data["mask"], expected_mask)
@@ -77,10 +93,20 @@ def test_optical_distortion_interpolation(interpolation):
     aug = A.OpticalDistortion(distort_limit=(0.05, 0.05), shift_limit=(0, 0), interpolation=interpolation, p=1)
     data = aug(image=image, mask=mask)
     expected_image = F.optical_distortion(
-        image, k=0.05, dx=0, dy=0, interpolation=interpolation, border_mode=cv2.BORDER_REFLECT_101
+        image,
+        k=0.05,
+        dx=0,
+        dy=0,
+        interpolation=interpolation,
+        border_mode=cv2.BORDER_REFLECT_101,
     )
     expected_mask = F.optical_distortion(
-        mask, k=0.05, dx=0, dy=0, interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_REFLECT_101
+        mask,
+        k=0.05,
+        dx=0,
+        dy=0,
+        interpolation=cv2.INTER_NEAREST,
+        border_mode=cv2.BORDER_REFLECT_101,
     )
     assert np.array_equal(data["image"], expected_image)
     assert np.array_equal(data["mask"], expected_mask)
@@ -93,7 +119,12 @@ def test_grid_distortion_interpolation(interpolation):
     aug = A.GridDistortion(num_steps=1, distort_limit=(0.3, 0.3), interpolation=interpolation, p=1)
     data = aug(image=image, mask=mask)
     expected_image = F.grid_distortion(
-        image, num_steps=1, xsteps=[1.3], ysteps=[1.3], interpolation=interpolation, border_mode=cv2.BORDER_REFLECT_101
+        image,
+        num_steps=1,
+        xsteps=[1.3],
+        ysteps=[1.3],
+        interpolation=interpolation,
+        border_mode=cv2.BORDER_REFLECT_101,
     )
     expected_mask = F.grid_distortion(
         mask,
@@ -120,7 +151,8 @@ def test_elastic_transform_interpolation(monkeypatch, interpolation):
     image = np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
     mask = np.random.randint(low=0, high=2, size=(100, 100), dtype=np.uint8)
     monkeypatch.setattr(
-        "albumentations.augmentations.geometric.ElasticTransform.get_params", lambda *_: {"random_state": 1111}
+        "albumentations.augmentations.geometric.ElasticTransform.get_params",
+        lambda *_: {"random_state": 1111},
     )
     aug = A.ElasticTransform(alpha=1, sigma=50, alpha_affine=50, interpolation=interpolation, p=1)
     data = aug(image=image, mask=mask)
@@ -183,7 +215,11 @@ def test_binary_mask_interpolation(augmentation_cls, params):
             A.RandomSizedCrop: {"min_max_height": (4, 8), "height": 10, "width": 10},
             A.Resize: {"height": 10, "width": 10},
         },
-        except_augmentations={A.RandomCropNearBBox, A.RandomSizedBBoxSafeCrop, A.CropAndPad},
+        except_augmentations={
+            A.RandomCropNearBBox,
+            A.RandomSizedBBoxSafeCrop,
+            A.CropAndPad,
+        },
     ),
 )
 def test_semantic_mask_interpolation(augmentation_cls, params):
@@ -250,8 +286,18 @@ def test_force_apply():
                         A.RandomSizedCrop(min_max_height=(256, 1025), height=512, width=512, p=1),
                         A.OneOf(
                             [
-                                A.RandomSizedCrop(min_max_height=(256, 512), height=384, width=384, p=0.5),
-                                A.RandomSizedCrop(min_max_height=(256, 512), height=512, width=512, p=0.5),
+                                A.RandomSizedCrop(
+                                    min_max_height=(256, 512),
+                                    height=384,
+                                    width=384,
+                                    p=0.5,
+                                ),
+                                A.RandomSizedCrop(
+                                    min_max_height=(256, 512),
+                                    height=512,
+                                    width=512,
+                                    p=0.5,
+                                ),
                             ]
                         ),
                     ]
@@ -294,7 +340,10 @@ def test_force_apply():
     ),
 )
 def test_additional_targets_for_image_only(augmentation_cls, params):
-    aug = A.Compose([augmentation_cls(always_apply=True, **params)], additional_targets={"image2": "image"})
+    aug = A.Compose(
+        [augmentation_cls(always_apply=True, **params)],
+        additional_targets={"image2": "image"},
+    )
     for _i in range(10):
         image1 = np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
         image2 = image1.copy()
@@ -319,7 +368,11 @@ def test_lambda_transform():
         return F.keypoint_vflip(keypoint, **kwargs)
 
     aug = A.Lambda(
-        image=negate_image, mask=partial(one_hot_mask, num_channels=16), bbox=vflip_bbox, keypoint=vflip_keypoint, p=1
+        image=negate_image,
+        mask=partial(one_hot_mask, num_channels=16),
+        bbox=vflip_bbox,
+        keypoint=vflip_keypoint,
+        p=1,
     )
 
     output = aug(
@@ -520,7 +573,11 @@ def test_multiplicative_noise_grayscale(image):
 
 
 @pytest.mark.parametrize(
-    "image", [np.random.randint(0, 256, [256, 320, 3], np.uint8), np.random.random([256, 320, 3]).astype(np.float32)]
+    "image",
+    [
+        np.random.randint(0, 256, [256, 320, 3], np.uint8),
+        np.random.random([256, 320, 3]).astype(np.float32),
+    ],
 )
 def test_multiplicative_noise_rgb(image):
     dtype = image.dtype
@@ -577,7 +634,11 @@ def test_mask_dropout():
 
 
 @pytest.mark.parametrize(
-    "image", [np.random.randint(0, 256, [256, 320, 3], np.uint8), np.random.random([256, 320, 3]).astype(np.float32)]
+    "image",
+    [
+        np.random.randint(0, 256, [256, 320, 3], np.uint8),
+        np.random.random([256, 320, 3]).astype(np.float32),
+    ],
 )
 def test_grid_dropout_mask(image):
     mask = np.ones([256, 320], dtype=np.uint8)
@@ -612,7 +673,15 @@ def test_grid_dropout_mask(image):
 
 
 @pytest.mark.parametrize(
-    ["ratio", "holes_number_x", "holes_number_y", "unit_size_min", "unit_size_max", "shift_x", "shift_y"],
+    [
+        "ratio",
+        "holes_number_x",
+        "holes_number_y",
+        "unit_size_min",
+        "unit_size_max",
+        "shift_x",
+        "shift_y",
+    ],
     [
         (0.00001, 10, 10, 100, 100, 50, 50),
         (0.9, 100, None, 200, None, 0, 0),
@@ -620,7 +689,15 @@ def test_grid_dropout_mask(image):
         (0.00004, None, None, 2, 100, None, None),
     ],
 )
-def test_grid_dropout_params(ratio, holes_number_x, holes_number_y, unit_size_min, unit_size_max, shift_x, shift_y):
+def test_grid_dropout_params(
+    ratio,
+    holes_number_x,
+    holes_number_y,
+    unit_size_min,
+    unit_size_max,
+    shift_x,
+    shift_y,
+):
     img = np.random.randint(0, 256, [256, 320], np.uint8)
 
     aug = A.GridDropout(
@@ -726,7 +803,10 @@ def test_color_jitter_float_uint8_equal(brightness, contrast, saturation, hue):
         assert _max <= 2, "Max: {}".format(_max)
 
 
-@pytest.mark.parametrize(["hue", "sat", "val"], [[13, 17, 23], [14, 18, 24], [131, 143, 151], [132, 144, 152]])
+@pytest.mark.parametrize(
+    ["hue", "sat", "val"],
+    [[13, 17, 23], [14, 18, 24], [131, 143, 151], [132, 144, 152]],
+)
 def test_hue_saturation_value_float_uint8_equal(hue, sat, val):
     img = np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)
 
@@ -753,7 +833,10 @@ def test_hue_saturation_value_float_uint8_equal(hue, sat, val):
             t1 = A.Compose(
                 [
                     A.HueSaturationValue(
-                        hue_shift_limit=[_hue, _hue], sat_shift_limit=[_sat, _sat], val_shift_limit=[_val, _val], p=1
+                        hue_shift_limit=[_hue, _hue],
+                        sat_shift_limit=[_sat, _sat],
+                        val_shift_limit=[_val, _val],
+                        p=1,
                     )
                 ]
             )
@@ -776,13 +859,31 @@ def test_hue_saturation_value_float_uint8_equal(hue, sat, val):
 
 
 def test_shift_scale_separate_shift_x_shift_y(image, mask):
-    aug = A.ShiftScaleRotate(shift_limit=(0.3, 0.3), shift_limit_y=(0.4, 0.4), scale_limit=0, rotate_limit=0, p=1)
+    aug = A.ShiftScaleRotate(
+        shift_limit=(0.3, 0.3),
+        shift_limit_y=(0.4, 0.4),
+        scale_limit=0,
+        rotate_limit=0,
+        p=1,
+    )
     data = aug(image=image, mask=mask)
     expected_image = FGeometric.shift_scale_rotate(
-        image, angle=0, scale=1, dx=0.3, dy=0.4, interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_REFLECT_101
+        image,
+        angle=0,
+        scale=1,
+        dx=0.3,
+        dy=0.4,
+        interpolation=cv2.INTER_LINEAR,
+        border_mode=cv2.BORDER_REFLECT_101,
     )
     expected_mask = FGeometric.shift_scale_rotate(
-        mask, angle=0, scale=1, dx=0.3, dy=0.4, interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_REFLECT_101
+        mask,
+        angle=0,
+        scale=1,
+        dx=0.3,
+        dy=0.4,
+        interpolation=cv2.INTER_NEAREST,
+        border_mode=cv2.BORDER_REFLECT_101,
     )
     assert np.array_equal(data["image"], expected_image)
     assert np.array_equal(data["mask"], expected_mask)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -112,7 +112,9 @@ def get_transforms(
     except_augmentations: typing.Optional[typing.Set[typing.Type[albumentations.BasicTransform]]] = None,
 ) -> typing.List[typing.Tuple[typing.Type, dict]]:
     return get_filtered_transforms(
-        (albumentations.ImageOnlyTransform, albumentations.DualTransform), custom_arguments, except_augmentations
+        (albumentations.ImageOnlyTransform, albumentations.DualTransform),
+        custom_arguments,
+        except_augmentations,
     )
 
 


### PR DESCRIPTION
In response to this issue: https://github.com/albumentations-team/albumentations/issues/676

Made changes to the `get_params_dependent_on_targets` method in the `CoarseDropout` class of `albumentations/augmentations/transforms.py`.