### PR TITLE
Fixing a Corner Case Bug in Compose when transforms=[]

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -148,6 +148,7 @@ class BaseCompose(Serializable):
 
     def _set_keys(self) -> None:
         """Set _available_keys"""
+        self._available_keys.update(self._additional_targets.keys())
         for t in self.transforms:
             self._available_keys.update(t.available_keys)
         if self.processors:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -651,6 +651,22 @@ def test_compose_non_available_keys() -> None:
     expected_msg = "Key image_2 is not in available keys."
     assert str(exc_info.value) == expected_msg
 
+def test_compose_additional_targets_in_available_keys() -> None:
+    """Check whether `available_keys` always contains everything in `additional_targets`"""
+    first = MagicMock(available_keys={"image"})
+    second = MagicMock(available_keys={"image"})
+    image = np.ones((8, 8))
+
+    # non-empty `transforms`
+    augmentation = Compose([first, second], p=1, 
+                           additional_targets={"additional_target_1": "image", "additional_target_2": "image"})
+    augmentation(image=image, additional_target_1=image, additional_target_2=image) # will raise exception if not
+
+    # empty `transforms`
+    augmentation = Compose([], p=1, 
+                           additional_targets={"additional_target_1": "image", "additional_target_2": "image"})
+    augmentation(image=image, additional_target_1=image, additional_target_2=image) # will raise exception if not
+    
 
 def test_transform_always_apply_warning() -> None:
     """Check that warning is raised if always_apply argument is used"""


### PR DESCRIPTION
When `transforms` is `[]`, `_set_keys()` will NOT be adding `additional_targets` into `self._available_keys` (as it is just going through all transforms and processors, which is nothing done when there is no transform or processor), and causes runtime errors if passing those in the usage. 
Adding the L151 will fix this corner case.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a corner case bug in the Compose class by ensuring that `additional_targets` are added to `_available_keys` even when `transforms` is an empty list, thereby preventing potential runtime errors.

* **Bug Fixes**:
    - Fixed a corner case bug in the Compose class where `additional_targets` were not being added to `_available_keys` when `transforms` is an empty list, preventing runtime errors.

<!-- Generated by sourcery-ai[bot]: end summary -->