### PR TITLE
Fix scikit-image version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 import io
 import os
 import re
-from setuptools import setup, find_packages
+
 from pkg_resources import DistributionNotFound, get_distribution
+from setuptools import find_packages, setup
 
-
-INSTALL_REQUIRES = ["numpy>=1.11.1", "scipy", "scikit-image>=0.16.1", "PyYAML", "qudida>=0.0.4"]
+INSTALL_REQUIRES = ["numpy>=1.11.1", "scipy", "scikit-image>=0.16.1,<0.19", "PyYAML", "qudida>=0.0.4"]
 
 # If none of packages in first installed, install second package
 CHOOSE_INSTALL_REQUIRES = [


### PR DESCRIPTION
Problem: the new release of scikit-image (0.19.0) changed output dtypes of some functions. In the case of Albumentations, we got [`apply_histogram`](https://github.com/albumentations-team/albumentations/blob/master/albumentations/augmentations/domain_adaptation.py#L84) affected. It can be fixed with this change that explicitly converts the output of the skimage function to the required dtype - https://github.com/albumentations-team/albumentations/compare/fix_histogram_matching?expand=1

However, one of imgaug functions is also affected (see the CI log https://github.com/albumentations-team/albumentations/runs/4460596297?check_suite_focus=true), and I think we can't fix it by ourselves.

So I propose to fix the `scikit-image` version with this PR and then completely get rid of imgaug in our code and apply the fix from [`fix_histogram_matching`](https://github.com/albumentations-team/albumentations/compare/fix_histogram_matching?expand=1) to change our function and allow it to use the latest version of scikit-image. 
