### PR TITLE
Always_apply fix

### DIFF
--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -68,8 +68,8 @@ class Blur(ImageOnlyTransform):
     class InitSchema(BlurInitSchema):
         pass
 
-    def __init__(self, blur_limit: ScaleIntType = 7, always_apply: Optional[bool] = None, p: float = 0.5):
-        super().__init__(always_apply, p)
+    def __init__(self, blur_limit: ScaleIntType = 7, p: float = 0.5, always_apply: Optional[bool] = None):
+        super().__init__(p, always_apply)
         self.blur_limit = cast(Tuple[int, int], blur_limit)
 
     def apply(self, img: np.ndarray, kernel: int, **params: Any) -> np.ndarray:
@@ -126,7 +126,7 @@ class MotionBlur(Blur):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(blur_limit=blur_limit, always_apply=always_apply, p=p)
+        super().__init__(blur_limit=blur_limit, p=p, always_apply=always_apply)
         self.allow_shifted = allow_shifted
         self.blur_limit = cast(Tuple[int, int], blur_limit)
 
@@ -191,8 +191,8 @@ class MedianBlur(Blur):
 
     """
 
-    def __init__(self, blur_limit: ScaleIntType = 7, always_apply: Optional[bool] = None, p: float = 0.5):
-        super().__init__(blur_limit, always_apply, p)
+    def __init__(self, blur_limit: ScaleIntType = 7, p: float = 0.5, always_apply: Optional[bool] = None):
+        super().__init__(blur_limit, p, always_apply)
 
     def apply(self, img: np.ndarray, kernel: int, **params: Any) -> np.ndarray:
         return fblur.median_blur(img, kernel)
@@ -257,7 +257,7 @@ class GaussianBlur(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.blur_limit = cast(Tuple[int, int], blur_limit)
         self.sigma_limit = cast(Tuple[float, float], sigma_limit)
 
@@ -313,7 +313,7 @@ class GlassBlur(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.sigma = sigma
         self.max_delta = max_delta
         self.iterations = iterations
@@ -434,7 +434,7 @@ class AdvancedBlur(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
 
         if sigmaX_limit is not None:
             warnings.warn("sigmaX_limit is deprecated; use sigma_x_limit instead.", DeprecationWarning, stacklevel=2)
@@ -529,7 +529,7 @@ class Defocus(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.radius = cast(Tuple[int, int], radius)
         self.alias_blur = cast(Tuple[float, float], alias_blur)
 
@@ -579,7 +579,7 @@ class ZoomBlur(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.max_factor = cast(Tuple[float, float], max_factor)
         self.step_factor = cast(Tuple[float, float], step_factor)
 

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -77,8 +77,8 @@ class RandomCrop(DualTransform):
     class InitSchema(CropInitSchema):
         pass
 
-    def __init__(self, height: int, width: int, always_apply: Optional[bool] = None, p: float = 1.0):
-        super().__init__(always_apply, p)
+    def __init__(self, height: int, width: int, p: float = 1.0, always_apply: Optional[bool] = None):
+        super().__init__(p, always_apply)
         self.height = height
         self.width = width
 
@@ -119,8 +119,8 @@ class CenterCrop(DualTransform):
     class InitSchema(CropInitSchema):
         pass
 
-    def __init__(self, height: int, width: int, always_apply: Optional[bool] = None, p: float = 1.0):
-        super().__init__(always_apply, p)
+    def __init__(self, height: int, width: int, p: float = 1.0, always_apply: Optional[bool] = None):
+        super().__init__(p, always_apply)
         self.height = height
         self.width = width
 
@@ -182,7 +182,7 @@ class Crop(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 1.0,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.x_min = x_min
         self.y_min = y_min
         self.x_max = x_max
@@ -239,7 +239,7 @@ class CropNonEmptyMaskIfExists(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 1.0,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
 
         self.height = height
         self.width = width
@@ -367,7 +367,7 @@ class _BaseRandomSizedCrop(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 1.0,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.size = size
         self.interpolation = interpolation
 
@@ -486,7 +486,7 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
         always_apply: Optional[bool] = None,
         p: float = 1.0,
     ):
-        super().__init__(size=cast(Tuple[int, int], size), interpolation=interpolation, always_apply=always_apply, p=p)
+        super().__init__(size=cast(Tuple[int, int], size), interpolation=interpolation, p=p, always_apply=always_apply)
         self.min_max_height = min_max_height
         self.w2h_ratio = w2h_ratio
 
@@ -570,7 +570,7 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
         always_apply: Optional[bool] = None,
         p: float = 1.0,
     ):
-        super().__init__(size=cast(Tuple[int, int], size), interpolation=interpolation, always_apply=always_apply, p=p)
+        super().__init__(size=cast(Tuple[int, int], size), interpolation=interpolation, p=p, always_apply=always_apply)
         self.scale = scale
         self.ratio = ratio
 
@@ -668,7 +668,7 @@ class RandomCropNearBBox(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 1.0,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         # Check for deprecated parameter and issue warning
         if cropping_box_key is not None:
             warn(
@@ -762,8 +762,8 @@ class BBoxSafeRandomCrop(DualTransform):
         )
         p: ProbabilityType = 1
 
-    def __init__(self, erosion_rate: float = 0.0, always_apply: Optional[bool] = None, p: float = 1.0):
-        super().__init__(always_apply, p)
+    def __init__(self, erosion_rate: float = 0.0, p: float = 1.0, always_apply: Optional[bool] = None):
+        super().__init__(p, always_apply)
         self.erosion_rate = erosion_rate
 
     def apply(
@@ -873,7 +873,7 @@ class RandomSizedBBoxSafeCrop(BBoxSafeRandomCrop):
         always_apply: Optional[bool] = None,
         p: float = 1.0,
     ):
-        super().__init__(erosion_rate, always_apply, p)
+        super().__init__(erosion_rate, p, always_apply)
         self.height = height
         self.width = width
         self.interpolation = interpolation
@@ -1043,7 +1043,7 @@ class CropAndPad(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 1.0,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
 
         self.px = px
         self.percent = percent
@@ -1360,7 +1360,7 @@ class RandomCropFromBorders(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 1.0,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.crop_left = crop_left
         self.crop_right = crop_right
         self.crop_top = crop_top

--- a/albumentations/augmentations/domain_adaptation.py
+++ b/albumentations/augmentations/domain_adaptation.py
@@ -83,7 +83,7 @@ class HistogramMatching(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.reference_images = reference_images
         self.read_fn = read_fn
         self.blend_ratio = blend_ratio
@@ -182,7 +182,7 @@ class FDA(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.reference_images = reference_images
         self.read_fn = read_fn
         self.beta_limit = cast(Tuple[float, float], beta_limit)
@@ -277,7 +277,7 @@ class PixelDistributionAdaptation(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.reference_images = reference_images
         self.read_fn = read_fn
         self.blend_ratio = blend_ratio

--- a/albumentations/augmentations/dropout/channel_dropout.py
+++ b/albumentations/augmentations/dropout/channel_dropout.py
@@ -44,7 +44,7 @@ class ChannelDropout(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
 
         self.channel_drop_range = channel_drop_range
         self.fill_value = fill_value

--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -166,7 +166,7 @@ class CoarseDropout(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.num_holes_range = num_holes_range
         self.hole_height_range = hole_height_range
         self.hole_width_range = hole_width_range

--- a/albumentations/augmentations/dropout/grid_dropout.py
+++ b/albumentations/augmentations/dropout/grid_dropout.py
@@ -126,7 +126,7 @@ class GridDropout(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.ratio = ratio
         self.unit_size_range = unit_size_range
         self.holes_number_xy = holes_number_xy

--- a/albumentations/augmentations/dropout/mask_dropout.py
+++ b/albumentations/augmentations/dropout/mask_dropout.py
@@ -60,7 +60,7 @@ class MaskDropout(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.max_objects = cast(Tuple[int, int], max_objects)
         self.image_fill_value = image_fill_value
         self.mask_fill_value = mask_fill_value

--- a/albumentations/augmentations/dropout/xy_masking.py
+++ b/albumentations/augmentations/dropout/xy_masking.py
@@ -85,7 +85,7 @@ class XYMasking(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.num_masks_x = cast(Tuple[int, int], num_masks_x)
         self.num_masks_y = cast(Tuple[int, int], num_masks_y)
 

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -62,7 +62,7 @@ class RandomScale(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.scale_limit = cast(Tuple[float, float], scale_limit)
         self.interpolation = interpolation
 
@@ -142,7 +142,7 @@ class LongestMaxSize(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 1,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.interpolation = interpolation
         self.max_size = max_size
 
@@ -207,7 +207,7 @@ class SmallestMaxSize(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 1,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.interpolation = interpolation
         self.max_size = max_size
 
@@ -277,7 +277,7 @@ class Resize(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 1,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.height = height
         self.width = width
         self.interpolation = interpolation

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -126,7 +126,7 @@ class Rotate(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.limit = cast(Tuple[float, float], limit)
         self.interpolation = interpolation
         self.border_mode = border_mode
@@ -296,7 +296,7 @@ class SafeRotate(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.limit = cast(Tuple[float, float], limit)
         self.interpolation = interpolation
         self.border_mode = border_mode

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -129,7 +129,7 @@ class ElasticTransform(DualTransform):
         same_dxdy: bool = False,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.alpha = alpha
         self.alpha_affine = alpha_affine
         self.sigma = sigma
@@ -285,7 +285,7 @@ class Perspective(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.scale = cast(Tuple[float, float], scale)
         self.keep_size = keep_size
         self.pad_mode = pad_mode
@@ -621,7 +621,7 @@ class Affine(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
 
         params = [scale, translate_percent, translate_px, rotate, shear]
         if all(p is None for p in params):
@@ -1121,7 +1121,7 @@ class PiecewiseAffine(DualTransform):
         keypoints_threshold: float = 0.01,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
 
         warn(
             "This augmenter is very slow. Try to use ``ElasticTransformation`` instead, which is at least 10x faster.",
@@ -1354,7 +1354,7 @@ class PadIfNeeded(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 1.0,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.min_height = min_height
         self.min_width = min_width
         self.pad_width_divisor = pad_width_divisor
@@ -1715,7 +1715,7 @@ class OpticalDistortion(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.shift_limit = cast(Tuple[float, float], shift_limit)
         self.distort_limit = cast(Tuple[float, float], distort_limit)
         self.interpolation = interpolation
@@ -1856,7 +1856,7 @@ class GridDistortion(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
 
         self.num_steps = num_steps
         self.distort_limit = cast(Tuple[float, float], distort_limit)
@@ -2017,7 +2017,7 @@ class D4(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 1,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
 
     def apply(self, img: np.ndarray, group_element: D4Type, **params: Any) -> np.ndarray:
         return fgeometric.d4(img, group_element)

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -123,7 +123,7 @@ class MixUp(ReferenceBasedTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.mix_coef_return_name = mix_coef_return_name
 
         self.read_fn = read_fn

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -154,8 +154,8 @@ class RandomGridShuffle(DualTransform):
 
     _targets = (Targets.IMAGE, Targets.MASK, Targets.KEYPOINTS)
 
-    def __init__(self, grid: Tuple[int, int] = (3, 3), always_apply: Optional[bool] = None, p: float = 0.5):
-        super().__init__(always_apply=always_apply, p=p)
+    def __init__(self, grid: Tuple[int, int] = (3, 3), p: float = 0.5, always_apply: Optional[bool] = None):
+        super().__init__(p=p, always_apply=always_apply)
         self.grid = grid
 
     def apply(self, img: np.ndarray, tiles: np.ndarray, mapping: List[int], **params: Any) -> np.ndarray:
@@ -306,7 +306,7 @@ class Normalize(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 1.0,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.mean = mean
         self.mean_np = np.array(mean, dtype=np.float32) * max_pixel_value
         self.std = std
@@ -411,7 +411,7 @@ class ImageCompression(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.quality_range = quality_range
         self.compression_type = compression_type
 
@@ -522,7 +522,7 @@ class RandomSnow(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
 
         self.snow_point_range = snow_point_range
         self.brightness_coeff = brightness_coeff
@@ -577,7 +577,7 @@ class RandomGravel(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.gravel_roi = gravel_roi
         self.number_of_patches = number_of_patches
 
@@ -750,7 +750,7 @@ class RandomRain(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.slant_range = slant_range
         self.drop_length = drop_length
         self.drop_width = drop_width
@@ -889,7 +889,7 @@ class RandomFog(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.fog_coef_range = fog_coef_range
         self.alpha_coef = alpha_coef
 
@@ -1059,7 +1059,7 @@ class RandomSunFlare(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
 
         self.angle_range = angle_range
         self.num_flare_circles_range = num_flare_circles_range
@@ -1234,7 +1234,7 @@ class RandomShadow(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
 
         self.shadow_roi = shadow_roi
         self.shadow_dimension = shadow_dimension
@@ -1311,7 +1311,7 @@ class RandomToneCurve(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.scale = scale
 
     def apply(self, img: np.ndarray, low_y: float, high_y: float, **params: Any) -> np.ndarray:
@@ -1360,7 +1360,7 @@ class HueSaturationValue(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.hue_shift_limit = cast(Tuple[float, float], hue_shift_limit)
         self.sat_shift_limit = cast(Tuple[float, float], sat_shift_limit)
         self.val_shift_limit = cast(Tuple[float, float], val_shift_limit)
@@ -1408,8 +1408,8 @@ class Solarize(ImageOnlyTransform):
     class InitSchema(BaseTransformInitSchema):
         threshold: OnePlusFloatRangeType = (128, 128)
 
-    def __init__(self, threshold: ScaleType = (128, 128), always_apply: Optional[bool] = None, p: float = 0.5):
-        super().__init__(always_apply=always_apply, p=p)
+    def __init__(self, threshold: ScaleType = (128, 128), p: float = 0.5, always_apply: Optional[bool] = None):
+        super().__init__(p=p, always_apply=always_apply)
         self.threshold = cast(Tuple[float, float], threshold)
 
     def apply(self, img: np.ndarray, threshold: int, **params: Any) -> np.ndarray:
@@ -1462,7 +1462,7 @@ class Posterize(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.num_bits = cast(Union[Tuple[int, ...], List[Tuple[int, ...]]], num_bits)
 
     def apply(self, img: np.ndarray, num_bits: int, **params: Any) -> np.ndarray:
@@ -1516,7 +1516,7 @@ class Equalize(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
 
         self.mode = mode
         self.by_channels = by_channels
@@ -1573,7 +1573,7 @@ class RGBShift(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.r_shift_limit = cast(Tuple[float, float], r_shift_limit)
         self.g_shift_limit = cast(Tuple[float, float], g_shift_limit)
         self.b_shift_limit = cast(Tuple[float, float], b_shift_limit)
@@ -1633,7 +1633,7 @@ class RandomBrightnessContrast(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.brightness_limit = cast(Tuple[float, float], brightness_limit)
         self.contrast_limit = cast(Tuple[float, float], contrast_limit)
         self.brightness_by_max = brightness_by_max
@@ -1690,7 +1690,7 @@ class GaussNoise(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.var_limit = cast(Tuple[float, float], var_limit)
         self.mean = mean
         self.per_channel = per_channel
@@ -1767,7 +1767,7 @@ class ISONoise(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.intensity = intensity
         self.color_shift = color_shift
 
@@ -1820,7 +1820,7 @@ class CLAHE(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.clip_limit = cast(Tuple[float, float], clip_limit)
         self.tile_grid_size = tile_grid_size
 
@@ -1902,8 +1902,7 @@ class RandomGamma(ImageOnlyTransform):
         gamma_limit (Union[int, Tuple[int, int]]): The range for gamma adjustment. If `gamma_limit` is a single
             int, the range will be interpreted as (-gamma_limit, gamma_limit), defining how much
             to adjust the image's gamma. Default is (80, 120).
-        always_apply (bool): If `True`, the transform will always be applied, regardless of `p`.
-            Default is `False`.
+        always_apply: Depreciated. Use `p=1` instead.
         p (float): The probability that the transform will be applied. Default is 0.5.
 
     Targets:
@@ -1926,7 +1925,7 @@ class RandomGamma(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.gamma_limit = cast(Tuple[float, float], gamma_limit)
 
     def apply(self, img: np.ndarray, gamma: float, **params: Any) -> np.ndarray:
@@ -1988,8 +1987,8 @@ class ToRGB(ImageOnlyTransform):
 
     """
 
-    def __init__(self, always_apply: bool = True, p: float = 1.0):
-        super().__init__(always_apply=always_apply, p=p)
+    def __init__(self, p: float = 1.0, always_apply: Optional[bool] = True):
+        super().__init__(p=p, always_apply=always_apply)
 
     def apply(self, img: np.ndarray, **params: Any) -> np.ndarray:
         if is_rgb_image(img):
@@ -2019,8 +2018,8 @@ class ToSepia(ImageOnlyTransform):
 
     """
 
-    def __init__(self, always_apply: Optional[bool] = None, p: float = 0.5):
-        super().__init__(always_apply, p)
+    def __init__(self, p: float = 0.5, always_apply: Optional[bool] = None):
+        super().__init__(p, always_apply)
         self.sepia_transformation_matrix = np.array(
             [[0.393, 0.769, 0.189], [0.349, 0.686, 0.168], [0.272, 0.534, 0.131]],
         )
@@ -2059,8 +2058,8 @@ class ToFloat(ImageOnlyTransform):
         max_value: Optional[float] = Field(default=None, description="Maximum possible input value.")
         p: ProbabilityType = 1
 
-    def __init__(self, max_value: Optional[float] = None, always_apply: Optional[bool] = None, p: float = 1.0):
-        super().__init__(always_apply, p)
+    def __init__(self, max_value: Optional[float] = None, p: float = 1.0, always_apply: Optional[bool] = None):
+        super().__init__(p, always_apply)
         self.max_value = max_value
 
     def apply(self, img: np.ndarray, **params: Any) -> np.ndarray:
@@ -2106,7 +2105,7 @@ class FromFloat(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 1.0,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.dtype = np.dtype(dtype)
         self.max_value = max_value
 
@@ -2223,7 +2222,7 @@ class Downscale(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.scale_range = scale_range
         self.interpolation_pair = interpolation_pair
 
@@ -2273,7 +2272,7 @@ class Lambda(NoOp):
         always_apply: Optional[bool] = None,
         p: float = 1.0,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
 
         self.name = name
         self.custom_apply_fns = {
@@ -2375,7 +2374,7 @@ class MultiplicativeNoise(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.multiplier = cast(Tuple[float, float], multiplier)
         self.elementwise = elementwise
 
@@ -2433,8 +2432,8 @@ class FancyPCA(ImageOnlyTransform):
     class InitSchema(BaseTransformInitSchema):
         alpha: float = Field(default=0.1, description="Scale for perturbing the eigen vectors and values", ge=0)
 
-    def __init__(self, alpha: float = 0.1, always_apply: Optional[bool] = None, p: float = 0.5):
-        super().__init__(always_apply=always_apply, p=p)
+    def __init__(self, alpha: float = 0.1, p: float = 0.5, always_apply: Optional[bool] = None):
+        super().__init__(p=p, always_apply=always_apply)
         self.alpha = alpha
 
     def apply(self, img: np.ndarray, alpha: float, **params: Any) -> np.ndarray:
@@ -2511,7 +2510,7 @@ class ColorJitter(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
 
         self.brightness = cast(Tuple[float, float], brightness)
         self.contrast = cast(Tuple[float, float], contrast)
@@ -2591,7 +2590,7 @@ class Sharpen(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.alpha = alpha
         self.lightness = lightness
 
@@ -2643,7 +2642,7 @@ class Emboss(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.alpha = alpha
         self.strength = strength
 
@@ -2732,7 +2731,7 @@ class Superpixels(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.p_replace = cast(Tuple[float, float], p_replace)
         self.n_segments = cast(Tuple[int, int], n_segments)
         self.max_size = max_size
@@ -2811,7 +2810,7 @@ class TemplateTransform(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.templates = templates
         self.img_weight = cast(Tuple[float, float], img_weight)
         self.template_weight = cast(Tuple[float, float], template_weight)
@@ -2921,7 +2920,7 @@ class RingingOvershoot(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.blur_limit = cast(Tuple[int, int], blur_limit)
         self.cutoff = cast(Tuple[float, float], cutoff)
 
@@ -3006,7 +3005,7 @@ class UnsharpMask(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.blur_limit = cast(Tuple[int, int], blur_limit)
         self.sigma_limit = cast(Tuple[float, float], sigma_limit)
         self.alpha = cast(Tuple[float, float], alpha)
@@ -3081,7 +3080,7 @@ class PixelDropout(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.dropout_prob = dropout_prob
         self.per_channel = per_channel
         self.drop_value = drop_value
@@ -3248,7 +3247,7 @@ class Spatter(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.mean = cast(Tuple[float, float], mean)
         self.std = cast(Tuple[float, float], std)
         self.gauss_sigma = cast(Tuple[float, float], gauss_sigma)
@@ -3375,7 +3374,7 @@ class ChromaticAberration(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
         self.primary_distortion_limit = cast(Tuple[float, float], primary_distortion_limit)
         self.secondary_distortion_limit = cast(Tuple[float, float], secondary_distortion_limit)
         self.mode = mode
@@ -3493,7 +3492,7 @@ class Morphological(DualTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply, p)
+        super().__init__(p, always_apply)
         self.scale = cast(Tuple[int, int], scale)
         self.operation = operation
 
@@ -3604,7 +3603,7 @@ class PlanckianJitter(ImageOnlyTransform):
         always_apply: Optional[bool] = None,
         p: float = 0.5,
     ) -> None:
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p, always_apply=always_apply)
 
         self.mode = mode
         self.temperature_limit = cast(Tuple[int, int], temperature_limit)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1987,7 +1987,7 @@ class ToRGB(ImageOnlyTransform):
 
     """
 
-    def __init__(self, p: float = 1.0, always_apply: Optional[bool] = True):
+    def __init__(self, p: float = 1.0, always_apply: Optional[bool] = None):
         super().__init__(p=p, always_apply=always_apply)
 
     def apply(self, img: np.ndarray, **params: Any) -> np.ndarray:

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -63,7 +63,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
     class InitSchema(BaseTransformInitSchema):
         pass
 
-    def __init__(self, always_apply: Optional[bool] = None, p: float = 0.5):
+    def __init__(self, p: float = 0.5, always_apply: Optional[bool] = None):
         self.p = p
         if always_apply is not None:
             if always_apply:

--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -26,8 +26,8 @@ class ToTensorV2(BasicTransform):
 
     _targets = (Targets.IMAGE, Targets.MASK)
 
-    def __init__(self, transpose_mask: bool = False, always_apply: Optional[bool] = None, p: float = 1.0):
-        super().__init__(always_apply=always_apply, p=p)
+    def __init__(self, transpose_mask: bool = False, p: float = 1.0, always_apply: Optional[bool] = None):
+        super().__init__(p=p, always_apply=always_apply)
         self.transpose_mask = transpose_mask
 
     @property

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -354,8 +354,8 @@ def test_transform_without_schema() -> None:
 
 
 class CustomImageTransform(ImageOnlyTransform):
-    def __init__(self, custom_param: int, always_apply: Optional[bool] = None, p: float = 0.5):
-        super().__init__(always_apply=always_apply, p=p)
+    def __init__(self, custom_param: int, p: float = 0.5, always_apply: Optional[bool] = None):
+        super().__init__(p=p, always_apply=always_apply)
         self.custom_param = custom_param
 
 


### PR DESCRIPTION
change arguments order at `BasicTransform`.
Now `p` before deprecated `always_apply`.

fix for #1435

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses issue #1435 by reordering the arguments in the `BasicTransform` and its subclasses to ensure that the `p` parameter comes before the deprecated `always_apply` parameter. This change ensures consistency and proper usage of the parameters.

- **Bug Fixes**:
    - Reordered arguments in the `BasicTransform` and its subclasses to place `p` before the deprecated `always_apply` parameter.

<!-- Generated by sourcery-ai[bot]: end summary -->