### PR TITLE
Fix deprecated imports of scipy.ndimage.gaussian_filter

### DIFF
--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Sequence, Tuple, Union
 import cv2
 import numpy as np
 import skimage.transform
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 
 from albumentations.augmentations.utils import (
     _maybe_process_in_chunks,

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 import cv2
 import numpy as np
 from scipy import special
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 
 from albumentations import random_utils
 from albumentations.augmentations.blur.functional import blur

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import re
 from pkg_resources import DistributionNotFound, get_distribution
 from setuptools import find_packages, setup
 
-INSTALL_REQUIRES = ["numpy>=1.11.1", "scipy", "scikit-image>=0.16.1", "PyYAML", "qudida>=0.0.4"]
+INSTALL_REQUIRES = ["numpy>=1.11.1", "scipy>=1.1.0", "scikit-image>=0.16.1", "PyYAML", "qudida>=0.0.4"]
 
 # If none of packages in first installed, install second package
 CHOOSE_INSTALL_REQUIRES = [


### PR DESCRIPTION
scipy deprecated the use of the `ndimage.filters` submodule in v1.8.0 and plans to remove the compatibility import in v2.0.0 The filters were availalble in the `ndimage` module going back at least to 2012, and I tested the import on scipy==1.1.0.

Fixes the following error:
```
$ python -W always -c "import albumentations.augmentations.transforms" albumentations/albumentations/augmentations/geometric/functional.py:7: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
  from scipy.ndimage.filters import gaussian_filter
```