### PR TITLE
Feature: PoC for the bounding box reflection in `bbox_shift_scale_rotate`

### DIFF
--- a/albumentations/augmentations/crops/functional.py
+++ b/albumentations/augmentations/crops/functional.py
@@ -7,9 +7,12 @@ from albumentations.augmentations.utils import (
     _maybe_process_in_chunks,
     preserve_channel_dim,
 )
+
 from ...core.bbox_utils import (
-    denormalize_bbox, normalize_bbox,
-    denormalize_bboxes2, normalize_bboxes2,
+    denormalize_bbox,
+    denormalize_bboxes2,
+    normalize_bbox,
+    normalize_bboxes2,
 )
 from ...core.transforms_interface import BoxInternalType, KeypointInternalType
 from ..geometric import functional as FGeometric

--- a/albumentations/augmentations/crops/functional.py
+++ b/albumentations/augmentations/crops/functional.py
@@ -7,8 +7,10 @@ from albumentations.augmentations.utils import (
     _maybe_process_in_chunks,
     preserve_channel_dim,
 )
-
-from ...core.bbox_utils import denormalize_bbox, normalize_bbox
+from ...core.bbox_utils import (
+    denormalize_bbox, normalize_bbox,
+    denormalize_bboxes2, normalize_bboxes2,
+)
 from ...core.transforms_interface import BoxInternalType, KeypointInternalType
 from ..geometric import functional as FGeometric
 
@@ -16,6 +18,7 @@ __all__ = [
     "get_random_crop_coords",
     "random_crop",
     "crop_bbox_by_coords",
+    "crop_bboxes_by_coords",
     "bbox_random_crop",
     "crop_keypoint_by_coords",
     "keypoint_random_crop",
@@ -85,6 +88,38 @@ def crop_bbox_by_coords(
     x1, y1, _, _ = crop_coords
     cropped_bbox = x_min - x1, y_min - y1, x_max - x1, y_max - y1
     return normalize_bbox(cropped_bbox, crop_height, crop_width)
+
+
+def crop_bboxes_by_coords(
+    bboxes: np.ndarray, crop_coords: Tuple[int, int, int, int], crop_height: int, crop_width: int, rows: int, cols: int
+):
+    """Crop a bounding box using the provided coordinates of bottom-left and top-right corners in pixels and the
+    required height and width of the crop.
+    Args:
+        bboxes (np.ndarray): A cropped box `(x_min, y_min, x_max, y_max)`.
+        crop_coords (tuple): Crop coordinates `(x1, y1, x2, y2)`.
+        crop_height (int):
+        crop_width (int):
+        rows (int): Image rows.
+        cols (int): Image cols.
+    Returns:
+        bboxes (np.ndarray): A cropped bounding box `(x_min, y_min, x_max, y_max)`.
+    """
+    if not isinstance(bboxes, np.ndarray):
+        raise ValueError("bboxes should be np.ndarray")
+
+    bboxes = denormalize_bboxes2(bboxes, rows, cols)
+    bboxes = np.array(bboxes)
+    new_bboxes = bboxes.copy()
+    x1, y1, _, _ = crop_coords
+
+    new_bboxes[:, 0] = bboxes[:, 0] - x1
+    new_bboxes[:, 1] = bboxes[:, 1] - y1
+    new_bboxes[:, 2] = bboxes[:, 2] - x1
+    new_bboxes[:, 3] = bboxes[:, 3] - y1
+    new_bboxes = normalize_bboxes2(new_bboxes, crop_height, crop_width)
+
+    return new_bboxes
 
 
 def bbox_random_crop(

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -6,7 +6,6 @@ import numpy as np
 import skimage.transform
 from scipy.ndimage.filters import gaussian_filter
 
-
 from albumentations.augmentations.utils import (
     _maybe_process_in_chunks,
     angle_2pi_range,
@@ -14,7 +13,7 @@ from albumentations.augmentations.utils import (
     preserve_channel_dim,
     preserve_shape,
 )
-from ..crops import functional as FCrop
+
 from ... import random_utils
 from ...core.bbox_utils import denormalize_bbox, normalize_bbox
 from ...core.transforms_interface import (
@@ -23,6 +22,7 @@ from ...core.transforms_interface import (
     ImageColorType,
     KeypointInternalType,
 )
+from ..crops import functional as FCrop
 
 __all__ = [
     "optical_distortion",

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -75,8 +75,9 @@ class ShiftScaleRotate(DualTransform):
             in the range [0, 1]. Default: None.
         rotate_method (str): rotation method used for the bounding boxes. Should be one of "largest_box" or "ellipse".
             Default: "largest_box"
-        reflec_annotation: If True and the border_mode is one of: cv2.BORDER_REFLECT, cv2.BORDER_WRAP, cv2.BORDER_REFLECT_101,
-            then annotations(keypoints are not supported yet) are also reflected or wrapped in the same way as image.
+        reflec_annotation: If True and the border_mode is one of: cv2.BORDER_REFLECT, cv2.BORDER_WRAP,
+            cv2.BORDER_REFLECT_101, then annotations(keypoints are not supported yet) are also reflected or wrapped
+            in the same way as the image.
             Default: False
         p (float): probability of applying the transform. Default: 0.5.
 

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -7,7 +7,12 @@ import cv2
 import numpy as np
 import skimage.transform
 
-from albumentations.core.bbox_utils import denormalize_bbox, normalize_bbox
+from albumentations.core.bbox_utils import (
+    denormalize_bbox,
+    normalize_bbox,
+    to_ndarray_bboxes,
+    to_tuple_bboxes,
+)
 
 from ... import random_utils
 from ...core.transforms_interface import (
@@ -70,10 +75,13 @@ class ShiftScaleRotate(DualTransform):
             in the range [0, 1]. Default: None.
         rotate_method (str): rotation method used for the bounding boxes. Should be one of "largest_box" or "ellipse".
             Default: "largest_box"
+        reflec_annotation: If True and the border_mode is one of: cv2.BORDER_REFLECT, cv2.BORDER_WRAP, cv2.BORDER_REFLECT_101,
+            then annotations(keypoints are not supported yet) are also reflected or wrapped in the same way as image.
+            Default: False
         p (float): probability of applying the transform. Default: 0.5.
 
     Targets:
-        image, mask, keypoints
+        image, mask, keypoints, bboxes
 
     Image types:
         uint8, float32
@@ -91,6 +99,7 @@ class ShiftScaleRotate(DualTransform):
         shift_limit_x=None,
         shift_limit_y=None,
         rotate_method="largest_box",
+        reflect_annotation=False,
         always_apply=False,
         p=0.5,
     ):
@@ -104,6 +113,7 @@ class ShiftScaleRotate(DualTransform):
         self.value = value
         self.mask_value = mask_value
         self.rotate_method = rotate_method
+        self.reflect_annotation = reflect_annotation
 
         if self.rotate_method not in ["largest_box", "ellipse"]:
             raise ValueError(f"Rotation method {self.rotate_method} is not valid.")
@@ -124,6 +134,19 @@ class ShiftScaleRotate(DualTransform):
             "dx": random.uniform(self.shift_limit_x[0], self.shift_limit_x[1]),
             "dy": random.uniform(self.shift_limit_y[0], self.shift_limit_y[1]),
         }
+
+    def apply_to_bboxes(self, bboxes, angle, scale, dx, dy, rows, cols, **params):
+        if not self.reflect_annotation:
+            bboxes = super().apply_to_bboxes(
+                bboxes, angle=angle, scale=scale, dx=dx, dy=dy, rows=rows, cols=cols, **params
+            )
+        else:
+            bboxes, labels = to_ndarray_bboxes(bboxes)
+            bboxes = F.bboxes_shift_scale_rotate_reflect(
+                bboxes, angle, scale, dx, dy, self.rotate_method, rows, cols, self.border_mode
+            )
+            bboxes = to_tuple_bboxes(bboxes, labels)
+        return bboxes
 
     def apply_to_bbox(self, bbox, angle, scale, dx, dy, **params):
         return F.bbox_shift_scale_rotate(bbox, angle, scale, dx, dy, self.rotate_method, **params)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1146,15 +1146,18 @@ def test_bboxes_shift_scale_rotate():
     scale = 1.2
     dx, dy = 0.15, 0.05
     bboxes = np.array([[0.1, 0.1, 0.2, 0.2], [0.6, 0.5, 0.8, 0.6]])
+    rotate_method = "largest_bbox"
     # Use the result of bbox_shift_scale_rotate as a truth result.
     expect = []
     for bbox in bboxes:
         box = FGeometric.bbox_shift_scale_rotate(
-            bbox, angle=angle, scale=scale, dx=dx, dy=dy, rotate_method="largest_box", rows=rows, cols=cols
+            bbox, angle=angle, scale=scale, dx=dx, dy=dy, rotate_method=rotate_method, rows=rows, cols=cols
         )
         expect.append(box)
     expect = np.array(expect)
-    actual = FGeometric.bboxes_shift_scale_rotate(bboxes, angle=angle, scale=scale, dx=dx, dy=dy, rows=rows, cols=cols)
+    actual = FGeometric.bboxes_shift_scale_rotate(
+        bboxes, angle=angle, scale=scale, dx=dx, dy=dy, rotate_method=rotate_method, rows=rows, cols=cols
+    )
     np.testing.assert_allclose(actual, expect)
 
 
@@ -1401,5 +1404,8 @@ def test_bboxes_expand_grid(bboxes, n_x, n_y, border_mode, expect):
 )
 def test_bboxes_shift_scale_rotate_with_reflect(bboxes, angle, scale, dx, dy, border_mode, expect):
     rows, cols = 100, 100
-    actual = FGeometric.bboxes_shift_scale_rotate_reflect(bboxes, angle, scale, dx, dy, rows, cols, border_mode)
+    rotate_method = "largest_box"
+    actual = FGeometric.bboxes_shift_scale_rotate_reflect(
+        bboxes, angle, scale, dx, dy, rotate_method, rows, cols, border_mode
+    )
     np.testing.assert_allclose(actual, expect)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -20,7 +20,6 @@ from albumentations.core.bbox_utils import (
     to_ndarray_bboxes,
     to_tuple_bboxes,
 )
-
 from tests.utils import convert_2d_to_target_format
 
 
@@ -1150,7 +1149,9 @@ def test_bboxes_shift_scale_rotate():
     # Use the result of bbox_shift_scale_rotate as a truth result.
     expect = []
     for bbox in bboxes:
-        box = FGeometric.bbox_shift_scale_rotate(bbox, angle=angle, scale=scale, dx=dx, dy=dy, rotate_method='largest_box', rows=rows, cols=cols)
+        box = FGeometric.bbox_shift_scale_rotate(
+            bbox, angle=angle, scale=scale, dx=dx, dy=dy, rotate_method="largest_box", rows=rows, cols=cols
+        )
         expect.append(box)
     expect = np.array(expect)
     actual = FGeometric.bboxes_shift_scale_rotate(bboxes, angle=angle, scale=scale, dx=dx, dy=dy, rows=rows, cols=cols)


### PR DESCRIPTION
## About this PR

I had implemented a bbox reflection functionality for `bbox_shift_scale_rotate` for my own specific usecase. I think this functionality will be beneficial for other users. So I made this PR.

My goal is to integrate the bbox reflection mode like (cv2.BORDER_REFLECT and cv2.BORDER_WRAP) into current transforms like `ShiftScaleRotate`.
 
But it was not an easy task.

So in this PR, I provide a only functional version (`bboxes_shift_scale_rotate_reflect`) as a first step. I think it is sufficient to look into how it works and what challenges exist.
And if you think this implementation seems promising to merge, I want to get into the next step.

I'm not sure this PR can be merged, but I hope this implementation and analysis inspire someone.

## Demo

This is a demo: An input image(left), a result of `bbox_shift_scale_rotate`(center), and a result of `bboxes_shift_scale_rotate_reflect`(right) proposed in this PR.

![bbox_reflection](https://user-images.githubusercontent.com/9190086/154016516-4affc6e6-7c04-443f-b71f-c98d899e9196.jpeg)

The full runnable code is here:
```py
import numpy as np
import matplotlib.pyplot as plt
from matplotlib.patches import Rectangle
import cv2
import skimage
import albumentations as A

# define helper funcs
def add_bbox(ax, bbox):
    label = 0    
    if len(bbox) > 4:
        bbox, label = bbox[:4], bbox[4]        
    bbox_color = plt.get_cmap("tab10").colors[label]
    x_min, y_min, x_max, y_max = bbox
    w, h = x_max - x_min, y_max - y_min
    pat = Rectangle(xy=(x_min, y_min), width=w, height=h, fill=False, lw=3, color=bbox_color)
    ax.add_patch(pat)

def plot_image_and_bboxes(image, bboxes, ax):
    ax.imshow(image)
    for i in range(len(bboxes)):
        add_bbox(ax, bboxes[i])

def get_shift_scale_rotate_bboxes(bboxes, params):
    bboxes_out = []
    for bbox in bboxes:
        label = []
        if len(bbox) > 4:
            label.append(bbox[4])
        bbox = A.normalize_bbox(bbox, params["rows"], params["cols"])
        bbox = A.bbox_shift_scale_rotate(bbox, **params)
        bbox = A.denormalize_bbox(bbox, params["rows"], params["cols"])
        bboxes_out.append((*bbox, *label))
    return bboxes_out

def get_shift_scale_rotate_reflect_bboxes(bboxes, params):
    bboxes, labels = A.to_ndarray_bboxes(bboxes)
    bboxes = A.normalize_bboxes2(bboxes, params["rows"], params["cols"])
    bboxes = A.bboxes_shift_scale_rotate_reflect(bboxes, **box_params)
    bboxes = A.denormalize_bboxes2(bboxes, params["rows"], params["cols"])
    bboxes = A.to_tuple_bboxes(bboxes, labels)
    return bboxes

# setup
image = skimage.data.astronaut()
rows, cols = image.shape[:2]
bboxes = [[170, 30, 280, 180, 0], [350, 80, 460, 290, 1], [140, 350, 200, 420, 2]]
img_params = dict(angle=45, scale=0.5, dx=0.1, dy=0.2, border_mode=cv2.BORDER_REFLECT)
box_params = img_params.copy()
box_params.update({"rows": rows, "cols": cols})
fig, axes = plt.subplots(1, 3, figsize=(18, 6))

# show original image
axes[0].set_title("original image")
plot_image_and_bboxes(image, bboxes, axes[0])

## shift_scale_rotate
axes[1].set_title("shift_scale_rotate")
print("image transform")
%timeit image_tr = A.shift_scale_rotate(image, **img_params)
print("shift_scale_rotate")
%timeit bboxes_no_reflect = get_shift_scale_rotate_bboxes(bboxes, box_params)
plot_image_and_bboxes(image_tr, bboxes_no_reflect, axes[1])

## shift_scale_rotate_reflect
axes[2].set_title("shift_scale_rotate_reflect")
print("shift_scale_rotate with reflection")
%timeit bboxes_reflect = get_shift_scale_rotate_reflect_bboxes(bboxes, box_params)
plot_image_and_bboxes(image_tr, bboxes_reflect, axes[2])
#plt.savefig("./bbox_reflection.jpg")
```

## About implementation

This implementation is very straightforward.

A summary is here:

1. Generate flipped copies and laid out them around the original image.
2. Apply affine transform to the bboxes, including coped ones.
3. Apply center bbox crop and remove invisible bboxes

```text
        step.1       step.2       step.3

                       q p q
        +-+-+-+      +-+-+-+
        |q|p|q|      | |d|b|d
        +-+-+-+      +-+-+-+       +-+
  b  -> |d|b|d|  ->  | |q|p|q  ->  |q|
        +-+-+-+      +-+-+-+       +-+
        |q|p|q|      | | | |
        +-+-+-+      +-+-+-+
```

This works.
But this is not efficient because this makes many bbox copies that will be removed finally.
I searched for an efficient algorithm for this task, but I could not find it.
Therefore, I decided to continue adopting this method.

To mitigate the disadvantage for the performance, I decided to implement this functionality in the vectorized bboxes.
This is why this PR has some 'bboxes_xyz' functions vectorized versions of existing `bbox_xyz` counterparts.

This PR has many changes, but I tried not to change any existing codes to avoid unintentional problems.

## About performance 

The std output of the above example is here.

```text
image transform
3.39 ms ± 880 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
shift_scale_rotate
155 µs ± 16.8 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
shift_scale_rotate with reflection
385 µs ± 9.66 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

The time of 385 µs is not so bad compared to the img transform result of 3.39ms.
But it is slower than the original `shift_scale_rotate` despite vectorization.
The benefit of vectorization appears as the number of bboxes becomes large.
To see this, I run the following codes:

```py
def get_grid_bboxes(n_grid, bbox_size, rows, cols):
    bboxes = []
    d_y = rows / n_grid
    d_x = cols / n_grid
    for i_y in range(n_grid):
        y_min = (i_y + 0.5) * d_y
        y_max = y_min + bbox_size
        for i_x in range(n_grid):
            x_min = (i_x + 0.5) * d_x
            x_max = x_min + bbox_size            
            bboxes.append([x_min, y_min, x_max, y_max])
    return bboxes

#grid_bboxes = get_grid_bboxes(3, 32, rows, cols)
#fig, ax = plt.subplots(1, 1, figsize=(6, 6))
#plot_image_and_bboxes(image, grid_bboxes, ax)

box_params["border_mode"] = cv2.BORDER_REFLECT_101
#box_params["border_mode"] = cv2.BORDER_CONSTANT

grid_bboxes = get_grid_bboxes(1, 32, rows, cols)
print(f"{len(grid_bboxes)} boxes")
%timeit get_shift_scale_rotate_bboxes(grid_bboxes, box_params)
%timeit get_shift_scale_rotate_reflect_bboxes(grid_bboxes, box_params)

grid_bboxes = get_grid_bboxes(3, 32, rows, cols)
print(f"{len(grid_bboxes)} boxes")
%timeit get_shift_scale_rotate_bboxes(grid_bboxes, box_params)
%timeit get_shift_scale_rotate_reflect_bboxes(grid_bboxes, box_params)

grid_bboxes = get_grid_bboxes(10, 32, rows, cols)
print(f"{len(grid_bboxes)} boxes")
%timeit get_shift_scale_rotate_bboxes(grid_bboxes, box_params)
%timeit get_shift_scale_rotate_reflect_bboxes(grid_bboxes, box_params)
```

The results are here (the parameters are the same as the previous example):

```text
1 boxes
45.3 µs ± 1.01 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
293 µs ± 5.56 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
9 boxes
402 µs ± 7.01 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
418 µs ± 15.3 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
100 boxes
4.48 ms ± 71.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
1.68 ms ± 36.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

The vectorized version surpassed the original one as the number of bboxes increased. Also, note that the number of bboxes processed by the `bboxes_shift_scale_rotate_reflect` is about some times larger than 
the `bbox_shift_scale_rotate` does because `bbox_shift_scale_rotate` does not process any of reflected bboxes.

## Know issues and some notes

I list some known issues and notes that I found through the implementation.

#### 1. Computational cost depends on parameters.

For example, assume to set a very small scale factor, like scale=0.01. In such a case, the number of bbox will be multiplied by 10^4.
This can cause performance issues, so users should be careful about small scale factors.

#### 2. Extra care for tracking the bbox and labels is needed

~~Albumentation allows adding label information as a different target by using `label_fields`.~~
~~Since bbox reflection changes the number of input bboxes, it makes it difficult to track the relation between bbox and label_fields.~~
~~I think some extra care about the `label_fields` is needed to integrate this functionality into albumentation's pipeline.~~

--> The `label_fields` are automatically concatenated to bbox, so we do not need extra work about it.

#### 3. Extra care for mismatches between numpy ndarray and tuple bboxes is needed

Albumentation allows adding label information to the bboxes as an additional element, and the label information can be a string type.
So bbox should be split into pure bbox and label so that the `np.array(bboxes)` does not create `str` ndarray.
To solve this issue, I introduced `to_ndarray_bboxes(bboxes)` and `to_tuple_bboxes(bboxes, labels)` functions.

#### 4. This implementation does not care about the difference between `BORDER_REFLECT` and `BORDER_REFLECT_101`

Since I am not sure that this gives a significant disadvantage for results, this implementation does not care about the difference between `BORDER_REFLECT` and `BORDER_REFLECT_101` to avoid extra complications.
I may need to do something about it, but I don't have any ideas on how to implement BORDER_REFLECT_101 precisely at the moment.

#### 5. A well-established algorithm is wanted

This implementation is easy to understand but it is better if there is a more efficient and established algorithm.
