### PR TITLE
Prevent to get zeros array after transform by chainging order of asty…

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -801,7 +801,7 @@ def iso_noise(
         raise TypeError(msg)
 
     one_over_255 = float(1.0 / 255.0)
-    image = multiply(image, one_over_255).astype(np.float32)
+    image = multiply(image.astype(np.float32), one_over_255)
     hls = cv2.cvtColor(image, cv2.COLOR_RGB2HLS)
     _, stddev = cv2.meanStdDev(hls)
 


### PR DESCRIPTION
This pull request fixes an issue with getting zeros array after ISONoise transform.
I fixed it by changing the order of astype operations.
It seems that this issue can occur depending on the version of numpy.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug in the ISONoise transform function that caused it to produce an array of zeros. The issue was resolved by adjusting the order of the astype operations, ensuring compatibility across different versions of numpy.

- **Bug Fixes**:
    - Fixed an issue where the ISONoise transform resulted in an array of zeros by changing the order of astype operations.

<!-- Generated by sourcery-ai[bot]: end summary -->