### PR TITLE
Fix choice of transforms in OneOf and SomeOf

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -330,8 +330,8 @@ class SomeOf(BaseCompose):
             idx = random_state.choice(
                 len(self.transforms), size=self.n, replace=self.replace, p=self.transforms_ps  # type: ignore
             )
-            transforms = [self.transforms[i] for i in idx]
-            for t in transforms:
+            for i in idx:
+                t = self.transforms[i]
                 data = t(force_apply=True, **data)
         return data
 

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -294,7 +294,8 @@ class OneOf(BaseCompose):
 
         if self.transforms_ps and (force_apply or random.random() < self.p):
             random_state = np.random.RandomState(random.randint(0, 2 ** 32 - 1))
-            t = random_state.choice(self.transforms, p=self.transforms_ps)  # type: ignore
+            idx = random_state.choice(len(self.transforms), p=self.transforms_ps)  # type: ignore
+            t = self.transforms[idx]
             data = t(force_apply=True, **data)
         return data
 
@@ -326,9 +327,10 @@ class SomeOf(BaseCompose):
 
         if self.transforms_ps and (force_apply or random.random() < self.p):
             random_state = np.random.RandomState(random.randint(0, 2 ** 32 - 1))
-            transforms = random_state.choice(
-                self.transforms, size=self.n, replace=self.replace, p=self.transforms_ps  # type: ignore
+            idx = random_state.choice(
+                len(self.transforms), size=self.n, replace=self.replace, p=self.transforms_ps  # type: ignore
             )
+            transforms = [self.transforms[i] for i in idx]
             for t in transforms:
                 data = t(force_apply=True, **data)
         return data

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,16 +27,17 @@ from albumentations.core.composition import (
     KeypointParams,
     OneOf,
     OneOrOther,
-    SomeOf,
     PerChannel,
     ReplayCompose,
     Sequential,
+    SomeOf,
 )
 from albumentations.core.transforms_interface import (
     DualTransform,
     ImageOnlyTransform,
     to_tuple,
 )
+
 from .utils import get_filtered_transforms
 
 
@@ -370,3 +371,13 @@ def test_single_transform_compose(
     with pytest.warns(UserWarning):
         res_transform = compose_cls(transforms=transform, **compose_kwargs)  # type: ignore
     assert isinstance(res_transform.transforms, list)
+
+
+@pytest.mark.parametrize(
+    "transforms",
+    [OneOf([Sequential([HorizontalFlip(p=1)])], p=1), SomeOf([Sequential([HorizontalFlip(p=1)])], n=1, p=1)],
+)
+def test_choice_inner_compositions(transforms):
+    """Check that the inner composition is selected without errors."""
+    image = np.empty([10, 10, 3], dtype=np.uint8)
+    transforms(image=image)


### PR DESCRIPTION
After adding the `__len__` method to `BaseCompose`, it starts to be identified as a correct `Sequence`. 
After that, inside `OneOf` and `SomeOf`, `numpy.choice` started to identify transforms like a multi-dimensional array.
To solve this problem, we select the indexes and after that, we take the selected transforms. 