### PR TITLE
Issue #1263 Support for float p in InvertImg

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1549,8 +1549,15 @@ class InvertImg(ImageOnlyTransform):
         uint8
     """
 
+    def __init__(self, always_apply=False, p=0.1):
+        super(InvertImg, self).__init__(always_apply, p)
+        self.p: float = p
+
     def apply(self, img, **params):
-        return F.invert(img)
+        if random.random() < self.p:
+            return F.invert(img)
+        else:
+            return img
 
     def get_transform_init_args_names(self):
         return ()

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -298,6 +298,7 @@ def test_force_apply():
             A.TemplateTransform: {
                 "templates": np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8),
             },
+            A.InvertImg: {"p": 0},
         },
     ),
 )


### PR DESCRIPTION
Added support for `float p` in InvertImg in albumentations/augmentations/transforms.py. It defines the probability that InvertImg performs the inversion operation. By default `p = 0.5`.
The testing function `test_additional_targets_for_image_only()` had to be changed accordingly in order to pass. So it is tested by passing `p=0` and checking that the image is unchanged.
May be worth adding a specific testing function for InvertImg that tests for example that inverting twice returns the original image.