### PR TITLE
Albucore multiply add

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       types: [python]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.6
+    rev: v0.4.7
     hooks:
       # Run the linter.
       - id: ruff

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pytest>=8.2.0
 pytest_cov>=4.1.0
 pytest_mock>=3.14.0
 requests>=2.31.0
-ruff>=0.4.6
+ruff>=0.4.7
 tomli>=2.0.1
 types-pkg-resources
 types-PyYAML

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ INSTALL_REQUIRES = [
     "numpy>=1.24.4", "scipy>=1.10.0", "scikit-image>=0.21.0",
     "PyYAML", "typing-extensions>=4.9.0", "scikit-learn>=1.3.2",
     "pydantic>=2.7.0",
-    "albucore>=0.0.7"
+    "albucore>=0.0.8"
 ]
 
 MIN_OPENCV_VERSION = "4.9.0.80"

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -691,26 +691,6 @@ def test_is_multispectral_image():
     assert not is_multispectral_image(gray_image)
 
 
-# def test_brightness_contrast():
-#     dtype = np.uint8
-#     min_value = np.iinfo(dtype).min
-#     max_value = np.iinfo(dtype).max
-
-#     image_uint8 = np.random.randint(min_value, max_value, size=(5, 5, 3), dtype=dtype)
-
-#     assert np.array_equal(F.brightness_contrast_adjust(image_uint8), F._brightness_contrast_adjust_uint(image_uint8))
-
-#     assert np.array_equal(
-#         F._brightness_contrast_adjust_non_uint(image_uint8), F._brightness_contrast_adjust_uint(image_uint8)
-#     )
-
-#     image_float = np.random.random((5, 5, 3)).astype(np.float32)
-
-#     assert np.array_equal(
-#         F.brightness_contrast_adjust(image_float), F._brightness_contrast_adjust_non_uint(image_float)
-#     )
-
-
 @pytest.mark.parametrize(
     "img, tiles, mapping, expected",
     [

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -691,24 +691,24 @@ def test_is_multispectral_image():
     assert not is_multispectral_image(gray_image)
 
 
-def test_brightness_contrast():
-    dtype = np.uint8
-    min_value = np.iinfo(dtype).min
-    max_value = np.iinfo(dtype).max
+# def test_brightness_contrast():
+#     dtype = np.uint8
+#     min_value = np.iinfo(dtype).min
+#     max_value = np.iinfo(dtype).max
 
-    image_uint8 = np.random.randint(min_value, max_value, size=(5, 5, 3), dtype=dtype)
+#     image_uint8 = np.random.randint(min_value, max_value, size=(5, 5, 3), dtype=dtype)
 
-    assert np.array_equal(F.brightness_contrast_adjust(image_uint8), F._brightness_contrast_adjust_uint(image_uint8))
+#     assert np.array_equal(F.brightness_contrast_adjust(image_uint8), F._brightness_contrast_adjust_uint(image_uint8))
 
-    assert np.array_equal(
-        F._brightness_contrast_adjust_non_uint(image_uint8), F._brightness_contrast_adjust_uint(image_uint8)
-    )
+#     assert np.array_equal(
+#         F._brightness_contrast_adjust_non_uint(image_uint8), F._brightness_contrast_adjust_uint(image_uint8)
+#     )
 
-    image_float = np.random.random((5, 5, 3)).astype(np.float32)
+#     image_float = np.random.random((5, 5, 3)).astype(np.float32)
 
-    assert np.array_equal(
-        F.brightness_contrast_adjust(image_float), F._brightness_contrast_adjust_non_uint(image_float)
-    )
+#     assert np.array_equal(
+#         F.brightness_contrast_adjust(image_float), F._brightness_contrast_adjust_non_uint(image_float)
+#     )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -198,8 +198,7 @@ def test_color_jitter(brightness, contrast, saturation, hue):
     res1 = transform(image=img)["image"]
     res2 = np.array(pil_transform(pil_image))
 
-    _max = np.abs(res1.astype(np.int16) - res2.astype(np.int16)).max()
-    assert _max <= 2, f"Max: {_max}"
+    assert np.abs(res1.astype(np.int16) - res2.astype(np.int16)).max() <= 2, f"Max: {_max}"
 
 
 def test_post_data_check():


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request refactors several image processing functions to use a unified multiply_add function, improving code maintainability and readability. It also updates dependencies and pre-commit configurations, enhances documentation, and simplifies some tests.

* **Enhancements**:
    - Refactored brightness and contrast adjustment functions to use a unified multiply_add function, simplifying the code and improving maintainability.
    - Updated the iso_noise function to use the multiply function for better consistency and readability.
    - Refactored the adjust_contrast_torchvision function to use the multiply_add function, streamlining the contrast adjustment logic.
    - Improved the unsharp_mask function by using the add and multiply functions for better clarity and performance.
* **Build**:
    - Updated albucore dependency version from 0.0.7 to 0.0.8 in setup.py.
* **CI**:
    - Updated pre-commit configuration to use ruff-pre-commit version v0.4.7.
* **Documentation**:
    - Enhanced the documentation for the fancy_pca function by adding a reference link and clarifying the description of the alpha parameter.
* **Tests**:
    - Removed redundant tests for brightness and contrast adjustment functions in test_functional.py.
    - Simplified the test_color_jitter function in test_pytorch.py by removing unnecessary variable assignment.

<!-- Generated by sourcery-ai[bot]: end summary -->