### PR TITLE
Fix RandomSunFlare circles' color

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -695,8 +695,8 @@ class RandomSunFlare(ImageOnlyTransform):
             rad = random.randint(1, max(height // 100 - 2, 2))
 
             r_color = random.randint(max(self.src_color[0] - 50, 0), self.src_color[0])
-            g_color = random.randint(max(self.src_color[0] - 50, 0), self.src_color[0])
-            b_color = random.randint(max(self.src_color[0] - 50, 0), self.src_color[0])
+            g_color = random.randint(max(self.src_color[1] - 50, 0), self.src_color[1])
+            b_color = random.randint(max(self.src_color[2] - 50, 0), self.src_color[2])
 
             circles += [
                 (


### PR DESCRIPTION
The random RGB colors generated for the circles in the  `RandomSunFlare`'s `get_params_dependent_on_targets` method are only using the red component of the `src_color`. I modified this to use all 3 values given by the user instead.