### PR TITLE
Adding the option to disabled the automatic version check using NO_AL…

### DIFF
--- a/albumentations/__init__.py
+++ b/albumentations/__init__.py
@@ -1,5 +1,7 @@
 __version__ = "1.4.8"
 
+import os
+
 from albumentations.check_version import check_for_updates
 
 from .augmentations import *
@@ -8,4 +10,5 @@ from .core.serialization import *
 from .core.transforms_interface import *
 
 # Perform the version check after all other initializations
-check_for_updates()
+if os.getenv("NO_ALBUMENTATIONS_UPDATE", '').lower() not in ['true', '1']:
+    check_for_updates()


### PR DESCRIPTION
…BUMENTATIONS_UPDATE env variable.

Allow to disable the albumentation network check using an env variable.

Cf linked [Documentation MR](https://github.com/albumentations-team/albumentations.ai/pull/82)