### PR TITLE
Fix in docstring in grid distortion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       types: [python]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.0
+    rev: v0.5.1
     hooks:
       # Run the linter.
       - id: ruff

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -1807,7 +1807,7 @@ class GridDistortion(DualTransform):
     Args:
         num_steps (int): Number of grid cells on each side (minimum 1).
         distort_limit (float, (float, float)): Range of distortion limits. If a single float is provided,
-            the range will be from (-distort_limit, distort_limit). Default: (-0.03, 0.03).
+            the range will be from (-distort_limit, distort_limit). Default: (-0.3, 0.3).
         interpolation (OpenCV flag): Interpolation algorithm used for image transformation. Options are:
             cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
             Default: cv2.INTER_LINEAR.
@@ -1837,7 +1837,7 @@ class GridDistortion(DualTransform):
 
     class InitSchema(BaseTransformInitSchema):
         num_steps: Annotated[int, Field(ge=1, description="Count of grid cells on each side.")]
-        distort_limit: SymmetricRangeType = (-0.03, 0.03)
+        distort_limit: SymmetricRangeType = (-0.3, 0.3)
         interpolation: InterpolationType = cv2.INTER_LINEAR
         border_mode: BorderModeType = cv2.BORDER_REFLECT_101
         value: ColorType | None = Field(


### PR DESCRIPTION
Fixes https://github.com/albumentations-team/albumentations/issues/1349

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the default value for the 'distort_limit' parameter in the GridDistortion class's docstring and schema, and updates the pre-commit configuration to use Ruff version v0.5.1.

- **Bug Fixes**:
    - Corrected the default value for the 'distort_limit' parameter in the docstring and schema of the GridDistortion class.
- **Build**:
    - Updated the pre-commit configuration to use Ruff version v0.5.1.

<!-- Generated by sourcery-ai[bot]: end summary -->