### PR TITLE
Return applied params

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -187,6 +187,8 @@ class Compose(BaseCompose):
         p (float): probability of applying all list of transforms. Default: 1.0.
         is_check_shapes (bool): If True shapes consistency of images/mask/masks would be checked on each call. If you
             would like to disable this check - pass False (do it only if you are sure in your data consistency).
+        return_params (bool): if True returns params of each applied transform
+        save_key (str): key to save applied params, default is 'applied_params'
 
     """
 
@@ -285,6 +287,7 @@ class Compose(BaseCompose):
         return self.postprocess(data)
 
     def run_with_params(self, *, params: Dict[int, Dict[str, Any]], **data: Any) -> Dict[str, Any]:
+        """Run transforms with given parameters. Available only for Compose with `return_params=True`."""
         if self._transforms_dict is None:
             raise RuntimeError("`run_with_params` is not available for Compose with `return_params=False`.")
 

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -64,6 +64,8 @@ def get_transforms_dict(transforms: TransformsSeqType) -> Dict[int, BasicTransfo
 
 
 class BaseCompose(Serializable):
+    _transforms_dict: Optional[Dict[int, BasicTransform]] = None
+
     def __init__(self, transforms: TransformsSeqType, p: float):
         if isinstance(transforms, (BaseCompose, BasicTransform)):
             warnings.warn(
@@ -188,8 +190,6 @@ class Compose(BaseCompose):
 
     """
 
-    _transforms_dict: Dict[int, BasicTransform]
-
     def __init__(
         self,
         transforms: TransformsSeqType,
@@ -285,6 +285,9 @@ class Compose(BaseCompose):
         return self.postprocess(data)
 
     def run_with_params(self, *, params: Dict[int, Dict[str, Any]], **data: Any) -> Dict[str, Any]:
+        if self._transforms_dict is None:
+            raise RuntimeError("`run_with_params` is not available for Compose with `return_params=False`.")
+
         self.preprocess(data)
 
         for tr_id, param in params.items():

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -255,7 +255,7 @@ def test_random_rotate():
     assert len(bboxes) == len(transformed["bboxes"])
 
 
-def test_crop_boxes_replay_compose():
+def test_crop_boxes_replay_compose() -> None:
     image = np.ones((512, 384, 3))
     bboxes = [(78, 42, 142, 80), (32, 12, 42, 72), (200, 100, 300, 200)]
     labels = [0, 1, 2]
@@ -267,6 +267,23 @@ def test_crop_boxes_replay_compose():
     input_data = dict(image=image, bboxes=bboxes, labels=labels)
     transformed = transform(**input_data)
     transformed2 = ReplayCompose.replay(transformed["replay"], **input_data)
+
+    np.testing.assert_almost_equal(transformed["bboxes"], transformed2["bboxes"])
+
+
+def test_crop_boxes_return_params() -> None:
+    image = np.ones((512, 384, 3))
+    bboxes = [(78, 42, 142, 80), (32, 12, 42, 72), (200, 100, 300, 200)]
+    labels = [0, 1, 2]
+    transform = Compose(
+        [RandomCrop(256, 256, p=1.0)],
+        bbox_params=BboxParams(format="pascal_voc", min_area=16, label_fields=["labels"]),
+        return_params=True
+    )
+
+    input_data = dict(image=image, bboxes=bboxes, labels=labels)
+    transformed = transform(**input_data)
+    transformed2 = transform.run_with_params(params=transformed["applied_params"], **input_data)
 
     np.testing.assert_almost_equal(transformed["bboxes"], transformed2["bboxes"])
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,7 +3,6 @@ from unittest import mock
 from unittest.mock import MagicMock, Mock, call, patch
 
 import albumentations as A
-from albumentations.core.composition import BaseCompose
 
 import cv2
 import numpy as np
@@ -26,6 +25,8 @@ from albumentations.core.composition import (
     BaseCompose,
     BboxParams,
     Compose,
+    TransformsSeqType,
+    get_transforms_dict,
     KeypointParams,
     OneOf,
     OneOrOther,
@@ -35,7 +36,8 @@ from albumentations.core.composition import (
 )
 from albumentations.core.transforms_interface import (
     DualTransform,
-    ImageOnlyTransform
+    ImageOnlyTransform,
+    NoOp
 )
 from albumentations.core.utils import to_tuple
 from tests.conftest import IMAGES
@@ -192,7 +194,24 @@ def test_check_bboxes_with_end_greater_that_start():
     assert str(exc_info.value) == message
 
 
-def test_deterministic_oneof():
+@pytest.mark.parametrize(
+    ["transforms", "len_expected"],
+    [
+        ([], 0),
+        ([HorizontalFlip(), Blur()], 2),
+        ([OneOf([HorizontalFlip(), Blur()]), SomeOf([HorizontalFlip(), Blur()], n=2)], 4),
+        ([HorizontalFlip(), Sequential([NoOp(), NoOp()])], 3),
+    ],
+)
+def test_get_transforms_dict(transforms: TransformsSeqType, len_expected: int) -> None:
+    aug = Compose(transforms, return_params=True)
+    transforms_dict = get_transforms_dict(transforms)
+
+    assert len(transforms_dict) == len_expected
+    assert aug._transforms_dict == transforms_dict
+
+
+def test_deterministic_oneof() -> None:
     aug = ReplayCompose([OneOf([HorizontalFlip(), Blur()])], p=1)
     for _ in range(10):
         image = (np.random.random((8, 8)) * 255).astype(np.uint8)
@@ -203,7 +222,18 @@ def test_deterministic_oneof():
         assert np.array_equal(data["image"], data2["image"])
 
 
-def test_deterministic_one_or_other():
+def test_return_params_oneof() -> None:
+    aug = Compose([OneOf([HorizontalFlip(), Blur()])], p=1, return_params=True)
+    for _ in range(10):
+        image = (np.random.random((8, 8)) * 255).astype(np.uint8)
+        image2 = np.copy(image)
+        data = aug(image=image)
+        assert "applied_params" in data
+        data2 = aug.run_with_params(params=data["applied_params"], image=image2)
+        assert np.array_equal(data["image"], data2["image"])
+
+
+def test_deterministic_one_or_other() -> None:
     aug = ReplayCompose([OneOrOther(HorizontalFlip(), Blur())], p=1)
     for _ in range(10):
         image = (np.random.random((8, 8)) * 255).astype(np.uint8)
@@ -214,7 +244,18 @@ def test_deterministic_one_or_other():
         assert np.array_equal(data["image"], data2["image"])
 
 
-def test_deterministic_sequential():
+def test_return_params_one_or_other() -> None:
+    aug = Compose([OneOrOther(HorizontalFlip(), Blur())], p=1, return_params=True)
+    for _ in range(10):
+        image = (np.random.random((8, 8)) * 255).astype(np.uint8)
+        image2 = np.copy(image)
+        data = aug(image=image)
+        assert "applied_params" in data
+        data2 = aug.run_with_params(params=data["applied_params"], image=image2)
+        assert np.array_equal(data["image"], data2["image"])
+
+
+def test_deterministic_sequential() -> None:
     aug = ReplayCompose([Sequential([HorizontalFlip(), Blur()])], p=1)
     for _ in range(10):
         image = (np.random.random((8, 8)) * 255).astype(np.uint8)
@@ -222,6 +263,17 @@ def test_deterministic_sequential():
         data = aug(image=image)
         assert "replay" in data
         data2 = ReplayCompose.replay(data["replay"], image=image2)
+        assert np.array_equal(data["image"], data2["image"])
+
+
+def test_return_params_sequential() -> None:
+    aug = Compose([Sequential([HorizontalFlip(), Blur()])], p=1, return_params=True)
+    for _ in range(10):
+        image = (np.random.random((8, 8)) * 255).astype(np.uint8)
+        image2 = np.copy(image)
+        data = aug(image=image)
+        assert "applied_params" in data
+        data2 = aug.run_with_params(params=data["applied_params"], image=image2)
         assert np.array_equal(data["image"], data2["image"])
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -211,6 +211,16 @@ def test_get_transforms_dict(transforms: TransformsSeqType, len_expected: int) -
     assert aug._transforms_dict == transforms_dict
 
 
+def test_comose_run_with_params_exeption() -> None:
+    aug = Compose([NoOp()])
+    aug_2 = Compose([NoOp()], return_params=True)
+    res = aug_2(image=np.random.random((8, 8)))
+    assert "applied_params" in res
+
+    with pytest.raises(RuntimeError):
+        _ = aug.run_with_params(params=res["applied_params"], image=np.random.random((8, 8)))
+
+
 def test_deterministic_oneof() -> None:
     aug = ReplayCompose([OneOf([HorizontalFlip(), Blur()])], p=1)
     for _ in range(10):

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -127,7 +127,7 @@ def test_torch_to_tensor_v2_on_gray_scale_images():
     assert data["image"].dtype == torch.uint8
 
 
-def test_with_replaycompose():
+def test_with_replaycompose() -> None:
     aug = A.ReplayCompose([ToTensorV2()])
     kwargs = {
         "image": np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8),
@@ -135,6 +135,22 @@ def test_with_replaycompose():
     }
     res = aug(**kwargs)
     res2 = A.ReplayCompose.replay(res["replay"], **kwargs)
+    assert np.array_equal(res["image"], res2["image"])
+    assert np.array_equal(res["mask"], res2["mask"])
+    assert res["image"].dtype == torch.uint8
+    assert res["mask"].dtype == torch.uint8
+    assert res2["image"].dtype == torch.uint8
+    assert res2["mask"].dtype == torch.uint8
+
+
+def test_with_return_params() -> None:
+    aug = A.Compose([ToTensorV2()], return_params=True)
+    kwargs = {
+        "image": np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8),
+        "mask": np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8),
+    }
+    res = aug(**kwargs)
+    res2 = aug.run_with_params(params=res["applied_params"], **kwargs)
     assert np.array_equal(res["image"], res2["image"])
     assert np.array_equal(res["mask"], res2["mask"])
     assert res["image"].dtype == torch.uint8


### PR DESCRIPTION
 #1717
Return applied parameters from `Compose`.
Run `Compose` with returned parameters.