### PR TITLE
Add the confirmation label

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-a-company-as-a-user-of-albumentations.yaml
+++ b/.github/ISSUE_TEMPLATE/add-a-company-as-a-user-of-albumentations.yaml
@@ -26,6 +26,7 @@ body:
       required: true
   - type: checkboxes
     attributes:
+      label: Confirmation
       options:
       - label: "I hereby confirm that I have permission from the company specified above to use its name, link to a website, and logo to mention it as a user of Albumentations."
         required: true


### PR DESCRIPTION
Without the `label` field, GitGub returns a 400 error when a user submits an issue.