### PR TITLE
Fix misleading docstrings in transforms.py

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -222,7 +222,7 @@ class Normalize(ImageOnlyTransform):
 
 
 class ImageCompression(ImageOnlyTransform):
-    """Decrease Jpeg, WebP compression of an image.
+    """Decreases image quality by Jpeg, WebP compression of an image.
 
     Args:
         quality_lower (float): lower bound on the image quality.
@@ -292,7 +292,7 @@ class ImageCompression(ImageOnlyTransform):
 
 
 class JpegCompression(ImageCompression):
-    """Decrease Jpeg compression of an image.
+    """Decreases image quality by Jpeg, WebP compression of an image.
 
     Args:
         quality_lower (float): lower bound on the jpeg quality. Should be in [0, 100] range

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -292,7 +292,7 @@ class ImageCompression(ImageOnlyTransform):
 
 
 class JpegCompression(ImageCompression):
-    """Decreases image quality by Jpeg, WebP compression of an image.
+    """Decreases image quality by Jpeg compression of an image.
 
     Args:
         quality_lower (float): lower bound on the jpeg quality. Should be in [0, 100] range


### PR DESCRIPTION
Jpeg Compression uses cv2.imencode and cv2.imdecode to get a compressed version of the image. It compresses the image and decreases the image quality.

However, the docstrings of the related methods are misleading: "Decrease Jpeg compression of an image."

This implies that an active decrease in quality is recovered by this method.