### PR TITLE
Eliminate the possibility of the perspective transform collapsing

### DIFF
--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -341,7 +341,7 @@ class Perspective(DualTransform):
 
         scale = random_utils.uniform(*self.scale)
         points = random_utils.normal(0, scale, [4, 2])
-        points = np.mod(np.abs(points), 1)
+        points = np.mod(np.abs(points), 0.32)
 
         # top left -- no changes needed, just use jitter
         # top right


### PR DESCRIPTION
Prior to this change, while the perspective transform could collapse at any selection of the `scale` parameter, it was especially more prevelant for higher values of `scale`. Specifically, the randomly generated transformation polygon had a non-zero chance of being concave, which led to collapsed perspective transformations.

A more refined (and easier to understand) solution requires the implementation of "Concave Polygon Recoverer" like in imgaug. That being said, simply restricting the randomly generated `points` values to the range [0, 1/3] ensures geometrically that the generated polygon will be convex, hence resulting in a valid (uncollapsed) perspective transformation.

In the code, I set the upper limit at 0.32 instead of 1/3, to avoid any potential numerical issues (due to near-concave polygons), with the same motivation behind the piece of code ensuring that `min_height` and `min_width` are over 2.0, shortly following the polygon generation.

Fixes #1001