### PR TITLE
Fix rand, add randn

### DIFF
--- a/albumentations/random_utils.py
+++ b/albumentations/random_utils.py
@@ -29,13 +29,13 @@ def uniform(
 def rand(d0: NumType, d1: NumType, *more, random_state: Optional[np.random.RandomState] = None, **kwargs) -> Any:
     if random_state is None:
         random_state = get_random_state()
-    return random_state.rand(d0, d1, *more, **kwargs)
+    return random_state.rand(d0, d1, *more, **kwargs)  # type: ignore
 
 
 def randn(d0: NumType, d1: NumType, *more, random_state: Optional[np.random.RandomState] = None, **kwargs) -> Any:
     if random_state is None:
         random_state = get_random_state()
-    return random_state.randn(d0, d1, *more, **kwargs)
+    return random_state.randn(d0, d1, *more, **kwargs)  # type: ignore
 
 
 def normal(

--- a/albumentations/random_utils.py
+++ b/albumentations/random_utils.py
@@ -2,7 +2,7 @@
 # because numpy can return single number and ndarray
 
 import random as py_random
-from typing import Optional, Sequence, Union, Type, Any
+from typing import Any, Optional, Sequence, Type, Union
 
 import numpy as np
 
@@ -29,7 +29,13 @@ def uniform(
 def rand(d0: NumType, d1: NumType, *more, random_state: Optional[np.random.RandomState] = None, **kwargs) -> Any:
     if random_state is None:
         random_state = get_random_state()
-    return random_state.randn(d0, d1, *more, **kwargs)  # type: ignore
+    return random_state.rand(d0, d1, *more, **kwargs)
+
+
+def randn(d0: NumType, d1: NumType, *more, random_state: Optional[np.random.RandomState] = None, **kwargs) -> Any:
+    if random_state is None:
+        random_state = get_random_state()
+    return random_state.randn(d0, d1, *more, **kwargs)
 
 
 def normal(

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -16,6 +16,7 @@ def _calc(args):
     [
         [random_utils.uniform, [-(1 << 15), 1 << 15, 100]],
         [random_utils.rand, [10, 10]],
+        [random_utils.randn, [10, 10]],
         [random_utils.normal, [0, 1, 100]],
         [random_utils.poisson, [1 << 15, 100]],
         [random_utils.permutation, [np.arange(1000)]],


### PR DESCRIPTION
This PR fixed rand issue described in #1165 
- Fix `ranom_utils.rand` to use numpy `rand` 
- Add `random_utils.randn` to use numpy `randn`
