### PR TITLE
Return Rotation Angle when Applying the Augmentation on Images.

### DIFF
--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -110,7 +110,7 @@ class Rotate(DualTransform):
         img_out = F.rotate(img, angle, interpolation, self.border_mode, self.value)
         if self.crop_border:
             img_out = FCrops.crop(img_out, x_min, y_min, x_max, y_max)
-        return img_out
+        return {"image":img_out, "angle":angle}
 
     def apply_to_mask(self, img, angle=0, x_min=None, x_max=None, y_min=None, y_max=None, **params):
         img_out = F.rotate(img, angle, cv2.INTER_NEAREST, self.border_mode, self.mask_value)


### PR DESCRIPTION
Hi, I have noticed that when we are applying rotation on images as follows, it does not return the angle at which albumentations has rotated the image, this angle is needed in various circumstances where albumentations might be used.

```python
import os
import sys
import pandas as pd
from PIL import Image
from albumentations.augmentations.geometric import Rotate
import numpy as np

img = Image.open("/home/muneeb/RotNet/db/0ac68e4c-4a3e-4f97-a4f3-a61614cbecd1.jpg")
image = np.asarray(img)
limit=10
interpolation=1
border_mode=1
value=None
mask_value=None

transform = Rotate(limit, interpolation, border_mode, value, mask_value, p=1.0)
augmented_image = transform(image=image)['image']
# PIL Show Image
print(augmented_image)
```

## Current Behaviour

It returns a dict as follows,

```json
{"image":img_out}
```

## Proposed Behaviour

```json
{"image":img_out, "angle":angle}
```

**This is a non-breaking change, and hence must be included, as it is a must have for many applications where albumnations might be used.**