### PR TITLE
Fix rotatate by 90

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -48,6 +48,8 @@ __all__ = [
     "adjust_hue_torchvision",
     "adjust_saturation_torchvision",
     "brightness_contrast_adjust",
+    "center",
+    "center_bbox",
     "channel_shuffle",
     "clahe",
     "convolve",
@@ -1430,6 +1432,19 @@ def center(width: NumericType, height: NumericType) -> tuple[float, float]:
         tuple[float, float]: The center coordinates of the rectangle.
     """
     return width / 2 - 0.5, height / 2 - 0.5
+
+
+def center_bbox(width: NumericType, height: NumericType) -> tuple[float, float]:
+    """Calculate the center coordinates of a rectangle.
+
+    Args:
+        width (NumericType): The width of the rectangle.
+        height (NumericType): The height of the rectangle.
+
+    Returns:
+        tuple[float, float]: The center coordinates of the rectangle.
+    """
+    return width / 2, height / 2
 
 
 PLANCKIAN_COEFFS = {

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -1422,27 +1422,27 @@ def morphology(img: np.ndarray, kernel: np.ndarray, operation: str) -> np.ndarra
 
 
 def center(width: NumericType, height: NumericType) -> tuple[float, float]:
-    """Calculate the center coordinates of a rectangle.
+    """Calculate the center coordinates if image. Used by images, masks and keypoints.
 
     Args:
         width (NumericType): The width of the rectangle.
         height (NumericType): The height of the rectangle.
 
     Returns:
-        tuple[float, float]: The center coordinates of the rectangle.
+        tuple[float, float]: The center coordinates.
     """
     return width / 2 - 0.5, height / 2 - 0.5
 
 
 def center_bbox(width: NumericType, height: NumericType) -> tuple[float, float]:
-    """Calculate the center coordinates of a rectangle.
+    """Calculate the center coordinates for of image for bounding boxes.
 
     Args:
         width (NumericType): The width of the rectangle.
         height (NumericType): The height of the rectangle.
 
     Returns:
-        tuple[float, float]: The center coordinates of the rectangle.
+        tuple[float, float]: The center coordinates.
     """
     return width / 2, height / 2
 

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Sequence, cast
 import cv2
 import numpy as np
 import skimage.transform
-from albucore.utils import clipped, maybe_process_in_chunks, preserve_channel_dim
+from albucore.utils import clipped, maybe_process_in_chunks, preserve_channel_dim, contiguous
 from scipy.ndimage import gaussian_filter
 
 from albumentations import random_utils
@@ -80,7 +80,7 @@ ROT90_180_FACTOR = 2
 ROT90_270_FACTOR = 3
 
 
-def bbox_rot90(bbox: BoxInternalType, factor: int, rows: int, cols: int) -> BoxInternalType:
+def bbox_rot90(bbox: BoxInternalType, factor: int, rows: int | None = None, cols: int | None = None) -> BoxInternalType:
     """Rotates a bounding box by 90 degrees CCW (see np.rot90)
 
     Args:
@@ -991,9 +991,9 @@ def transpose(img: np.ndarray) -> np.ndarray:
     return img.transpose(new_axes)
 
 
+@contiguous
 def rot90(img: np.ndarray, factor: int) -> np.ndarray:
-    img = np.rot90(img, factor)
-    return np.ascontiguousarray(img)
+    return np.rot90(img, factor)
 
 
 def bbox_vflip(bbox: BoxInternalType, rows: int, cols: int) -> BoxInternalType:

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -106,7 +106,12 @@ def bbox_rot90(bbox: BoxInternalType, factor: int, rows: int | None = None, cols
     return bbox
 
 
-def bbox_d4(bbox: BoxInternalType, group_member: D4Type, rows: int, cols: int) -> BoxInternalType:
+def bbox_d4(
+    bbox: BoxInternalType,
+    group_member: D4Type,
+    rows: int | None = None,
+    cols: int | None = None,
+) -> BoxInternalType:
     """Applies a `D_4` symmetry group transformation to a bounding box.
 
     The function transforms a bounding box according to the specified group member from the `D_4` group.
@@ -134,13 +139,13 @@ def bbox_d4(bbox: BoxInternalType, group_member: D4Type, rows: int, cols: int) -
     """
     transformations = {
         "e": lambda x: x,  # Identity transformation
-        "r90": lambda x: bbox_rot90(x, 1, rows, cols),  # Rotate 90 degrees
-        "r180": lambda x: bbox_rot90(x, 2, rows, cols),  # Rotate 180 degrees
-        "r270": lambda x: bbox_rot90(x, 3, rows, cols),  # Rotate 270 degrees
+        "r90": lambda x: bbox_rot90(x, 1),  # Rotate 90 degrees
+        "r180": lambda x: bbox_rot90(x, 2),  # Rotate 180 degrees
+        "r270": lambda x: bbox_rot90(x, 3),  # Rotate 270 degrees
         "v": lambda x: bbox_vflip(x, rows, cols),  # Vertical flip
-        "hvt": lambda x: bbox_transpose(bbox_rot90(x, 2, rows, cols), rows, cols),  # Reflect over anti-diagonal
-        "h": lambda x: bbox_hflip(x, rows, cols),  # Horizontal flip
-        "t": lambda x: bbox_transpose(x, rows, cols),  # Transpose (reflect over main diagonal)
+        "hvt": lambda x: bbox_transpose(bbox_rot90(x, 2)),  # Reflect over anti-diagonal
+        "h": lambda x: bbox_hflip(x),  # Horizontal flip
+        "t": lambda x: bbox_transpose(x),  # Transpose (reflect over main diagonal)
     }
 
     # Execute the appropriate transformation
@@ -996,7 +1001,7 @@ def rot90(img: np.ndarray, factor: int) -> np.ndarray:
     return np.rot90(img, factor)
 
 
-def bbox_vflip(bbox: BoxInternalType, rows: int, cols: int) -> BoxInternalType:
+def bbox_vflip(bbox: BoxInternalType, rows: int | None = None, cols: int | None = None) -> BoxInternalType:
     """Flip a bounding box vertically around the x-axis.
 
     Args:
@@ -1012,7 +1017,7 @@ def bbox_vflip(bbox: BoxInternalType, rows: int, cols: int) -> BoxInternalType:
     return x_min, 1 - y_max, x_max, 1 - y_min
 
 
-def bbox_hflip(bbox: BoxInternalType, rows: int, cols: int) -> BoxInternalType:
+def bbox_hflip(bbox: BoxInternalType, rows: int | None = None, cols: int | None = None) -> BoxInternalType:
     """Flip a bounding box horizontally around the y-axis.
 
     Args:
@@ -1028,7 +1033,7 @@ def bbox_hflip(bbox: BoxInternalType, rows: int, cols: int) -> BoxInternalType:
     return 1 - x_max, y_min, 1 - x_min, y_max
 
 
-def bbox_flip(bbox: BoxInternalType, d: int, rows: int, cols: int) -> BoxInternalType:
+def bbox_flip(bbox: BoxInternalType, d: int, rows: int | None = None, cols: int | None = None) -> BoxInternalType:
     """Flip a bounding box either vertically, horizontally or both depending on the value of `d`.
 
     Args:
@@ -1045,18 +1050,22 @@ def bbox_flip(bbox: BoxInternalType, d: int, rows: int, cols: int) -> BoxInterna
 
     """
     if d == 0:
-        bbox = bbox_vflip(bbox, rows, cols)
+        bbox = bbox_vflip(bbox)
     elif d == 1:
-        bbox = bbox_hflip(bbox, rows, cols)
+        bbox = bbox_hflip(bbox)
     elif d == -1:
-        bbox = bbox_hflip(bbox, rows, cols)
-        bbox = bbox_vflip(bbox, rows, cols)
+        bbox = bbox_hflip(bbox)
+        bbox = bbox_vflip(bbox)
     else:
         raise ValueError(f"Invalid d value {d}. Valid values are -1, 0 and 1")
     return bbox
 
 
-def bbox_transpose(bbox: KeypointInternalType, rows: int, cols: int) -> KeypointInternalType:
+def bbox_transpose(
+    bbox: KeypointInternalType,
+    rows: int | None = None,
+    cols: int | None = None,
+) -> KeypointInternalType:
     """Transposes a bounding box along given axis.
 
     Args:

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -47,11 +47,7 @@ class RandomRotate90(DualTransform):
     _targets = (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS)
 
     def apply(self, img: np.ndarray, factor: float, **params: Any) -> np.ndarray:
-        """Args:
-        factor (int): number of times the input will be rotated by 90 degrees.
-
-        """
-        return np.ascontiguousarray(np.rot90(img, factor))
+        return fgeometric.rot90(img, factor)
 
     def get_params(self) -> dict[str, int]:
         # Random int in the range [0, 3]

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -747,13 +747,13 @@ class Affine(DualTransform):
     def apply_to_bbox(
         self,
         bbox: BoxInternalType,
-        matrix_bbox: skimage.transform.ProjectiveTransform,
+        bbox_matrix: skimage.transform.ProjectiveTransform,
         rows: int,
         cols: int,
         output_shape: SizeType,
         **params: Any,
     ) -> BoxInternalType:
-        return fgeometric.bbox_affine(bbox, matrix_bbox, self.rotate_method, rows, cols, output_shape)
+        return fgeometric.bbox_affine(bbox, bbox_matrix, self.rotate_method, rows, cols, output_shape)
 
     def apply_to_keypoint(
         self,
@@ -846,7 +846,7 @@ class Affine(DualTransform):
         # Bounding box transformation matrix
         matrix_to_topleft_bbox = skimage.transform.SimilarityTransform(translation=[-shift_x_bbox, -shift_y_bbox])
         matrix_to_center_bbox = skimage.transform.SimilarityTransform(translation=[shift_x_bbox, shift_y_bbox])
-        matrix_bbox = (
+        bbox_matrix = (
             matrix_to_topleft_bbox
             + matrix_shear_y_rot
             + matrix_shear_y
@@ -864,7 +864,7 @@ class Affine(DualTransform):
             "rotate": rotate,
             "scale": scale,
             "matrix": matrix,
-            "matrix_bbox": matrix_bbox,
+            "bbox_matrix": bbox_matrix,
             "output_shape": output_shape,
         }
 

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import random
 from enum import Enum
-from typing import Any, Callable, Literal, Sequence, Tuple, cast
+from typing import Any, Callable, Literal, Tuple, cast
 from warnings import warn
 
 import cv2
@@ -14,7 +14,7 @@ from pydantic import Field, ValidationInfo, field_validator, model_validator
 from typing_extensions import Annotated, Self
 
 from albumentations import random_utils
-from albumentations.augmentations.functional import bbox_from_mask, center
+from albumentations.augmentations.functional import bbox_from_mask, center, center_bbox
 from albumentations.augmentations.utils import check_range
 from albumentations.core.bbox_utils import denormalize_bbox, normalize_bbox
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
@@ -747,13 +747,13 @@ class Affine(DualTransform):
     def apply_to_bbox(
         self,
         bbox: BoxInternalType,
-        matrix: skimage.transform.ProjectiveTransform,
+        matrix_bbox: skimage.transform.ProjectiveTransform,
         rows: int,
         cols: int,
-        output_shape: Sequence[int],
+        output_shape: SizeType,
         **params: Any,
     ) -> BoxInternalType:
-        return fgeometric.bbox_affine(bbox, matrix, self.rotate_method, rows, cols, output_shape)
+        return fgeometric.bbox_affine(bbox, matrix_bbox, self.rotate_method, rows, cols, output_shape)
 
     def apply_to_keypoint(
         self,
@@ -814,16 +814,15 @@ class Affine(DualTransform):
         else:
             translate = {"x": 0, "y": 0}
 
-        # Look to issue https://github.com/albumentations-team/albumentations/issues/1079
         shear = {key: -random.uniform(*value) for key, value in self.shear.items()}
 
         scale = self.get_scale(self.scale, self.keep_ratio, self.balanced_scale)
-
-        # Look to issue https://github.com/albumentations-team/albumentations/issues/1079
         rotate = -random.uniform(*self.rotate)
 
         shift_x, shift_y = center(width, height)
+        shift_x_bbox, shift_y_bbox = center_bbox(width, height)
 
+        # Image transformation matrix
         matrix_to_topleft = skimage.transform.SimilarityTransform(translation=[-shift_x, -shift_y])
         matrix_shear_y_rot = skimage.transform.AffineTransform(rotation=-np.pi / 2)
         matrix_shear_y = skimage.transform.AffineTransform(shear=np.deg2rad(shear["y"]))
@@ -843,6 +842,19 @@ class Affine(DualTransform):
             + matrix_transforms
             + matrix_to_center
         )
+
+        # Bounding box transformation matrix
+        matrix_to_topleft_bbox = skimage.transform.SimilarityTransform(translation=[-shift_x_bbox, -shift_y_bbox])
+        matrix_to_center_bbox = skimage.transform.SimilarityTransform(translation=[shift_x_bbox, shift_y_bbox])
+        matrix_bbox = (
+            matrix_to_topleft_bbox
+            + matrix_shear_y_rot
+            + matrix_shear_y
+            + matrix_shear_y_rot_inv
+            + matrix_transforms
+            + matrix_to_center_bbox
+        )
+
         if self.fit_output:
             matrix, output_shape = self._compute_affine_warp_output_shape(matrix, params["image"].shape)
         else:
@@ -852,6 +864,7 @@ class Affine(DualTransform):
             "rotate": rotate,
             "scale": scale,
             "matrix": matrix,
+            "matrix_bbox": matrix_bbox,
             "output_shape": output_shape,
         }
 

--- a/albumentations/core/keypoints_utils.py
+++ b/albumentations/core/keypoints_utils.py
@@ -207,7 +207,9 @@ def convert_keypoint_to_albumentations(
     if angle_in_degrees:
         a = math.radians(a)
 
-    keypoint = (x, y, angle_to_2pi_range(a), s, *tail)
+    # if we do not truncate keypoints to integer values, they get into wrong positions after the rotation
+    # https://github.com/albumentations-team/albumentations/issues/1819
+    keypoint = (int(x), int(y), angle_to_2pi_range(a), s, *tail)
     if check_validity:
         check_keypoint(keypoint, rows, cols)
     return keypoint

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def albumentations_bboxes():
 
 @pytest.fixture
 def keypoints():
-    return [[20, 30, 40, 50, 1], [20, 30, 60, 80, 2]]
+    return [[30, 20, 40, 50, 1], [20, 30, 60, 80, 2]]
 
 @pytest.fixture
 def template():

--- a/tests/functional/test_affine.py
+++ b/tests/functional/test_affine.py
@@ -4,9 +4,9 @@ import pytest
 import skimage.transform
 import cv2
 import albumentations.augmentations.geometric.functional as FGeometric
+import albumentations as A
 
 from itertools import product
-
 
 # Define your parameter sets
 image_shapes = [
@@ -151,6 +151,7 @@ def test_inverse_angle_scale(image_shape, angle, shape, scale):
 
     # Adjust the assertion threshold based on expected discrepancies from complex transformations
     assert np.mean(np.abs(image - restored_img)) < 7, "Inverse transformation failed: The restored image is not close enough to the original."
+
 
 @pytest.mark.parametrize("img,expected", [ (np.array( [[0.01, 0.02, 0.03, 0.04], [0.05, 0.06, 0.07, 0.08], [0.09, 0.10, 0.11, 0.12], [0.13, 0.14, 0.15, 0.16]], dtype=np.float32, ), np.array( [[0.04, 0.08, 0.12, 0.16], [0.03, 0.07, 0.11, 0.15], [0.02, 0.06, 0.10, 0.14], [0.01, 0.05, 0.09, 0.13]], dtype=np.float32, ) ), ( np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]], dtype=np.uint8), np.array([[6, 6, 7, 7], [6, 6, 7, 7], [10, 10, 11, 11], [10, 10, 11, 11]], dtype=np.uint8) )])  # Scale factors
 def test_scale_with_warp_affine(img, expected):


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the handling of bounding box rotations by making rows and cols parameters optional in various transformation functions. It also includes refactoring for better code clarity and adds new tests to ensure the correctness of the `rot90` function.

- **Bug Fixes**:
    - Fixed incorrect handling of bounding box rotations by ensuring optional parameters for rows and cols are correctly handled.
- **Enhancements**:
    - Refactored bounding box transformation functions to handle optional rows and cols parameters.
    - Simplified the `rot90` function to directly return the rotated image without making it contiguous.
- **Tests**:
    - Added parameterized tests for `rot90` function to validate bounding box and keypoint transformations at different angles.

<!-- Generated by sourcery-ai[bot]: end summary -->