### PR TITLE
Fix docstring for ToTensorV2

### DIFF
--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -65,9 +65,11 @@ class ToTensorV2(BasicTransform):
     instead).
 
     Args:
-        transpose_mask (bool): if True and an input mask has three dimensions, this transform will transpose dimensions
-        so the shape `[height, width, num_channels]` becomes `[num_channels, height, width]`. The latter format is a
-        standard format for PyTorch Tensors. Default: False.
+        transpose_mask (bool): If True and an input mask has three dimensions, this transform will transpose dimensions
+            so the shape `[height, width, num_channels]` becomes `[num_channels, height, width]`. The latter format is a
+            standard format for PyTorch Tensors. Default: False.
+        always_apply (bool): Indicates whether this transformation should be always applied. Default: True.
+        p (float): Probability of applying the transform. Default: 1.0.
     """
 
     def __init__(self, transpose_mask=False, always_apply=True, p=1.0):


### PR DESCRIPTION
The current [ToTensorV2](https://albumentations.ai/docs/api_reference/pytorch/transforms/#albumentations.pytorch.transforms.ToTensorV2) documentation has broken and missing parameters. 
Corrected the docstring format for ToTensorV2 class.