### PR TITLE
Perf: deprecate mix_arrays use add_weighted instead

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -18,13 +18,7 @@ from albumentations.augmentations.utils import (
     preserve_channel_dim,
     preserve_shape,
 )
-from albumentations.core.types import (
-    ColorType,
-    ImageMode,
-    ScalarType,
-    SpatterMode,
-    image_modes,
-)
+from albumentations.core.types import ColorType, ImageMode, ScalarType, SpatterMode, image_modes
 
 __all__ = [
     "add_fog",
@@ -1332,8 +1326,10 @@ def superpixels(
 
 
 @clipped
+@preserve_shape
 def add_weighted(img1: np.ndarray, alpha: float, img2: np.ndarray, beta: float) -> np.ndarray:
-    return img1.astype(float) * alpha + img2.astype(float) * beta
+    img2 = img2.reshape(img1.shape).astype(img1.dtype)
+    return cv2.addWeighted(img1, alpha, img2, beta, 0)
 
 
 @clipped

--- a/albumentations/augmentations/mixing/functional.py
+++ b/albumentations/augmentations/mixing/functional.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 import cv2
 import numpy as np
 
@@ -7,5 +9,11 @@ from albumentations.augmentations.utils import clipped, preserve_shape
 @clipped
 @preserve_shape
 def mix_arrays(array1: np.ndarray, array2: np.ndarray, mix_coef: float) -> np.ndarray:
+    warn(
+        "The function 'mix_arrays' is deprecated."
+        "Please use 'add_weighted(array1, mix_coef, array_2, 1 - mix_coef)' instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     array2 = array2.reshape(array1.shape).astype(array1.dtype)
     return cv2.addWeighted(array1, mix_coef, array2, 1 - mix_coef, 0)

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -5,12 +5,11 @@ from warnings import warn
 
 import numpy as np
 
+from albumentations.augmentations.functional import add_weighted
 from albumentations.augmentations.utils import is_grayscale_image
 from albumentations.core.transforms_interface import ReferenceBasedTransform
 from albumentations.core.types import BoxType, KeypointType, ReferenceImage, Targets
 from albumentations.random_utils import beta
-
-from .functional import mix_arrays
 
 __all__ = ["MixUp"]
 
@@ -147,11 +146,11 @@ class MixUp(ReferenceBasedTransform):
             msg = "The shape of the reference image should be the same as the input image."
             raise ValueError(msg)
 
-        return mix_arrays(img, mix_img, mix_coef) if mix_img is not None else img
+        return add_weighted(img, mix_coef, mix_img, 1 - mix_coef) if mix_img is not None else img
 
     def apply_to_mask(self, mask: np.ndarray, mix_data: ReferenceImage, mix_coef: float, **params: Any) -> np.ndarray:
         mix_mask = mix_data.get("mask")
-        return mix_arrays(mask, mix_mask, mix_coef) if mix_mask is not None else mask
+        return add_weighted(mask, mix_coef, mix_mask, 1 - mix_coef) if mix_mask is not None else mask
 
     def apply_to_global_label(
         self, label: np.ndarray, mix_data: ReferenceImage, mix_coef: float, **params: Any

--- a/tests/test_functional_mixing.py
+++ b/tests/test_functional_mixing.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
-from albumentations.augmentations.mixing.functional import mix_arrays
+
+from albumentations.augmentations.functional import add_weighted
+
 
 def find_mix_coef(r: np.ndarray, array1: np.ndarray, array2: np.ndarray) -> float:
     """
@@ -45,8 +47,8 @@ def find_mix_coef(r: np.ndarray, array1: np.ndarray, array2: np.ndarray) -> floa
         # Additional test cases can be added here.
     ]
 )
-def test_mix_arrays_shapes(array1, array2, mix_coef, expected_shape):
-    result = mix_arrays(array1, array2, mix_coef)
+def test_add_weighted_shapes(array1, array2, mix_coef, expected_shape):
+    result = add_weighted(array1, mix_coef, array2, 1 - mix_coef)
     assert result.shape == expected_shape, f"Expected shape {expected_shape}, got {result.shape}"
 
     # Additionally, you can check if the result type matches the first array type


### PR DESCRIPTION
Addresses #1606

Refactor `add_weighted` to use cv2 and replace all usages of `mix_arrays` with `add_weighted`. In addition, deprecate the use of `mix_arrays`.

I made a micro-benchmark just to verify that the new function works faster as expected:
**Setup code** 
```python
import numpy as np

from albumentations.augmentations.functional import add_weighted

np.random.seed(0)
SIZE = 1000
img1 = np.random.random((SIZE, SIZE))
img2 = np.random.random((SIZE, SIZE))
```
**Current version**
```python
%%timeit
add_weighted(img1, 0.5, img2, 0.5)
# 7.7 ms ± 362 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

**This PR**
```python
%%timeit
add_weighted(img1, 0.5, img2, 0.5)
# 5.7 ms ± 56.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
