### PR TITLE
Update transforms.py

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -396,7 +396,7 @@ class RandomRain(ImageOnlyTransform):
         drop_color (list of (r, g, b)): rain lines color.
         blur_value (int): rainy view are blurry
         brightness_coefficient (float): rainy days are usually shady. Should be in range [0, 1].
-        rain_type: One of [None, "drizzle", "heavy", "torrestial"]
+        rain_type: One of [None, "drizzle", "heavy", "torrential"]
 
     Targets:
         image


### PR DESCRIPTION
docs of random rain gives suggests rain_type "torrestial" which has a typo. Corrected to be torrential