### PR TITLE
Return applied alpha for MixUp

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
       - id: codespell
         additional_dependencies: ["tomli"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: mypy
         files: ^albumentations/

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -37,6 +37,7 @@ class MixUp(ReferenceBasedTransform):
                 - The returned dictionary must include an 'image' key with a numpy array value.
                 - It may also include 'mask', 'global_label' each associated with numpy array values.
             Defaults to a function that assumes input dictionary contains numpy arrays and directly returns it.
+        mix_coef_return_name (str): With this name will be returned applied alpha coefficient.
         alpha (float):
             The alpha parameter for the Beta distribution, influencing the mix's balance. Must be ≥ 0.
             Higher values lead to more uniform mixing. Defaults to 0.4.
@@ -65,10 +66,12 @@ class MixUp(ReferenceBasedTransform):
         reference_data: Optional[Union[Generator[ReferenceImage, None, None], Sequence[Any]]] = None,
         read_fn: Callable[[ReferenceImage], Any] = lambda x: {"image": x, "mask": None, "class_label": None},
         alpha: float = 0.4,
+        mix_coef_return_name: str = "mix_coef",
         always_apply: bool = False,
         p: float = 0.5,
     ):
         super().__init__(always_apply, p)
+        self.mix_coef_return_name = mix_coef_return_name
 
         if alpha < 0:
             msg = "Alpha must be >= 0."
@@ -151,3 +154,9 @@ class MixUp(ReferenceBasedTransform):
         # If mix_data is not None, calculate mix_coef and apply read_fn
         mix_coef = beta(self.alpha, self.alpha)  # Assuming beta is defined elsewhere
         return {"mix_data": self.read_fn(mix_data), "mix_coef": mix_coef}
+
+    def apply_with_params(self, params: Dict[str, Any], *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        res = super().apply_with_params(params, *args, **kwargs)
+        if self.mix_coef_return_name:
+            res[self.mix_coef_return_name] = params["mix_coef"]
+        return res

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -37,7 +37,8 @@ class MixUp(ReferenceBasedTransform):
                 - The returned dictionary must include an 'image' key with a numpy array value.
                 - It may also include 'mask', 'global_label' each associated with numpy array values.
             Defaults to a function that assumes input dictionary contains numpy arrays and directly returns it.
-        mix_coef_return_name (str): With this name will be returned applied alpha coefficient.
+         mix_coef_return_name (str): Name used for the applied alpha coefficient in the returned dictionary.
+            Defaults to "mix_coef".
         alpha (float):
             The alpha parameter for the Beta distribution, influencing the mix's balance. Must be ≥ 0.
             Higher values lead to more uniform mixing. Defaults to 0.4.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 deepdiff>=6.7.1
-mypy>=1.8.0
+mypy>=1.9.0
 pre_commit>=3.5.0
 pytest>=8.0.2
 pytest_cov>=4.1.0


### PR DESCRIPTION
Example:
```python
import albumentations as A
import numpy as np
from albumentations.core.types import ReferenceImage

reference_data = [ReferenceImage(image=np.empty([100, 100, 3], dtype=np.uint8)) for i in range(10)]
augmentation_cls = A.RandomRotate90
params = {}
mix_up = A.MixUp(p=1, reference_data=reference_data, read_fn=lambda x: x)

aug = A.Compose([augmentation_cls(**params), mix_up])

image = np.empty([100, 100, 3], dtype=np.uint8)
mask = np.empty([100, 100, 3], dtype=np.uint8)
global_label = ["A"]
data = aug(image=image, global_label=global_label, mask=mask)
print(data["mix_coef"]). # 0.9991580344142427
```