### PR TITLE
Fix bug with random.choice and an ndarray

### DIFF
--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -41,7 +41,7 @@ class Blur(ImageOnlyTransform):
         return F.blur(img, ksize)
 
     def get_params(self) -> Dict[str, Any]:
-        return {"ksize": int(random.choice(np.arange(self.blur_limit[0], self.blur_limit[1] + 1, 2)))}
+        return {"ksize": int(random.choice(list(range(self.blur_limit[0], self.blur_limit[1] + 1, 2))))}
 
     def get_transform_init_args_names(self) -> Tuple[str, ...]:
         return ("blur_limit",)
@@ -84,7 +84,7 @@ class MotionBlur(Blur):
         return FMain.convolve(img, kernel=kernel)
 
     def get_params(self) -> Dict[str, Any]:
-        ksize = random.choice(np.arange(self.blur_limit[0], self.blur_limit[1] + 1, 2))
+        ksize = random.choice(list(range(self.blur_limit[0], self.blur_limit[1] + 1, 2)))
         if ksize <= 2:
             raise ValueError("ksize must be > 2. Got: {}".format(ksize))
         kernel = np.zeros((ksize, ksize), dtype=np.uint8)


### PR DESCRIPTION
I'm hitting an error I'm assuming is due to a change in Python3.11 or perhaps a numpy change

I'm hitting:

```
  File "/home/joncrall/code/albumentations/albumentations/core/transforms_interface.py", line 102, in __call__
    params = self.get_params()
             ^^^^^^^^^^^^^^^^^

  File "/home/joncrall/code/albumentations/albumentations/augmentations/blur/transforms.py", line 44, in get_params
    return {"ksize": int(random.choice(np.arange(self.blur_limit[0], self.blur_limit[1] + 1, 2)))}
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/joncrall/.pyenv/versions/3.11.0/lib/python3.11/random.py", line 369, in choice
    if not seq:

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

I changed the numpy arrays to Python lists and that resolves the issue. 
