### PR TITLE
Raise Exception if `bbox_params` is not specified and bbox transformation is called

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -325,3 +325,10 @@ def test_check_each_transform(targets, bbox_params, keypoint_params, expected):
 
     for key, item in expected.items():
         assert np.all(np.array(item) == np.array(res[key]))
+
+
+def test_bbox_params_is_not_set(image, bboxes):
+    t = Compose([])
+    with pytest.raises(ValueError) as exc_info:
+        t(image=image, bboxes=bboxes)
+    assert str(exc_info.value) == "bbox_params must be specified for bbox transformations"


### PR DESCRIPTION
In response to this issue: #861

- Made changes in `_check_args` method in `albumentations/core/composition.py`.
- Added test to `tests/test_core`
- Disabled `_check_args` for inner transforms. 