### PR TITLE
Added rotate_method in Affine

### DIFF
--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -531,7 +531,8 @@ class Affine(DualTransform):
             after applying rotations. Default: False
         keep_ratio (bool): When True, the original aspect ratio will be kept when the random scale is applied.
                            Default: False.
-        rotate_method (str): rotation method used for the bounding boxes. Should be one of "largest_box" or "ellipse".
+        rotate_method (str): rotation method used for the bounding boxes. Should be one of "largest_box" or
+            "ellipse"[1].
             Default: "largest_box"
         p (float): probability of applying the transform. Default: 0.5.
 
@@ -541,6 +542,8 @@ class Affine(DualTransform):
     Image types:
         uint8, float32
 
+    Reference:
+        [1] https://arxiv.org/abs/2109.13488
     """
 
     def __init__(

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -531,6 +531,8 @@ class Affine(DualTransform):
             after applying rotations. Default: False
         keep_ratio (bool): When True, the original aspect ratio will be kept when the random scale is applied.
                            Default: False.
+        rotate_method (str): rotation method used for the bounding boxes. Should be one of "largest_box" or "ellipse".
+            Default: "largest_box"
         p (float): probability of applying the transform. Default: 0.5.
 
     Targets:
@@ -555,6 +557,7 @@ class Affine(DualTransform):
         mode: int = cv2.BORDER_CONSTANT,
         fit_output: bool = False,
         keep_ratio: bool = False,
+        rotate_method: str = "largest_box",
         always_apply: bool = False,
         p: float = 0.5,
     ):
@@ -582,6 +585,7 @@ class Affine(DualTransform):
         self.fit_output = fit_output
         self.shear = self._handle_dict_arg(shear, "shear")
         self.keep_ratio = keep_ratio
+        self.rotate_method = rotate_method
 
         if self.keep_ratio and self.scale["x"] != self.scale["y"]:
             raise ValueError(
@@ -602,6 +606,7 @@ class Affine(DualTransform):
             "shear",
             "cval_mask",
             "keep_ratio",
+            "rotate_method",
         )
 
     @staticmethod
@@ -680,7 +685,7 @@ class Affine(DualTransform):
         output_shape: Sequence[int] = (),
         **params
     ) -> BoxInternalType:
-        return F.bbox_affine(bbox, matrix, rows, cols, output_shape)
+        return F.bbox_affine(bbox, matrix, self.rotate_method, rows, cols, output_shape)
 
     def apply_to_keypoint(
         self,


### PR DESCRIPTION
This PR try to add rotate_method="ellipse" in the Affine transform.

close #1316
related issues #1388, #1373

## Abount the implementation

As for the affine transform, we need to consider not only the rotation but also the effect of other parameters, such as the shear that also introduces additional space between the object and the bounding boxes.
Ex.

![bbox_shear](https://user-images.githubusercontent.com/9190086/216827811-f8798ff3-cec2-47f4-9748-92e890e68c17.jpg)

Fortunately, a generalization looks to be straightforward.
The ellipse rotation assumes the object's shape is an ellipse and applies the rotation to the ellipse instead of the bbox, then reconstructs the rotated bbox from the rotated ellipse.
I think the same idea can be applied to the generic affine transform:

- Assume the object shape as the ellipse.
- Apply the affine transform to the ellipse.
- Get the bbox from the transformed ellipse.

I have not analyzed as the original author of the ellipse rotation did, but I expect this generalized version to work.
See the example below.

## Example

```py
import numpy as np
import matplotlib.pyplot as plt
from matplotlib.patches import Rectangle
import cv2
import albumentations as A

def visualize(ax, img, bboxes, grid=False):
    box_colors = ["grey", "black"]
    cmap = plt.cm.get_cmap("tab10")
    ax.imshow(img)
    for i, bbox in enumerate(bboxes):
        ax.add_patch(Rectangle(bbox[:2], bbox[2], bbox[3], fill=False, lw=2, color=box_colors[i]))
    ax.grid(grid)
    return ax

def get_data():    
    ## prepare sample image and bbox
    img = np.full((300, 300, 3), 255, dtype=np.uint8)
    cx, cy = (150, 150)
    rx = 50
    ry = 100
    cv2.rectangle(img, (cx-rx, cy-ry), (cx+rx, cy+ry), (255, 127, 127), -1)
    cv2.ellipse(img, (cx, cy), (rx, ry), 0, 0, 360, (127, 255, 127), -1)
    bboxes = [[cx-rx, cy-ry, 2 * rx, 2 * ry, "label"]]
    return img, bboxes

def get_affine_aug(rot=0, shear=(0, 0), rotate_method="largest_box"):
    shear_x, shear_y = shear
    aug = A.Compose([
        A.Affine(
            p=1, 
            scale=1,
            translate_percent=0,
            rotate=rot,
            shear={"x": (shear_x, shear_x), "y": (shear_y, shear_y)},
            rotate_method=rotate_method,
            mode=cv2.BORDER_CONSTANT,
            cval=(255, 255, 255)
        ),
    ], bbox_params=A.BboxParams(format='coco'))
    return aug

fig, axes = plt.subplots(1, 2, figsize=(10, 5), sharey=True)    

img, bboxes = get_data()
visualize(axes[0], img, bboxes)
aug1 = get_affine_aug(rot=15, shear=(50, 0), rotate_method="largest_box")
aug2 = get_affine_aug(rot=15, shear=(50, 0), rotate_method="ellipse")

data1 = aug1(image=img, bboxes=bboxes)
data2 = aug2(image=img, bboxes=bboxes)

img1 = data1["image"]
bboxes1 = data1["bboxes"]
bboxes2 = data2["bboxes"]

visualize(axes[1], img1, bboxes1 + bboxes2)
fig.savefig("./affine_ellipse.jpg", bbox_inches="tight")
```
![affine_ellipse](https://user-images.githubusercontent.com/9190086/216827894-b8319f34-2ab6-422a-aad8-471848a1b963.jpg)

Black bbox is a result of a generalized ellipse rotation. It looks much better than the gray box (largest_box).
