### PR TITLE
fix RandomFog infinite loop

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -566,8 +566,8 @@ class RandomFog(ImageOnlyTransform):
                 y = random.randint(midy, height - midy - hw)
                 haze_list.append((x, y))
 
-            midx -= 3 * hw * width // sum(imshape)
-            midy -= 3 * hw * height // sum(imshape)
+            midx -= 3 * hw * max(1, width // sum(imshape))
+            midy -= 3 * hw * max(1, height // sum(imshape))
             index += 1
 
         return {"haze_list": haze_list, "fog_coef": fog_coef}


### PR DESCRIPTION
### Where's the bug?
```
while midx > -hw or midy > -hw:
    for _i in range(hw // 10 * index):
        x = random.randint(midx, width - midx - hw)
        y = random.randint(midy, height - midy - hw)
        haze_list.append((x, y))

    midx -= 3 * hw * width // sum(imshape)
    midy -= 3 * hw * height // sum(imshape)
    index += 1
```

This while loop is supposed to end when _midy_ drops below a certain value. But in some cases _height // sum(imshape)_ can be 0, which means _midy_ won't get any smaller from there, resulting in an infinite loop.
Note that _hw_ is always a positive integer thus the change in _midy_ becomes 0 if and only if _height // sum(imshape)_ equals 0.

The same applies to _midx_, so both lines should be changed.


### How to reproduce?
Run the code below and it will almost surely fall into an infinite loop.
```
from PIL import Image
import albumentations as A
import numpy as np

img = Image.new("RGB", (32, 95), "white")
img = np.array(img)
for _ in range(20):
    A.RandomFog(0.13814, 0.13814, 0.6, p=1.0)(image=img)
```

### Additional comments
As far as I can see, a similar issue was reported and a fix was merged about 3 years ago. (#361 )
However the infinite loop still occurs under certain conditions and requires an additional change; therefore this PR.