### PR TITLE
Rename method to rotate_method in Rotate

### DIFF
--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -62,7 +62,7 @@ class Rotate(DualTransform):
         mask_value (int, float,
                     list of ints,
                     list of float): padding value if border_mode is cv2.BORDER_CONSTANT applied for masks.
-        method (str): rotation method used for the bounding boxes. Should be one of "largest_box" or "ellipse".
+        rotate_method (str): rotation method used for the bounding boxes. Should be one of "largest_box" or "ellipse".
             Default: "largest_box"
         crop_border (bool): If True would make a largest possible crop within rotated image
         p (float): probability of applying the transform. Default: 0.5.
@@ -81,7 +81,7 @@ class Rotate(DualTransform):
         border_mode=cv2.BORDER_REFLECT_101,
         value=None,
         mask_value=None,
-        method="largest_box",
+        rotate_method="largest_box",
         crop_border=False,
         always_apply=False,
         p=0.5,
@@ -92,11 +92,11 @@ class Rotate(DualTransform):
         self.border_mode = border_mode
         self.value = value
         self.mask_value = mask_value
-        self.method = method
+        self.rotate_method = rotate_method
         self.crop_border = crop_border
 
-        if method not in ["largest_box", "ellipse"]:
-            raise ValueError(f"Rotation method {self.method} is not valid.")
+        if rotate_method not in ["largest_box", "ellipse"]:
+            raise ValueError(f"Rotation method {self.rotate_method} is not valid.")
 
     def apply(
         self, img, angle=0, interpolation=cv2.INTER_LINEAR, x_min=None, x_max=None, y_min=None, y_max=None, **params
@@ -113,7 +113,7 @@ class Rotate(DualTransform):
         return img_out
 
     def apply_to_bbox(self, bbox, angle=0, x_min=None, x_max=None, y_min=None, y_max=None, cols=0, rows=0, **params):
-        bbox_out = F.bbox_rotate(bbox, angle, self.method, rows, cols)
+        bbox_out = F.bbox_rotate(bbox, angle, self.rotate_method, rows, cols)
         if self.crop_border:
             bbox_out = FCrops.bbox_crop(bbox_out, x_min, y_min, x_max, y_max, rows, cols)
         return bbox_out
@@ -172,7 +172,7 @@ class Rotate(DualTransform):
         return out_params
 
     def get_transform_init_args_names(self):
-        return ("limit", "interpolation", "border_mode", "value", "mask_value", "method", "crop_border")
+        return ("limit", "interpolation", "border_mode", "value", "mask_value", "rotate_method", "crop_border")
 
 
 class SafeRotate(DualTransform):


### PR DESCRIPTION
Fixes #1239
We added the ability to select `rotate_method` for `Rotate` and `ShiftScaleRotate` after #1203 
This changes were released in the previous version of the library. Because previous version was minor and I do not think many people used this feature, I suggest using the same name for this param in both transforms to keep consistency,