### PR TITLE
strict argument - fix for available keys #1807

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -229,10 +229,10 @@ class Compose(BaseCompose, HubMixin):
             self._available_keys.update(AVAILABLE_KEYS)
 
         self.is_check_args = True
+        self.strict = strict
         self._disable_check_args_for_transforms(self.transforms)
 
         self.is_check_shapes = is_check_shapes
-        self.strict = strict
         self._check_each_transform = tuple(  # processors that checks after each transform
             proc for proc in self.processors.values() if getattr(proc.params, "check_each_transform", False)
         )
@@ -254,6 +254,7 @@ class Compose(BaseCompose, HubMixin):
 
     def disable_check_args_private(self) -> None:
         self.is_check_args = False
+        self.strict = False
 
     def __call__(self, *args: Any, force_apply: bool = False, **data: Any) -> Dict[str, Any]:
         if args:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -645,13 +645,23 @@ def test_compose_non_available_keys() -> None:
     )
     image = np.empty([10, 10, 3], dtype=np.uint8)
     mask = np.empty([10, 10], dtype=np.uint8)
-    _res = transform(image=image, mask=mask)
-    _res = transform(image=image, masks=[mask])
+    _ = transform(image=image, mask=mask)
+    _ = transform(image=image, masks=[mask])
     with pytest.raises(ValueError) as exc_info:
-        _res = transform(image=image, image_2=mask)
+        _ = transform(image=image, image_2=mask)
 
     expected_msg = "Key image_2 is not in available keys."
     assert str(exc_info.value) == expected_msg
+
+    # strict=False should not raise error
+    transform = A.Compose(
+        [MagicMock(available_keys={"image"}),],
+        strict=False,
+    )
+    _ = transform(image=image, mask=mask)
+    _ = transform(image=image, masks=[mask])
+    _ = transform(image=image, image_2=mask)
+
 
 def test_compose_additional_targets_in_available_keys() -> None:
     """Check whether `available_keys` always contains everything in `additional_targets`"""
@@ -662,12 +672,18 @@ def test_compose_additional_targets_in_available_keys() -> None:
     # non-empty `transforms`
     augmentation = Compose([first, second], p=1,
                            additional_targets={"additional_target_1": "image", "additional_target_2": "image"})
-    augmentation(image=image, additional_target_1=image, additional_target_2=image) # will raise exception if not
+    augmentation(image=image, additional_target_1=image, additional_target_2=image)  # will raise exception if not
+    # strict=False should not raise error without additional_targets
+    augmentation = Compose([first, second], p=1, strict=False)
+    augmentation(image=image, additional_target_1=image, additional_target_2=image)
 
     # empty `transforms`
     augmentation = Compose([], p=1,
                            additional_targets={"additional_target_1": "image", "additional_target_2": "image"})
-    augmentation(image=image, additional_target_1=image, additional_target_2=image) # will raise exception if not
+    augmentation(image=image, additional_target_1=image, additional_target_2=image)  # will raise exception if not
+    # strict=False should not raise error without additional_targets
+    augmentation = Compose([], p=1, strict=False)
+    augmentation(image=image, additional_target_1=image, additional_target_2=image)
 
 
 def test_transform_always_apply_warning() -> None:


### PR DESCRIPTION
#1807

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a 'strict' argument to the Compose class, allowing users to control whether unknown keys raise an error or are ignored. Corresponding test cases have been added to validate this new behavior.

- **Enhancements**:
    - Introduced a 'strict' argument to the Compose class to control whether unknown keys raise an error or are ignored.
- **Tests**:
    - Added test cases to verify the behavior of the 'strict' argument in the Compose class, ensuring no errors are raised when 'strict' is set to False.

<!-- Generated by sourcery-ai[bot]: end summary -->