### PR TITLE
Issue/update random snow interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@
 # verbose regular expressions by Black.  Use [ ] to denote a significant space
 # character.
 
-
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
@@ -13,171 +12,165 @@ requires = [
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
-exclude = [
-    ".bzr",
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".git-rewrite",
-    ".hg",
-    ".ipynb_checkpoints",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".pyenv",
-    ".pytest_cache",
-    ".pytype",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    ".vscode",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "site-packages",
-    "venv",
-    "tests",
-    "setup.py",
-    "tools",
-    "benchmark",
-    "site",
-]
+target-version = "py38"
 
 line-length = 120
 indent-width = 4
 
 # Assume Python 3.8
-target-version = "py38"
-
-[tool.ruff.lint]
-explicit-preview-rules = true
-
-select = [
-    "F",
-    "E",
-    "W",
-    "C90",
-    "I",
-    "N",
-    "D",
-    "UP",
-    "YTT",
-    "ANN",
-    "ASYNC",
-    "TRIO",
-    "S",
-    "BLE",
-    "FBT",
-    "B",
-    "A",
-    "COM",
-    "CPY",
-    "C4",
-    "DTZ",
-    "T10",
-    "DJ",
-    "EM",
-    "EXE",
-    "ISC",
-    "ICN",
-    "G",
-    "INP",
-    "PIE",
-    "T20",
-    "PYI",
-    "PT",
-    "Q",
-    "RSE",
-    "RET",
-    "SLF",
-    "SLOT",
-    "SIM",
-    "TID",
-    "TCH",
-    "INT",
-    "ARG",
-    "PTH",
-    "TD",
-    "FIX",
-    "ERA",
-    "PD",
-    "PGH",
-    "PL",
-    "TRY",
-    "FLY",
-    "NPY",
-    "PERF",
-    "FURB",
-    "LOG",
-    "RUF",
-]
-ignore = [
-    "ANN101",
-    "D107",
-    "ANN401",
-    "ANN204",
-    "ARG002",
-    "S311",
-    "F403",
-    "PLR0913",
-    "FBT001",
-    "FBT002",
-    "ANN102",
-    "EM102",
-    "TRY003",
-    "A002",
-    "PTH123",
-    "ARG001",
-    "ARG005",
-    "B028",
-    "N812",
-    "FBT003",
-    "B027",
-    "D104",
-    "D100",
-    "D103",
-    "D102",
-    "D415",
-    "D101",
-    "D205",
-    "D105",
-    "D417",
-    "D106",
-    "EM101",
-    "COM812",
-    "B008",
-    "G004",
+exclude = [
+  ".bzr",
+  ".direnv",
+  ".eggs",
+  ".git",
+  ".git-rewrite",
+  ".hg",
+  ".ipynb_checkpoints",
+  ".mypy_cache",
+  ".nox",
+  ".pants.d",
+  ".pyenv",
+  ".pytest_cache",
+  ".pytype",
+  ".ruff_cache",
+  ".svn",
+  ".tox",
+  ".venv",
+  ".vscode",
+  "__pypackages__",
+  "_build",
+  "benchmark",
+  "buck-out",
+  "build",
+  "dist",
+  "node_modules",
+  "setup.py",
+  "site",
+  "site-packages",
+  "tests",
+  "tools",
+  "venv",
 ]
 
-# Allow fix for all enabled rules (when `--fix`) is provided.
-fixable = ["ALL"]
-unfixable = []
-
-# Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-
-[tool.ruff.format]
-# Like Black, use double quotes for strings.
-quote-style = "double"
-
-# Like Black, indent with spaces, rather than tabs.
-indent-style = "space"
-
+format.indent-style = "space"
 # Like Black, respect magic trailing commas.
-skip-magic-trailing-comma = false
-
+format.quote-style = "double"
+# Like Black, indent with spaces, rather than tabs.
+format.line-ending = "auto"
+format.skip-magic-trailing-comma = false
 # Like Black, automatically detect the appropriate line ending.
-line-ending = "auto"
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
+lint.select = [
+  "A",
+  "ANN",
+  "ARG",
+  "ASYNC",
+  "B",
+  "BLE",
+  "C4",
+  "C90",
+  "COM",
+  "CPY",
+  "D",
+  "DJ",
+  "DTZ",
+  "E",
+  "EM",
+  "ERA",
+  "EXE",
+  "F",
+  "FBT",
+  "FIX",
+  "FLY",
+  "FURB",
+  "G",
+  "I",
+  "ICN",
+  "INP",
+  "INT",
+  "ISC",
+  "LOG",
+  "N",
+  "NPY",
+  "PD",
+  "PERF",
+  "PGH",
+  "PIE",
+  "PL",
+  "PT",
+  "PTH",
+  "PYI",
+  "Q",
+  "RET",
+  "RSE",
+  "RUF",
+  "S",
+  "SIM",
+  "SLF",
+  "SLOT",
+  "T10",
+  "T20",
+  "TCH",
+  "TD",
+  "TID",
+  "TRIO",
+  "TRY",
+  "UP",
+  "W",
+  "YTT",
+]
+lint.explicit-preview-rules = true
+lint.fixable = [
+  "ALL",
+]
+lint.unfixable = [
+]
+# Allow unused variables when underscore-prefixed.
+lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+# Like Black, use double quotes for strings.
+lint.pydocstyle.convention = "google"
+lint.ignore = [
+  "A002",
+  "ANN101",
+  "ANN102",
+  "ANN204",
+  "ANN401",
+  "ARG001",
+  "ARG002",
+  "ARG005",
+  "B008",
+  "B027",
+  "B028",
+  "COM812",
+  "D100",
+  "D101",
+  "D102",
+  "D103",
+  "D104",
+  "D105",
+  "D106",
+  "D107",
+  "D205",
+  "D415",
+  "D417",
+  "EM101",
+  "EM102",
+  "F403",
+  "FBT001",
+  "FBT002",
+  "FBT003",
+  "G004",
+  "N812",
+  "PLR0913",
+  "PTH123",
+  "S311",
+  "TRY003",
+]
+# Allow fix for all enabled rules (when `--fix`) is provided.
 
 [tool.mypy]
-plugins = ["pydantic.mypy"]
+plugins = [
+  "pydantic.mypy",
+]
 
 python_version = "3.8"
 ignore_missing_imports = true

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -15,6 +15,7 @@ import albumentations.augmentations.geometric.functional as FGeometric
 from albumentations.augmentations.transforms import ImageCompression
 from albumentations.core.types import ImageCompressionType
 from albumentations.random_utils import get_random_seed
+from albumentations.augmentations.transforms import RandomSnow
 from tests.conftest import IMAGES, SQUARE_MULTI_UINT8_IMAGE, SQUARE_UINT8_IMAGE
 
 from .utils import get_dual_transforms, get_image_only_transforms, get_transforms, set_seed
@@ -1524,3 +1525,26 @@ def test_pad_if_needed_functionality(params, expected):
     # Assert each expected key/value pair
     for key, value in expected.items():
         assert aug_dict[key] == value, f"Failed on {key} with value {value}"
+
+@pytest.mark.parametrize("params, expected", [
+    # Test default initialization values
+    ({}, {"snow_point_range": (0.1, 0.3)}),
+    # Test custom quality range and compression type
+    ({"snow_point_range": (0.2, 0.6)},
+     {"snow_point_range": (0.2, 0.6)}),
+    # Deprecated quality values handling
+    ({"snow_point_lower": 0.15}, {"snow_point_range": (0.15, 0.3)}),
+])
+def test_image_compression_initialization(params, expected):
+    img_comp = RandomSnow(**params)
+    for key, value in expected.items():
+        assert getattr(img_comp, key) == value, f"Failed on {key} with value {value}"
+
+@pytest.mark.parametrize("params", [
+    ({"snow_point_range": (1.2, 1.5)}),  # Invalid quality range -> upper bound
+    ({"snow_point_range": (0.9, 0.7)}),  # Invalid range  -> not increasing
+])
+def test_image_compression_invalid_input(params):
+    with pytest.raises(Exception):
+        a = RandomSnow(**params)
+        print(a.snow_point_range)


### PR DESCRIPTION
Fixing issue 1628.

Created new interface for `RandomSnow` following #1704. 
In the `InitSchema` class, `snow_point_range` is simply declared as `Tuple[ float, float ]` because the `ZeroOneRangeType` was automatically sorting elements in the range tuple, failing some tests. 