### PR TITLE
Fix compose check data post transform

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1,7 +1,7 @@
 import random
 import warnings
 from collections import OrderedDict, defaultdict
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Union, cast
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, Union, cast
 
 import cv2
 import numpy as np
@@ -18,7 +18,7 @@ from .serialization import (
     instantiate_nonserializable,
 )
 from .transforms_interface import BasicTransform
-from .utils import format_args, get_shape
+from .utils import DataProcessor, format_args, get_shape
 
 __all__ = [
     "BaseCompose",
@@ -61,6 +61,7 @@ def get_transforms_dict(transforms: TransformsSeqType) -> Dict[int, BasicTransfo
 
 class BaseCompose(Serializable):
     _transforms_dict: Optional[Dict[int, BasicTransform]] = None
+    check_each_transform: Optional[Tuple[DataProcessor, ...]] = None
 
     def __init__(self, transforms: TransformsSeqType, p: float):
         if isinstance(transforms, (BaseCompose, BasicTransform)):
@@ -174,6 +175,19 @@ class BaseCompose(Serializable):
         for t in self.transforms:
             t.set_deterministic(flag, save_key)
 
+    def check_data_post_transform(self, data: Any) -> Dict[str, Any]:
+        if self.check_each_transform:
+            rows, cols = get_shape(data["image"])
+
+            for proc in self.check_each_transform:
+                for data_name in data:
+                    if data_name in proc.data_fields or (
+                        data_name in self._additional_targets
+                        and self._additional_targets[data_name] in proc.data_fields
+                    ):
+                        data[data_name] = proc.filter(data[data_name], rows, cols)
+        return data
+
 
 class Compose(BaseCompose, HubMixin):
     """Compose transforms and handle all transformations regarding bounding boxes
@@ -235,12 +249,12 @@ class Compose(BaseCompose, HubMixin):
 
         self.is_check_args = True
         self.strict = strict
-        self._disable_check_args_for_transforms(self.transforms)
 
         self.is_check_shapes = is_check_shapes
-        self._check_each_transform = tuple(  # processors that checks after each transform
+        self.check_each_transform = tuple(  # processors that checks after each transform
             proc for proc in self.processors.values() if getattr(proc.params, "check_each_transform", False)
         )
+        self._set_check_args_for_transforms(self.transforms)
 
         self.return_params = return_params
         if return_params:
@@ -249,11 +263,13 @@ class Compose(BaseCompose, HubMixin):
             self._transforms_dict = get_transforms_dict(self.transforms)
             self.set_deterministic(True, save_key=save_key)
 
-    @staticmethod
-    def _disable_check_args_for_transforms(transforms: TransformsSeqType) -> None:
+    def _set_check_args_for_transforms(self, transforms: TransformsSeqType) -> None:
         for transform in transforms:
             if isinstance(transform, BaseCompose):
-                Compose._disable_check_args_for_transforms(transform.transforms)
+                self._set_check_args_for_transforms(transform.transforms)
+                transform.check_each_transform = self.check_each_transform
+                if not isinstance(transform, Compose):  # need fix compose.
+                    transform.processors = self.processors
             if isinstance(transform, Compose):
                 transform.disable_check_args_private()
 
@@ -281,9 +297,7 @@ class Compose(BaseCompose, HubMixin):
 
         for t in self.transforms:
             data = t(**data)
-
-            if self._check_each_transform:
-                data = self._check_data_post_transform(data)
+            data = self.check_data_post_transform(data)
 
         return self.postprocess(data)
 
@@ -297,9 +311,7 @@ class Compose(BaseCompose, HubMixin):
         for tr_id, param in params.items():
             tr = self._transforms_dict[tr_id]
             data = tr.apply_with_params(param, **data)
-
-            if self._check_each_transform:
-                data = self._check_data_post_transform(data)
+            data = self.check_data_post_transform(data)
 
         return self.postprocess(data)
 
@@ -320,17 +332,6 @@ class Compose(BaseCompose, HubMixin):
         data = Compose._make_targets_contiguous(data)  # ensure output targets are contiguous
         for p in self.processors.values():
             p.postprocess(data)
-        return data
-
-    def _check_data_post_transform(self, data: Any) -> Dict[str, Any]:
-        rows, cols = get_shape(data["image"])
-
-        for p in self._check_each_transform:
-            for data_name in data:
-                if data_name in p.data_fields or (
-                    data_name in self._additional_targets and self._additional_targets[data_name] in p.data_fields
-                ):
-                    data[data_name] = p.filter(data[data_name], rows, cols)
         return data
 
     def to_dict_private(self) -> Dict[str, Any]:
@@ -676,4 +677,5 @@ class Sequential(BaseCompose):
         if self.replay_mode or force_apply or random.random() < self.p:
             for t in self.transforms:
                 data = t(**data)
+                data = self.check_data_post_transform(data)
         return data

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -457,6 +457,7 @@ class SomeOf(BaseCompose):
         if self.replay_mode:
             for t in self.transforms:
                 data = t(**data)
+                data = self.check_data_post_transform(data)
             return data
 
         if self.transforms_ps and (force_apply or random.random() < self.p):
@@ -464,6 +465,7 @@ class SomeOf(BaseCompose):
             for i in idx:
                 t = self.transforms[i]
                 data = t(force_apply=True, **data)
+                data = self.check_data_post_transform(data)
         return data
 
     def to_dict_private(self) -> Dict[str, Any]:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -101,6 +101,7 @@ def test_sequential(target_as_params):
     augmentation(image=image)
     assert len([transform for transform in transforms if transform.called]) == len(transforms)
 
+
 @pytest.mark.parametrize("input,kwargs,expected", [
     (10, {}, (-10, 10)),
     (0.5, {}, (-0.5, 0.5)),
@@ -206,7 +207,7 @@ def test_get_transforms_dict(transforms: TransformsSeqType, len_expected: int) -
     assert aug._transforms_dict == transforms_dict
 
 
-def test_comose_run_with_params_exeption() -> None:
+def test_comose_run_with_params_exception() -> None:
     aug = Compose([NoOp()])
     aug_2 = Compose([NoOp()], return_params=True)
     res = aug_2(image=np.random.random((8, 8)))
@@ -583,7 +584,7 @@ def test_compose_image_mask_equal_size(targets):
     transforms(**targets)
 
 
-def test_additional_targets():
+def test_additional_targets_overwrite():
     """Check add_target rises error if trying add existing target."""
     transforms = Compose([], additional_targets={"image2": "image"})
     # add same name, same target, OK
@@ -607,6 +608,7 @@ def test_sequential_with_horizontal_flip_prob_1(image):
 
     assert np.array_equal(result['image'], expected['image'])
     assert np.array_equal(result['mask'], expected['mask'])
+
 
 # Test 2: Probability 0 with HorizontalFlip
 @pytest.mark.parametrize("image", IMAGES)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -499,6 +499,98 @@ def test_check_each_transform_sequential(targets, bbox_params, keypoint_params, 
         assert np.all(np.array(item) == np.array(res[key]))
 
 
+@pytest.mark.parametrize(
+    ["targets", "bbox_params", "keypoint_params", "expected"],
+    [
+        [
+            {"keypoints": [[10, 10], [70, 70], [10, 70], [70, 10]]},
+            None,
+            KeypointParams("xy", check_each_transform=False),
+            {"keypoints": np.array([[10, 10], [70, 70], [10, 70], [70, 10]]) + 25},
+        ],
+        [
+            {"keypoints": [[10, 10], [70, 70], [10, 70], [70, 10]]},
+            None,
+            KeypointParams("xy", check_each_transform=True),
+            {"keypoints": np.array([[10, 10]]) + 25},
+        ],
+        [
+            {"bboxes": [[0, 0, 10, 10, 0], [5, 5, 70, 70, 0], [60, 60, 70, 70, 0]]},
+            BboxParams("pascal_voc", check_each_transform=False),
+            None,
+            {"bboxes": [[25, 25, 35, 35, 0], [30, 30, 95, 95, 0], [85, 85, 95, 95, 0]]},
+        ],
+        [
+            {"bboxes": [[0, 0, 10, 10, 0], [5, 5, 70, 70, 0], [60, 60, 70, 70, 0]]},
+            BboxParams("pascal_voc", check_each_transform=True),
+            None,
+            {"bboxes": [[25, 25, 35, 35, 0], [30, 30, 75, 75, 0]]},
+        ],
+        [
+            {
+                "bboxes": [[0, 0, 10, 10, 0], [5, 5, 70, 70, 0], [60, 60, 70, 70, 0]],
+                "keypoints": [[10, 10], [70, 70], [10, 70], [70, 10]],
+            },
+            BboxParams("pascal_voc", check_each_transform=True),
+            KeypointParams("xy", check_each_transform=True),
+            {"bboxes": [[25, 25, 35, 35, 0], [30, 30, 75, 75, 0]], "keypoints": np.array([[10, 10]]) + 25},
+        ],
+        [
+            {
+                "bboxes": [[0, 0, 10, 10, 0], [5, 5, 70, 70, 0], [60, 60, 70, 70, 0]],
+                "keypoints": [[10, 10], [70, 70], [10, 70], [70, 10]],
+            },
+            BboxParams("pascal_voc", check_each_transform=False),
+            KeypointParams("xy", check_each_transform=True),
+            {
+                "bboxes": [[25, 25, 35, 35, 0], [30, 30, 95, 95, 0], [85, 85, 95, 95, 0]],
+                "keypoints": np.array([[10, 10]]) + 25,
+            },
+        ],
+        [
+            {
+                "bboxes": [[0, 0, 10, 10, 0], [5, 5, 70, 70, 0], [60, 60, 70, 70, 0]],
+                "keypoints": [[10, 10], [70, 70], [10, 70], [70, 10]],
+            },
+            BboxParams("pascal_voc", check_each_transform=True),
+            KeypointParams("xy", check_each_transform=False),
+            {
+                "bboxes": [[25, 25, 35, 35, 0], [30, 30, 75, 75, 0]],
+                "keypoints": np.array([[10, 10], [70, 70], [10, 70], [70, 10]]) + 25,
+            },
+        ],
+        [
+            {
+                "bboxes": [[0, 0, 10, 10, 0], [5, 5, 70, 70, 0], [60, 60, 70, 70, 0]],
+                "keypoints": [[10, 10], [70, 70], [10, 70], [70, 10]],
+            },
+            BboxParams("pascal_voc", check_each_transform=False),
+            KeypointParams("xy", check_each_transform=False),
+            {
+                "bboxes": [[25, 25, 35, 35, 0], [30, 30, 95, 95, 0], [85, 85, 95, 95, 0]],
+                "keypoints": np.array([[10, 10], [70, 70], [10, 70], [70, 10]]) + 25,
+            },
+        ],
+    ],
+)
+def test_check_each_transform_someof(targets, bbox_params, keypoint_params, expected):
+    """test if someof inside compose"""
+    image = np.empty([100, 100], dtype=np.uint8)
+
+    augs = Compose(
+        [
+            SomeOf([Crop(0, 0, 50, 50)], n=1, replace=False, p=1.0),
+            SomeOf([PadIfNeeded(100, 100)], n=1, replace=False, p=1.0),
+        ],
+        bbox_params=bbox_params,
+        keypoint_params=keypoint_params,
+    )
+    res = augs(image=image, **targets)
+
+    for key, item in expected.items():
+        assert np.all(np.array(item) == np.array(res[key]))
+
+
 @pytest.mark.parametrize("image", IMAGES)
 def test_bbox_params_is_not_set(image, bboxes):
     t = Compose([A.NoOp(p=1.0)])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -484,6 +484,95 @@ def test_check_each_transform(targets, bbox_params, keypoint_params, expected):
         ],
     ],
 )
+def test_check_each_transform_compose(targets, bbox_params, keypoint_params, expected):
+    """test if compose inside compose"""
+    image = np.empty([100, 100], dtype=np.uint8)
+
+    augs = Compose(
+        [Compose([Crop(0, 0, 50, 50), PadIfNeeded(100, 100)])],
+        bbox_params=bbox_params,
+        keypoint_params=keypoint_params,
+    )
+    res = augs(image=image, **targets)
+
+    for key, item in expected.items():
+        assert np.all(np.array(item) == np.array(res[key]))
+
+
+@pytest.mark.parametrize(
+    ["targets", "bbox_params", "keypoint_params", "expected"],
+    [
+        [
+            {"keypoints": [[10, 10], [70, 70], [10, 70], [70, 10]]},
+            None,
+            KeypointParams("xy", check_each_transform=False),
+            {"keypoints": np.array([[10, 10], [70, 70], [10, 70], [70, 10]]) + 25},
+        ],
+        [
+            {"keypoints": [[10, 10], [70, 70], [10, 70], [70, 10]]},
+            None,
+            KeypointParams("xy", check_each_transform=True),
+            {"keypoints": np.array([[10, 10]]) + 25},
+        ],
+        [
+            {"bboxes": [[0, 0, 10, 10, 0], [5, 5, 70, 70, 0], [60, 60, 70, 70, 0]]},
+            BboxParams("pascal_voc", check_each_transform=False),
+            None,
+            {"bboxes": [[25, 25, 35, 35, 0], [30, 30, 95, 95, 0], [85, 85, 95, 95, 0]]},
+        ],
+        [
+            {"bboxes": [[0, 0, 10, 10, 0], [5, 5, 70, 70, 0], [60, 60, 70, 70, 0]]},
+            BboxParams("pascal_voc", check_each_transform=True),
+            None,
+            {"bboxes": [[25, 25, 35, 35, 0], [30, 30, 75, 75, 0]]},
+        ],
+        [
+            {
+                "bboxes": [[0, 0, 10, 10, 0], [5, 5, 70, 70, 0], [60, 60, 70, 70, 0]],
+                "keypoints": [[10, 10], [70, 70], [10, 70], [70, 10]],
+            },
+            BboxParams("pascal_voc", check_each_transform=True),
+            KeypointParams("xy", check_each_transform=True),
+            {"bboxes": [[25, 25, 35, 35, 0], [30, 30, 75, 75, 0]], "keypoints": np.array([[10, 10]]) + 25},
+        ],
+        [
+            {
+                "bboxes": [[0, 0, 10, 10, 0], [5, 5, 70, 70, 0], [60, 60, 70, 70, 0]],
+                "keypoints": [[10, 10], [70, 70], [10, 70], [70, 10]],
+            },
+            BboxParams("pascal_voc", check_each_transform=False),
+            KeypointParams("xy", check_each_transform=True),
+            {
+                "bboxes": [[25, 25, 35, 35, 0], [30, 30, 95, 95, 0], [85, 85, 95, 95, 0]],
+                "keypoints": np.array([[10, 10]]) + 25,
+            },
+        ],
+        [
+            {
+                "bboxes": [[0, 0, 10, 10, 0], [5, 5, 70, 70, 0], [60, 60, 70, 70, 0]],
+                "keypoints": [[10, 10], [70, 70], [10, 70], [70, 10]],
+            },
+            BboxParams("pascal_voc", check_each_transform=True),
+            KeypointParams("xy", check_each_transform=False),
+            {
+                "bboxes": [[25, 25, 35, 35, 0], [30, 30, 75, 75, 0]],
+                "keypoints": np.array([[10, 10], [70, 70], [10, 70], [70, 10]]) + 25,
+            },
+        ],
+        [
+            {
+                "bboxes": [[0, 0, 10, 10, 0], [5, 5, 70, 70, 0], [60, 60, 70, 70, 0]],
+                "keypoints": [[10, 10], [70, 70], [10, 70], [70, 10]],
+            },
+            BboxParams("pascal_voc", check_each_transform=False),
+            KeypointParams("xy", check_each_transform=False),
+            {
+                "bboxes": [[25, 25, 35, 35, 0], [30, 30, 95, 95, 0], [85, 85, 95, 95, 0]],
+                "keypoints": np.array([[10, 10], [70, 70], [10, 70], [70, 10]]) + 25,
+            },
+        ],
+    ],
+)
 def test_check_each_transform_sequential(targets, bbox_params, keypoint_params, expected):
     """test if sequential inside compose"""
     image = np.empty([100, 100], dtype=np.uint8)
@@ -913,8 +1002,10 @@ def test_transform_always_apply_warning() -> None:
 def test_crop_near_bbox(image):
     set_seed(42)
     bbox_key = "target_bbox"
-    aug = A.Compose([A.RandomCropNearBBox(max_part_shift=(0.1, 0.5), cropping_bbox_key=bbox_key, p=1)],
-        bbox_params=BboxParams("pascal_voc"))
+    aug = A.Compose(
+        [A.RandomCropNearBBox(max_part_shift=(0.1, 0.5), cropping_bbox_key=bbox_key, p=1)],
+        bbox_params=BboxParams("pascal_voc"),
+    )
 
     aug(image=image, bboxes=[[1, 2, 3, 4, 1]], target_bbox=[0, 5, 10, 20])
 
@@ -922,7 +1013,9 @@ def test_crop_near_bbox(image):
 
     assert aug._available_keys == target_keys
 
-    aug2 = A.Compose([A.Sequential([A.RandomCropNearBBox(max_part_shift=(0.1, 0.5), cropping_bbox_key=bbox_key, p=1)])],
-        bbox_params=BboxParams("pascal_voc"))
+    aug2 = A.Compose(
+        [A.Sequential([A.RandomCropNearBBox(max_part_shift=(0.1, 0.5), cropping_bbox_key=bbox_key, p=1)])],
+        bbox_params=BboxParams("pascal_voc"),
+    )
 
     assert aug2._available_keys == target_keys


### PR DESCRIPTION
When we uses nested containers like `Compose`, `Sequential`, `SomeOf ` inside `Compose`, we need check data after each transform inside those too.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhanced the Compose class to support data validation after each transform within nested containers and added corresponding test cases.

- **Enhancements**:
    - Added functionality to check data after each transform within nested containers like Compose, Sequential, and SomeOf.
    - Introduced new parameters and methods in the Compose class to support data validation post each transform.
- **Tests**:
    - Added multiple test cases to validate the new data checking functionality within nested Compose, Sequential, and SomeOf containers.

<!-- Generated by sourcery-ai[bot]: end summary -->