### PR TITLE
[bugfix] random.choice error with python3.11 (blur/transforms.py, ver…

### DIFF
--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -41,7 +41,7 @@ class Blur(ImageOnlyTransform):
         return F.blur(img, ksize)
 
     def get_params(self) -> Dict[str, Any]:
-        return {"ksize": int(random.choice(np.arange(self.blur_limit[0], self.blur_limit[1] + 1, 2)))}
+        return {"ksize": int(random.choice(np.arange(self.blur_limit[0], self.blur_limit[1] + 1, 2).tolist()))}
 
     def get_transform_init_args_names(self) -> Tuple[str, ...]:
         return ("blur_limit",)

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -84,7 +84,7 @@ class MotionBlur(Blur):
         return FMain.convolve(img, kernel=kernel)
 
     def get_params(self) -> Dict[str, Any]:
-        ksize = random.choice(np.arange(self.blur_limit[0], self.blur_limit[1] + 1, 2))
+        ksize = random.choice(np.arange(self.blur_limit[0], self.blur_limit[1] + 1, 2).tolist())
         if ksize <= 2:
             raise ValueError("ksize must be > 2. Got: {}".format(ksize))
         kernel = np.zeros((ksize, ksize), dtype=np.uint8)


### PR DESCRIPTION
…sion on 1.3.0)

  err info:ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
  fix with array.tolist()