### PR TITLE
fix for available keys

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -42,6 +42,11 @@ TransformType = Union[BasicTransform, "BaseCompose"]
 TransformsSeqType = List[TransformType]
 
 AVAILABLE_KEYS = ("image", "mask", "masks", "bboxes", "keypoints", "global_label")
+MASK_KEYS = ("mask", "masks")
+CHECKED_SINGLE = ("image", "mask")
+CHECKED_MULTI = ("masks",)
+CHECK_BBOX_PARAM = ("bboxes",)
+CHECK_KEYPOINTS_PARAM = ("keypoints",)
 
 
 def get_transforms_dict(transforms: TransformsSeqType) -> Dict[int, BasicTransform]:
@@ -347,29 +352,25 @@ class Compose(BaseCompose, HubMixin):
         return dictionary
 
     def _check_args(self, **kwargs: Any) -> None:
-        checked_single = ["image", "mask"]
-        checked_multi = ["masks"]
-        check_bbox_param = ["bboxes"]
-        check_keypoints_param = ["keypoints"]
         shapes = []
         for data_name, data in kwargs.items():
-            if data_name not in self._available_keys and data_name not in ["mask", "masks"]:
+            if data_name not in self._available_keys and data_name not in MASK_KEYS:
                 msg = f"Key {data_name} is not in available keys."
                 raise ValueError(msg)
             internal_data_name = self._additional_targets.get(data_name, data_name)
-            if internal_data_name in checked_single:
+            if internal_data_name in CHECKED_SINGLE:
                 if not isinstance(data, np.ndarray):
                     raise TypeError(f"{data_name} must be numpy array type")
                 shapes.append(data.shape[:2])
-            if internal_data_name in checked_multi and data is not None and len(data):
+            if internal_data_name in CHECKED_MULTI and data is not None and len(data):
                 if not isinstance(data[0], np.ndarray):
                     raise TypeError(f"{data_name} must be list of numpy arrays")
                 shapes.append(data[0].shape[:2])
-            if internal_data_name in check_bbox_param and self.processors.get("bboxes") is None:
+            if internal_data_name in CHECK_BBOX_PARAM and self.processors.get("bboxes") is None:
                 msg = "bbox_params must be specified for bbox transformations"
                 raise ValueError(msg)
 
-            if internal_data_name in check_keypoints_param and self.processors.get("keypoints") is None:
+            if internal_data_name in CHECK_KEYPOINTS_PARAM and self.processors.get("keypoints") is None:
                 msg = "keypoints_params must be specified for keypoint transformations"
                 raise ValueError(msg)
 


### PR DESCRIPTION
#1771 
Fix for available keys.
`mask` and `masks` always acceptable.
If you need any additional key be available - add it with `add_targets` as `add_targets({"some_key": None})

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the issue with 'mask' and 'masks' keys not being consistently recognized as acceptable. It also enhances the key-checking mechanism to allow additional keys to be added dynamically using the 'add_targets' method. New test cases have been added to verify these changes.

* **Bug Fixes**:
    - Fixed issue where 'mask' and 'masks' keys were not always recognized as acceptable keys in transformations.
* **Enhancements**:
    - Enhanced the key-checking mechanism to allow additional keys to be added dynamically using the 'add_targets' method.
* **Tests**:
    - Added new test cases to verify the handling of additional keys and ensure 'mask' and 'masks' are always acceptable.

<!-- Generated by sourcery-ai[bot]: end summary -->