### PR TITLE
Fixed deprecationwarning in sepia transform

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1575,7 +1575,7 @@ class ToSepia(ImageOnlyTransform):
 
     def __init__(self, always_apply=False, p=0.5):
         super(ToSepia, self).__init__(always_apply, p)
-        self.sepia_transformation_matrix = np.matrix(
+        self.sepia_transformation_matrix = np.array(
             [[0.393, 0.769, 0.189], [0.349, 0.686, 0.168], [0.272, 0.534, 0.131]]
         )
 


### PR DESCRIPTION
ToSepia raisies a deprecation warning due to np.matrix being phased out. This PR will update np.matrix to np.array causing no functional change in the library but with the warning gone.