### PR TITLE
Added MixUp augmentation

### DIFF
--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -34,7 +34,7 @@ __all__ = [
     "OpticalDistortion",
     "GridDistortion",
     "PadIfNeeded",
-    "Mixup"
+    "MixUp"
 ]
 
 

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -1494,7 +1494,7 @@ class GridDistortion(DualTransform):
         return "num_steps", "distort_limit", "interpolation", "border_mode", "value", "mask_value", "normalized"
 
 
-class MixUp2(DualTransform):
+class MixUp(DualTransform):
     """Generates a weighted combination of the pair of input images.
 
     Targets:

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -1508,25 +1508,24 @@ class MixUp(DualTransform):
         always_apply: bool = False,
         p: float = 1,
     ):
-        super(MixUp2, self).__init__(always_apply, p)
+        super(MixUp, self).__init__(always_apply, p)
 
-    def apply(self, image, image_l, **params) -> np.ndarray:
-        h1, w1, _ = image_l[0].shape
-        h2, w2, _ = image_l[0].shape
+    def apply(self, image, image1, **params) -> np.ndarray:
+        h1, w1, _ = image.shape
+        h2, w2, _ = image1.shape
         if h1 != h2 or w1 != w2:
             raise TypeError("MixUp transformation expects both images to have identical shape.")
         r = np.random.beta(32.0, 32.0)  # mixup ratio, alpha=beta=32.0
-        im = (image_l[0] * r + image_l[1] * (1 - r)).astype(np.uint8)
+        im = (image * r + image1 * (1 - r)).astype(np.uint8)
         return im
     
-    def apply_to_bboxes(self, bboxes: Sequence[BoxType], bboxes_l, **params) -> List[BoxType]:
-        bboxes_l = sum(bboxes_l, [])  # 2D bbox list to 1D
-        return bboxes_l 
+    def apply_to_bboxes(self, bboxes: Sequence[BoxType], bboxes1, **params) -> List[BoxType]:
+        return bboxes + bboxes1
 
     def get_params_dependent_on_targets(self, params: Dict[str, Any]) -> Dict[str, Any]:
         return {
-            "image_l": [params['image'], params['image1']], 
-            "bboxes_l": [params['bboxes'], params['bboxes1']]
+            "image1": params['image1'], 
+            "bboxes1": params['bboxes1']
         }
     
     @property

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -1512,8 +1512,8 @@ class MixUp(DualTransform):
 
     def __init__(
         self,
-        alpha = 32,
-        beta = 32,
+        alpha = 32.,
+        beta = 32.,
         always_apply: bool = False,
         p: float = 1,
     ):
@@ -1521,18 +1521,18 @@ class MixUp(DualTransform):
         self.alpha = alpha
         self.beta = beta
 
-    def apply(self, image, image1, r, **params) -> np.ndarray:
+    def apply(self, image: np.ndarray, image1: np.ndarray, r, **params) -> np.ndarray:
         h1, w1, _ = image.shape
         h2, w2, _ = image1.shape
         if h1 != h2 or w1 != w2:
             raise TypeError("MixUp transformation expects both images to have identical shape.")
-        im = (image * r + image1 * (1 - r)).astype(np.uint8)
+        im = (image * r + image1 * (1 - r))
         return im
     
     def get_params(self):
         return {"r": np.random.beta(self.alpha, self.beta)}  # draw samples from a Beta distribution.
     
-    def apply_to_bboxes(self, bboxes: Sequence[BoxType], bboxes1, **params) -> List[BoxType]:
+    def apply_to_bboxes(self, bboxes: Sequence[BoxType], bboxes1: Sequence[BoxType], **params) -> List[BoxType]:
         return bboxes + bboxes1
 
     def get_params_dependent_on_targets(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -1544,4 +1544,3 @@ class MixUp(DualTransform):
     @property
     def targets_as_params(self) -> List[str]:
         return ["image", "image1", "bboxes", "bboxes1"]
-


### PR DESCRIPTION
In this PR, I implemented MixUp (https://arxiv.org/pdf/1710.09412v2.pdf)
I appreciate any comment and suggetsion.

## Usage:

```python
import cv2
import numpy as np
import albumentations as A
from matplotlib import pyplot as plt


imgsz=640

# helper func
def draw_bboxes_on_img(img, bboxes):
    for bbox in bboxes:
        # top left
        x1 = bbox[0]
        y1 = bbox[1]
        # bottom right
        x2 = bbox[0] + bbox[2]
        y2 = bbox[1] + bbox[3]
        c1 = (int(x1), int(y1))
        c2 = (int(x2), int(y2))
        cv2.rectangle(img, c1, c2, (0, 0, 255), 1)

# images have to be of the same size, hence the resizing
image0 = cv2.imread('./images/train2017/000000000139.jpg')
image1 = cv2.imread('./images/train2017/000000000285.jpg')

# define some bogus bboxes
bboxes0 = [[0, 40, 80, 80, '0'], [0, 80, 160, 160, '1']]
bboxes1 = [[0, 160 , 320, 320, '2']]

# PIPELINE FOR GENERATING EQUALLY SIZED IMAGES
transform1 = A.Compose(
    [
        # https://albumentations.ai/docs/api_reference/augmentations/geometric/resize/#albumentations.augmentations.geometric.resize.LongestMaxSize
        A.geometric.resize.LongestMaxSize(imgsz),
        # https://albumentations.ai/docs/api_reference/augmentations/geometric/transforms/#albumentations.augmentations.geometric.transforms.PadIfNeeded
        A.geometric.transforms.PadIfNeeded(imgsz, imgsz, border_mode=0, value=(114, 114, 114)),
    ],
    bbox_params=A.BboxParams(format='coco', min_area=20),
)

# MIXUP ONLY AUGMENTAION
transform2 = A.Compose(
    [
        MixUp(
            alpha=32,
            beta=32
        )
    ],
    bbox_params=A.BboxParams(format='coco', min_area=20),
)

# Get equaly sized images without breaking the aspect ratio
transformed = transform1(
    image=image0,
    bboxes=bboxes0,
)

image0_transformed = transformed['image']
bboxe0_transformed = transformed['bboxes']

transformed = transform1(
    image=image1,
    bboxes=bboxes1,
)

image1_transformed = transformed['image']
bboxe1_transformed = transformed['bboxes']

draw_bboxes_on_img(image0_transformed, bboxe0_transformed)
draw_bboxes_on_img(image1_transformed, bboxe1_transformed)
cv2.imwrite('image0_transformed.jpg', image0_transformed)
cv2.imwrite('image1_transformed.jpg', image1_transformed)

# Input the results for the two images into MixUp
transformed = transform2(
    image=image0_transformed,
    image1=image1_transformed,
    bboxes=bboxe0_transformed,
    bboxes1=bboxe1_transformed,
)

image2_transformed = transformed['image']
bboxe2_transformed = transformed['bboxes']

draw_bboxes_on_img(image2_transformed, bboxe2_transformed)
cv2.imwrite('image_transformed.jpg', image2_transformed)
```

## Input images:

<img src="https://user-images.githubusercontent.com/18719680/220975802-84182d1f-4321-44a9-8b77-486c0b3f2e29.jpg" width="400">    <img src="https://user-images.githubusercontent.com/18719680/220975809-dd3d7d62-62af-4469-966a-88474dd583cc.jpg" width="400">

## Results:

<img src="https://user-images.githubusercontent.com/18719680/220975860-013da334-49a3-4317-a233-0de71eb86b95.jpg" width="400">   <img src="https://user-images.githubusercontent.com/18719680/222373989-bdf77acc-cdbf-47f1-a7db-f5b0df6835d7.png" width="400">

## Notes

Notice the images have to be of the same size for this augmentation to work. That is the reason for having the helper augmentation pipeline with `LongestMaxSize` and `PadIfNeeded`. MixUp works fine together with [mosaic](https://github.com/albumentations-team/albumentations/pull/1147) The image size is asserted within the **MixUp** augmentation and raise a `TypeError` exception if the images aren't of the same size