### PR TITLE
fix docstring of Downscale.

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1696,8 +1696,8 @@ class Downscale(ImageOnlyTransform):
     """Decreases image quality by downscaling and upscaling back.
 
     Args:
-        scale_min: lower bound on the image scale. Should be < 1.
-        scale_max:  lower bound on the image scale. Should be .
+        scale_min: lower bound on the image scale. Should be <= scale_max.
+        scale_max: upper bound on the image scale. Should be < 1.
         interpolation: cv2 interpolation method. Could be:
             - single cv2 interpolation flag - selected method will be used for downscale and upscale.
             - dict(downscale=flag, upscale=flag)


### PR DESCRIPTION
I have modified the docstring of the Downscale transform as follows.

- Corrected the description of `scale_max` by changing 'lower' to 'upper' and added the upper bound constraint `< 1`.
- Clarified that `scale_min` must be less than or equal to `scale_max`.