### PR TITLE
Call `random.random` at the last in the `if` condition of `BasicTransform`

### DIFF
--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -98,7 +98,7 @@ class BasicTransform(Serializable):
 
             return kwargs
 
-        if (random.random() < self.p) or self.always_apply or force_apply:
+        if force_apply or self.always_apply or (random.random() < self.p):
             params = self.get_params()
 
             if self.targets_as_params:


### PR DESCRIPTION
The order of the `if` condition is reordered so that the local variable is accessed first, then the instance variable, and finally call to the `random` module is made. Since or can stop evaluating when the first statement evaluated `True` is found, it makes the statement efficient.