### PR TITLE
CropAndPad: Accept tuples of ranges for each side of the image

### DIFF
--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -978,11 +978,25 @@ class CropAndPad(DualTransform):
     _targets = (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS)
 
     class InitSchema(BaseTransformInitSchema):
-        px: Optional[Union[int, Tuple[int, int], Tuple[int, int, int, int]]] = Field(
+        px: Optional[
+            Union[
+                int,
+                Tuple[int, int],
+                Tuple[int, int, int, int],
+                Tuple[Tuple[int, int], Tuple[int, int], Tuple[int, int], Tuple[int, int]],
+            ]
+        ] = Field(
             default=None,
             description="Number of pixels to crop (negative) or pad (positive).",
         )
-        percent: Optional[Union[float, Tuple[float, float], Tuple[float, float, float, float]]] = Field(
+        percent: Optional[
+            Union[
+                float,
+                Tuple[float, float],
+                Tuple[float, float, float, float],
+                Tuple[Tuple[float, float], Tuple[float, float], Tuple[float, float], Tuple[float, float]],
+            ]
+        ] = Field(
             default=None,
             description="Fraction of image size to crop (negative) or pad (positive).",
         )


### PR DESCRIPTION
Without this PR, when trying to run
```py
import albumentations as A

...
padding_factors = ((-0.01, 0.2), (-0.005, 0.01), (-0.01, 0.2), (-0.005, 0.01))
augment = A.CropAndPad(percent=padding_factors)
augment(some_image)
```
yields
```bash
pydantic_core._pydantic_core.ValidationError: 6 validation errors for InitSchema
percent.float
  Input should be a valid number [type=float_type, input_value=((-0.01, 0.2), (-0.005, 0...1, 0.2), (-0.005, 0.01)), input_type=tuple]
    For further information visit https://errors.pydantic.dev/2.7/v/float_type
percent.tuple[float, float]
  Tuple should have at most 2 items after validation, not 4 [type=too_long, input_value=((-0.01, 0.2), (-0.005, 0...1, 0.2), (-0.005, 0.01)), input_type=tuple]
    For further information visit https://errors.pydantic.dev/2.7/v/too_long
percent.tuple[float, float, float, float].0
  Input should be a valid number [type=float_type, input_value=(-0.01, 0.2), input_type=tuple]
    For further information visit https://errors.pydantic.dev/2.7/v/float_type
percent.tuple[float, float, float, float].1
  Input should be a valid number [type=float_type, input_value=(-0.005, 0.01), input_type=tuple]
    For further information visit https://errors.pydantic.dev/2.7/v/float_type
percent.tuple[float, float, float, float].2
  Input should be a valid number [type=float_type, input_value=(-0.01, 0.2), input_type=tuple]
    For further information visit https://errors.pydantic.dev/2.7/v/float_type
percent.tuple[float, float, float, float].3
  Input should be a valid number [type=float_type, input_value=(-0.005, 0.01), input_type=tuple]
    For further information visit https://errors.pydantic.dev/2.7/v/float_type
```

Upon looking into the implementation, I found that the case is already covered in code but fails only due to the pydantic validation. Hence, this PR extends the typing information to cover the specific case I was looking for. Note, that I assume there to be more similar cases (e.g. a list for each side, other transformations), that I don't think are covered. However this fixes my use case and is a super tiny and atomic change, which might make sense for a first PR in this project.