### PR TITLE
fix tests for FromFloat

### DIFF
--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -223,7 +223,7 @@ def test_dual_augmentations_with_float_values(augmentation_cls, params):
                 "mask_fill_value": 1,
                 "fill_value": 0,
             },
-             A.MixUp: {
+            A.MixUp: {
                 "reference_data": [{"image": SQUARE_UINT8_IMAGE,
                                     "mask": np.random.randint(0, 1, [100, 100, 1], dtype=np.uint8),
                                     }],
@@ -236,7 +236,7 @@ def test_dual_augmentations_with_float_values(augmentation_cls, params):
     ),
 )
 def test_augmentations_wont_change_input(augmentation_cls, params):
-    image = SQUARE_UINT8_IMAGE
+    image = SQUARE_FLOAT_IMAGE if augmentation_cls == A.FromFloat else SQUARE_UINT8_IMAGE
     mask = image[:, :, 0].copy()
     image_copy = image.copy()
     mask_copy = mask.copy()
@@ -393,7 +393,7 @@ def test_augmentations_wont_change_shape_grayscale(augmentation_cls, params, sha
     aug = augmentation_cls(p=1, **params)
 
     # Test for grayscale image
-    image = np.zeros(shape, dtype=np.uint8)
+    image = np.zeros(shape, dtype=np.float32) if augmentation_cls == A.FromFloat else np.zeros(shape, dtype=np.uint8)
     mask = np.zeros(shape)
     if augmentation_cls == A.OverlayElements:
         data = {
@@ -440,7 +440,7 @@ def test_augmentations_wont_change_shape_grayscale(augmentation_cls, params, sha
                 "mask_fill_value": 1,
                 "fill_value": 0,
             },
-             A.MixUp: {
+            A.MixUp: {
                 "reference_data": [{"image": SQUARE_UINT8_IMAGE,
                                     "mask": np.random.randint(0, 1, (100, 100, 3), dtype=np.uint8),
                                     }],
@@ -477,6 +477,11 @@ def test_augmentations_wont_change_shape_rgb(augmentation_cls, params):
         data = {
             "image": image_3ch,
             "overlay_metadata": [],
+            "mask": mask_3ch,
+        }
+    elif augmentation_cls == A.FromFloat:
+        data = {
+            "image": SQUARE_FLOAT_IMAGE,
             "mask": mask_3ch,
         }
     else:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -14,7 +14,7 @@ import albumentations.augmentations.geometric.functional as FGeometric
 from albumentations.core.serialization import SERIALIZABLE_REGISTRY, shorten_class_name
 from albumentations.core.transforms_interface import ImageOnlyTransform
 from albumentations.core.types import ImageCompressionType
-from tests.conftest import FLOAT32_IMAGES, IMAGES, SQUARE_UINT8_IMAGE, UINT8_IMAGES
+from tests.conftest import FLOAT32_IMAGES, IMAGES, SQUARE_UINT8_IMAGE, UINT8_IMAGES, SQUARE_FLOAT_IMAGE
 
 
 from .utils import (
@@ -571,12 +571,12 @@ def test_augmentations_serialization_to_file_with_custom_parameters(
             A.Resize: {"height": 10, "width": 10},
             A.RandomSizedBBoxSafeCrop: {"height": 10, "width": 10},
             A.BBoxSafeRandomCrop: {"erosion_rate": 0.6},
-             A.PadIfNeeded: {
-            "min_height": 512,
-            "min_width": 512,
-            "border_mode": 0,
-            "value": [124, 116, 104],
-            "position": "top_left"
+            A.PadIfNeeded: {
+                "min_height": 512,
+                "min_width": 512,
+                "border_mode": 0,
+                "value": [124, 116, 104],
+                "position": "top_left"
             },
         },
         except_augmentations={
@@ -600,10 +600,10 @@ def test_augmentations_serialization_to_file_with_custom_parameters(
 )
 @pytest.mark.parametrize("p", [0.5, 1])
 @pytest.mark.parametrize("seed", TEST_SEEDS)
-@pytest.mark.parametrize("image", UINT8_IMAGES)
 def test_augmentations_for_bboxes_serialization(
-    augmentation_cls, params, p, seed, image, albumentations_bboxes
+    augmentation_cls, params, p, seed, albumentations_bboxes
 ):
+    image = SQUARE_FLOAT_IMAGE if augmentation_cls == A.FromFloat else SQUARE_UINT8_IMAGE
     aug = augmentation_cls(p=p, **params)
     serialized_aug = A.to_dict(aug)
     deserialized_aug = A.from_dict(serialized_aug)
@@ -635,12 +635,12 @@ def test_augmentations_for_bboxes_serialization(
                 "fill_value": 0,
                 "mask_fill_value": 1,
             },
-             A.PadIfNeeded: {
-            "min_height": 512,
-            "min_width": 512,
-            "border_mode": 0,
-            "value": [124, 116, 104],
-            "position": "top_left"
+            A.PadIfNeeded: {
+                "min_height": 512,
+                "min_width": 512,
+                "border_mode": 0,
+                "value": [124, 116, 104],
+                "position": "top_left"
             }
         },
         except_augmentations={
@@ -665,8 +665,8 @@ def test_augmentations_for_bboxes_serialization(
 )
 @pytest.mark.parametrize("p", [0.5, 1])
 @pytest.mark.parametrize("seed", TEST_SEEDS)
-@pytest.mark.parametrize("image", UINT8_IMAGES)
-def test_augmentations_for_keypoints_serialization(augmentation_cls, params, p, seed, image, keypoints):
+def test_augmentations_for_keypoints_serialization(augmentation_cls, params, p, seed, keypoints):
+    image = SQUARE_FLOAT_IMAGE if augmentation_cls == A.FromFloat else SQUARE_UINT8_IMAGE
     aug = augmentation_cls(p=p, **params)
     serialized_aug = A.to_dict(aug)
     deserialized_aug = A.from_dict(serialized_aug)
@@ -887,8 +887,8 @@ def test_transform_pipeline_serialization_with_keypoints(seed, image, keypoints,
     ),
 )
 @pytest.mark.parametrize("seed", TEST_SEEDS)
-@pytest.mark.parametrize("image", UINT8_IMAGES)
-def test_additional_targets_for_image_only_serialization(augmentation_cls, params, image, seed):
+def test_additional_targets_for_image_only_serialization(augmentation_cls, params, seed):
+    image = SQUARE_FLOAT_IMAGE if augmentation_cls == A.FromFloat else SQUARE_UINT8_IMAGE
     aug = A.Compose(
         [augmentation_cls(p=1., **params)],
         additional_targets={"image2": "image"},

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -265,7 +265,7 @@ def __test_multiprocessing_support_proc(args):
 )
 def test_multiprocessing_support(mp_pool, augmentation_cls, params):
     """Checks whether we can use augmentations in multiprocessing environments"""
-    image = SQUARE_UINT8_IMAGE
+    image = SQUARE_FLOAT_IMAGE if augmentation_cls == A.FromFloat else SQUARE_UINT8_IMAGE
     aug = augmentation_cls(p=1, **params)
 
     mp_pool.map(__test_multiprocessing_support_proc, map(lambda x: (x, aug), [image] * 10))
@@ -332,7 +332,7 @@ def test_force_apply():
 def test_additional_targets_for_image_only(augmentation_cls, params):
     aug = A.Compose([augmentation_cls(p=1, **params)], additional_targets={"image2": "image"})
     for _ in range(10):
-        image1 = SQUARE_UINT8_IMAGE
+        image1 = SQUARE_FLOAT_IMAGE if augmentation_cls == A.FromFloat else SQUARE_UINT8_IMAGE
         image2 = image1.copy()
         res = aug(image=image1, image2=image2)
         aug1 = res["image"]
@@ -342,12 +342,13 @@ def test_additional_targets_for_image_only(augmentation_cls, params):
     aug = A.Compose([augmentation_cls(p=1, **params)])
     aug.add_targets(additional_targets={"image2": "image"})
     for _ in range(10):
-        image1 = SQUARE_UINT8_IMAGE
+        image1 = SQUARE_FLOAT_IMAGE if augmentation_cls == A.FromFloat else SQUARE_UINT8_IMAGE
         image2 = image1.copy()
         res = aug(image=image1, image2=image2)
         aug1 = res["image"]
         aug2 = res["image2"]
         assert np.array_equal(aug1, aug2)
+
 
 def test_image_invert():
     for _ in range(10):
@@ -1454,6 +1455,10 @@ def test_change_image(augmentation_cls, params):
                 "bbox": (0.1, 0.12, 0.6, 0.3)
             }
         }
+    elif augmentation_cls == A.FromFloat:
+        data = {
+            "image": SQUARE_FLOAT_IMAGE,
+        }
     else:
         data = {
             "image": image,
@@ -1513,7 +1518,8 @@ def test_change_image(augmentation_cls, params):
             A.RandomRotate90,
             A.FancyPCA,
             A.PlanckianJitter,
-            A.OverlayElements
+            A.OverlayElements,
+            A.FromFloat,
         },
     ),
 )


### PR DESCRIPTION
`FromFloat` need input array  in the range [0, 1.0].
Fix tests with int input array.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the tests for the `FromFloat` augmentation by ensuring that input arrays are in the range [0, 1.0] as required. The changes involve updating the test cases to use the correct input data type.

- **Bug Fixes**:
    - Fixed tests for `FromFloat` to use input arrays in the range [0, 1.0] instead of integer arrays.

<!-- Generated by sourcery-ai[bot]: end summary -->