### PR TITLE
Prevent int overflow in opencv code by clipping python values.

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -686,7 +686,7 @@ class RandomSunFlare(ImageOnlyTransform):
         y = []
 
         for rand_x in range(0, width, 10):
-            rand_y = math.tan(angle) * (rand_x - flare_center_x) + flare_center_y
+            rand_y = max(min(math.tan(angle) * (rand_x - flare_center_x) + flare_center_y, height*10), -height*10)
             x.append(rand_x)
             y.append(2 * flare_center_y - rand_y)
 


### PR DESCRIPTION
Fixes #1072 by adding a min/max to the tan(angle) call to prevent y from taking near infinite values.