### PR TITLE
Type area as float instead of int

### DIFF
--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -215,8 +215,8 @@ def denormalize_bboxes(bboxes: Sequence[BoxType], rows: int, cols: int) -> List[
     return [denormalize_bbox(bbox, rows, cols) for bbox in bboxes]
 
 
-def calculate_bbox_area(bbox: BoxType, rows: int, cols: int) -> int:
-    """Calculate the area of a bounding box in pixels.
+def calculate_bbox_area(bbox: BoxType, rows: int, cols: int) -> float:
+    """Calculate the area of a bounding box in (fractional) pixels.
 
     Args:
         bbox: A bounding box `(x_min, y_min, x_max, y_max)`.
@@ -224,13 +224,13 @@ def calculate_bbox_area(bbox: BoxType, rows: int, cols: int) -> int:
         cols: Image width.
 
     Return:
-        Area of a bounding box in pixels.
+        Area in (fractional) pixels of the (denormalized) bounding box.
 
     """
     bbox = denormalize_bbox(bbox, rows, cols)
     x_min, y_min, x_max, y_max = bbox[:4]
     area = (x_max - x_min) * (y_max - y_min)
-    return cast(int, area)
+    return area
 
 
 def filter_bboxes_by_visibility(


### PR DESCRIPTION
Bounding boxes are collections of floats, see https://github.com/albumentations-team/albumentations/blob/3904898e3bfe476137a75cad6ae3d1015e3d468e/albumentations/core/transforms_interface.py#L29

[Denormalizing](https://github.com/albumentations-team/albumentations/blob/3904898e3bfe476137a75cad6ae3d1015e3d468e/albumentations/core/bbox_utils.py#L127) does not (and should not) convert anything to `int`. The resulting `x_min`, `y_min`, `x_max`, `y_max` are not `int` and almost never whole numbers. Therefore, the value returned from [`calculate_bbox_area`](https://github.com/albumentations-team/albumentations/blob/3904898e3bfe476137a75cad6ae3d1015e3d468e/albumentations/core/bbox_utils.py#L218) will almost never be a whole number.

In all cases, the type of the value returned by [`calculate_bbox_area`](https://github.com/albumentations-team/albumentations/blob/3904898e3bfe476137a75cad6ae3d1015e3d468e/albumentations/core/bbox_utils.py#L218) will be `float`.