### PR TITLE
Add support for "masks" target to ToTensorV2

### DIFF
--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -76,7 +76,9 @@ class ToTensorV2(BasicTransform):
 
     @property
     def targets(self):
-        return {"image": self.apply, "mask": self.apply_to_mask}
+        return {"image": self.apply,
+                "mask": self.apply_to_mask,
+                "masks": self.apply_to_masks}
 
     def apply(self, img, **params):  # skipcq: PYL-W0613
         if len(img.shape) not in [2, 3]:
@@ -91,6 +93,9 @@ class ToTensorV2(BasicTransform):
         if self.transpose_mask and mask.ndim == 3:
             mask = mask.transpose(2, 0, 1)
         return torch.from_numpy(mask)
+    
+    def apply_to_masks(self, masks, **params):
+        return [self.apply_to_mask(mask, **params) for mask in masks]
 
     def get_transform_init_args_names(self):
         return ("transpose_mask",)

--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -76,9 +76,7 @@ class ToTensorV2(BasicTransform):
 
     @property
     def targets(self):
-        return {"image": self.apply,
-                "mask": self.apply_to_mask,
-                "masks": self.apply_to_masks}
+        return {"image": self.apply, "mask": self.apply_to_mask, "masks": self.apply_to_masks}
 
     def apply(self, img, **params):  # skipcq: PYL-W0613
         if len(img.shape) not in [2, 3]:
@@ -93,7 +91,7 @@ class ToTensorV2(BasicTransform):
         if self.transpose_mask and mask.ndim == 3:
             mask = mask.transpose(2, 0, 1)
         return torch.from_numpy(mask)
-    
+
     def apply_to_masks(self, masks, **params):
         return [self.apply_to_mask(mask, **params) for mask in masks]
 


### PR DESCRIPTION
As the title says.

Fix a bug I encountered that caused the masks passed to a composition through the "masks" argument to not be converted to pytorch tensors.
