### PR TITLE
Bugfix with targets from target_as_params

### DIFF
--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -647,9 +647,9 @@ class RandomCropNearBBox(DualTransform):
         uint8, float32
 
     Examples:
-        >>> aug = Compose([RandomCropNearBBox(max_part_shift=(0.1, 0.5), cropping_bbox_key='test_box')],
+        >>> aug = Compose([RandomCropNearBBox(max_part_shift=(0.1, 0.5), cropping_bbox_key='test_bbox')],
         >>>              bbox_params=BboxParams("pascal_voc"))
-        >>> result = aug(image=image, bboxes=bboxes, test_box=[0, 5, 10, 20])
+        >>> result = aug(image=image, bboxes=bboxes, test_bbox=[0, 5, 10, 20])
 
     """
 

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -696,6 +696,9 @@ class RandomCropNearBBox(DualTransform):
 
     def get_params_dependent_on_targets(self, params: Dict[str, Any]) -> Dict[str, int]:
         bbox = params[self.cropping_bbox_key]
+        image = params["image"]
+        height, width = image.shape[:2]
+
         h_max_shift = round((bbox[3] - bbox[1]) * self.max_part_shift[0])
         w_max_shift = round((bbox[2] - bbox[0]) * self.max_part_shift[1])
 
@@ -707,6 +710,9 @@ class RandomCropNearBBox(DualTransform):
 
         x_min = max(0, x_min)
         y_min = max(0, y_min)
+
+        x_max = min(width, x_max)
+        y_max = min(height, y_max)
 
         return {"x_min": x_min, "x_max": x_max, "y_min": y_min, "y_max": y_max}
 
@@ -726,7 +732,7 @@ class RandomCropNearBBox(DualTransform):
 
     @property
     def targets_as_params(self) -> List[str]:
-        return [self.cropping_bbox_key]
+        return ["image", self.cropping_bbox_key]
 
     def get_transform_init_args_names(self) -> Tuple[str, str]:
         return ("max_part_shift", "cropping_bbox_key")

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -151,6 +151,8 @@ class BaseCompose(Serializable):
         self._available_keys.update(self._additional_targets.keys())
         for t in self.transforms:
             self._available_keys.update(t.available_keys)
+            if hasattr(t, "targets_as_params"):
+                self._available_keys.update(t.targets_as_params)
         if self.processors:
             self._available_keys.update(["labels"])
             for proc in self.processors.values():
@@ -352,6 +354,7 @@ class Compose(BaseCompose, HubMixin):
         check_bbox_param = ["bboxes"]
         check_keypoints_param = ["keypoints"]
         shapes = []
+
         for data_name, data in kwargs.items():
             if data_name not in self._available_keys and data_name not in ["mask", "masks"]:
                 msg = f"Key {data_name} is not in available keys."

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -461,6 +461,7 @@ AUGMENTATION_CLS_PARAMS = [
     [A.Morphological, {}],
     [A.D4, {}],
     [A.PlanckianJitter, {}]
+
 ]
 
 AUGMENTATION_CLS_EXCEPT = {


### PR DESCRIPTION
https://github.com/albumentations-team/albumentations/issues/1806

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug related to target recognition in transformations by adding the 'targets_as_params' attribute. It also enhances the '_set_keys' method to include these parameters and introduces a new test to ensure the correct functionality of cropping near bounding boxes.

- **Bug Fixes**:
    - Fixed issue with targets not being recognized in transformations by adding 'targets_as_params' attribute to Mock objects in tests.
- **Enhancements**:
    - Updated '_set_keys' method in 'albumentations/core/composition.py' to include 'targets_as_params' in available keys.
- **Tests**:
    - Added new test 'test_crop_near_bbox' to validate the functionality of cropping near bounding boxes with specific target keys.

<!-- Generated by sourcery-ai[bot]: end summary -->