### PR TITLE
Added balanced scale parameter to Affine

### DIFF
--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -546,11 +546,18 @@ class Affine(DualTransform):
             Fitting the output shape can be useful to avoid corners of the image being outside the image plane
             after applying rotations. Default: False
         keep_ratio (bool): When True, the original aspect ratio will be kept when the random scale is applied.
-                           Default: False.
+            Default: False.
         rotate_method (Literal["largest_box", "ellipse"]): rotation method used for the bounding boxes.
             Should be one of "largest_box" or "ellipse"[1]. Default: "largest_box"
         balanced_scale (bool): When True, scaling factors are chosen to be either entirely below or above 1,
-                               ensuring balanced scaling. Default: False.
+            ensuring balanced scaling. Default: False.
+
+            This is important because without it, scaling tends to lean towards upscaling. For example, if we want
+            the image to zoom in and out by 2x, we may pick an interval [0.5, 2]. Since the interval [0.5, 1] is
+            three times smaller than [1, 2], values above 1 are picked three times more often if sampled directly
+            from [0.5, 2]. With `balanced_scale`, the  function ensures that half the time, the scaling
+            factor is picked from below 1 (zooming out), and the other half from above 1 (zooming in).
+            This makes the zooming in and out process more balanced.
         p (float): probability of applying the transform. Default: 0.5.
 
     Targets:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1759,3 +1759,28 @@ def test_gauss_noise(mean, image):
     result = A.Compose([aug])(image=image)
 
     assert not (result["image"] >= image).all()
+
+
+@pytest.mark.parametrize(
+    "scale, keep_ratio, balanced_scale, expected_x_range, expected_y_range",
+    [
+        ({"x": (0.5, 2), "y": (0.5, 2)}, False, True, (0.5, 2), (0.5, 2)),
+        ({"x": (1, 2), "y": (1, 2)}, True, True, (1, 2), (1, 2)),
+        ({"x": (0.5, 1), "y": (0.5, 1)}, True, True, (0.5, 1), (0.5, 1)),
+        ({"x": (0.5, 2), "y": (0.5, 2)}, False, False, (0.5, 2), (0.5, 2)),
+        ({"x": (0.5, 2), "y": (0.5, 2)}, True, False, (0.5, 2), (0.5, 2)),
+    ],
+)
+def test_get_random_scale(scale, keep_ratio, balanced_scale, expected_x_range, expected_y_range):
+    result = A.Affine.get_scale(scale, keep_ratio, balanced_scale)
+
+    assert expected_x_range[0] <= result["x"] <= expected_x_range[1], "x is out of range"
+
+    if keep_ratio:
+        assert result["y"] == result["x"], "y should be equal to x when keep_ratio is True"
+    else:
+        assert expected_y_range[0] <= result["y"] <= expected_y_range[1], "y is out of range"
+
+    if balanced_scale:
+        assert expected_x_range[0] <= result["x"] < 1 or 1 < result["x"] <= expected_x_range[1], "x should be in the balanced range"
+        assert expected_y_range[0] <= result["y"] < 1 or 1 < result["y"] <= expected_x_range[1], "x should be in the balanced range"


### PR DESCRIPTION
Closes: https://github.com/albumentations-team/albumentations/issues/1787
Partially addresses: https://github.com/albumentations-team/albumentations/issues/740

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a new 'balanced_scale' parameter to the Affine transformation, enabling balanced scaling. It also refactors the scale calculation logic and introduces new tests to ensure the correct functionality of the new parameter.

- **New Features**:
    - Introduced a 'balanced_scale' parameter to the Affine transformation, allowing scaling factors to be chosen either entirely below or above 1 for balanced scaling.
- **Enhancements**:
    - Refactored the scale calculation logic into a new static method 'get_scale' to support the new 'balanced_scale' parameter.
- **Tests**:
    - Added parameterized tests for the 'get_scale' method to verify the behavior of the new 'balanced_scale' parameter.

<!-- Generated by sourcery-ai[bot]: end summary -->