### PR TITLE
Add image target

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -45,8 +45,9 @@ TransformsSeqType = List[TransformType]
 
 AVAILABLE_KEYS = ("image", "mask", "masks", "bboxes", "keypoints", "global_label")
 MASK_KEYS = ("mask", "masks")
+IMAGE_KEYS = ("image", "images")
 CHECKED_SINGLE = ("image", "mask")
-CHECKED_MULTI = ("masks",)
+CHECKED_MULTI = ("masks", "images")
 CHECK_BBOX_PARAM = ("bboxes",)
 CHECK_KEYPOINTS_PARAM = ("keypoints",)
 
@@ -321,7 +322,7 @@ class Compose(BaseCompose, HubMixin):
     def preprocess(self, data: Any) -> None:
         if self.strict:
             for data_name in data:
-                if data_name not in self._available_keys and data_name not in MASK_KEYS:
+                if data_name not in self._available_keys and data_name not in MASK_KEYS and data_name not in IMAGE_KEYS:
                     msg = f"Key {data_name} is not in available keys."
                     raise ValueError(msg)
         if self.is_check_args:

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -44,7 +44,11 @@ TransformType = Union[BasicTransform, "BaseCompose"]
 TransformsSeqType = List[TransformType]
 
 AVAILABLE_KEYS = ("image", "mask", "masks", "bboxes", "keypoints", "global_label")
-MASK_KEYS = ("mask", "masks")
+MASK_KEYS = (
+    "mask",
+    "masks",
+)
+# Keys related to image data
 IMAGE_KEYS = ("image", "images")
 CHECKED_SINGLE = ("image", "mask")
 CHECKED_MULTI = ("masks", "images")

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -157,7 +157,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         """Apply transform on image."""
         raise NotImplementedError
 
-    def apply_to_images(self, images: np.ndarray, **params: Any) -> np.ndarray:
+    def apply_to_images(self, images: np.ndarray, **params: Any) -> list[np.ndarray]:
         """Apply transform on images."""
         return [self.apply(image, **params) for image in images]
 

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -199,12 +199,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         if hasattr(self, "mask_fill_value"):
             params["mask_fill_value"] = self.mask_fill_value
 
-        if "image" in kwargs:
-            params.update({"cols": kwargs["image"].shape[1], "rows": kwargs["image"].shape[0]})
-        elif "images" in kwargs:
-            params.update({"cols": kwargs["images"][0].shape[1], "rows": kwargs["images"][0].shape[0]})
-        else:
-            raise ValueError("You must provide 'image' or 'images' to augment")
+        params.update({"cols": kwargs["image"].shape[1], "rows": kwargs["image"].shape[0]})
 
         return params
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -40,9 +40,9 @@ from albumentations.core.transforms_interface import (
     NoOp
 )
 from albumentations.core.utils import to_tuple
-from tests.conftest import IMAGES
+from tests.conftest import IMAGES, SQUARE_FLOAT_IMAGE, SQUARE_UINT8_IMAGE
 
-from .utils import get_filtered_transforms, set_seed
+from .utils import get_filtered_transforms, get_image_only_transforms, get_transforms, set_seed
 
 
 def test_one_or_other():
@@ -996,3 +996,59 @@ def test_transform_always_apply_warning() -> None:
 
     assert record[0].message.args[0] == warning_expected_2
     assert aug.transforms[0].p == 0.5
+
+
+@pytest.mark.parametrize(
+    ["augmentation_cls", "params"],
+    get_transforms(
+        custom_arguments={
+            A.Crop: {"y_min": 0, "y_max": 10, "x_min": 0, "x_max": 10},
+            A.CenterCrop: {"height": 10, "width": 10},
+            A.CropNonEmptyMaskIfExists: {"height": 10, "width": 10},
+            A.RandomCrop: {"height": 10, "width": 10},
+            A.RandomResizedCrop: {"size": (10, 10)},
+            A.RandomSizedCrop: {"min_max_height": (4, 8), "size" : (10, 10)},
+            A.CropAndPad: {"px": 10},
+            A.Resize: {"height": 10, "width": 10},
+            A.XYMasking: {
+                "num_masks_x": (1, 3),
+                "num_masks_y": 3,
+                "mask_x_length": (10, 20),
+                "mask_y_length": 10,
+                "fill_value": 0,
+                "mask_fill_value": 1,
+            },
+            A.PadIfNeeded: {
+                "min_height": 512,
+                "min_width": 512,
+                "border_mode": 0,
+                "value": [124, 116, 104],
+                "position": "top_left"
+            },
+        },
+        except_augmentations={
+            A.FDA,
+            A.HistogramMatching,
+            A.PixelDistributionAdaptation,
+            A.Lambda,
+            A.TemplateTransform,
+            A.MixUp,
+            A.RandomSizedBBoxSafeCrop,
+            A.MaskDropout,
+            A.CropNonEmptyMaskIfExists,
+            A.BBoxSafeRandomCrop,
+            A.OverlayElements
+        },
+    ),
+)
+def test_additional_targets_vs_images(augmentation_cls, params):
+    image = SQUARE_FLOAT_IMAGE if augmentation_cls == A.FromFloat else SQUARE_UINT8_IMAGE
+    image2 = image.copy()
+
+    aug = A.Compose(
+        [augmentation_cls(p=1., **params)]
+    )
+
+    transformed2 = aug(images=[image, image2])
+
+    assert np.array_equal(transformed2["images"][0], transformed2["images"][1])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -40,9 +40,9 @@ from albumentations.core.transforms_interface import (
     NoOp
 )
 from albumentations.core.utils import to_tuple
-from tests.conftest import IMAGES, SQUARE_FLOAT_IMAGE, SQUARE_UINT8_IMAGE
+from tests.conftest import IMAGES, RECTANGULAR_FLOAT_IMAGE, RECTANGULAR_UINT8_IMAGE
 
-from .utils import get_filtered_transforms, get_image_only_transforms, get_transforms, set_seed
+from .utils import get_filtered_transforms, get_transforms
 
 
 def test_one_or_other():
@@ -1041,8 +1041,8 @@ def test_transform_always_apply_warning() -> None:
         },
     ),
 )
-def test_additional_targets_vs_images(augmentation_cls, params):
-    image = SQUARE_FLOAT_IMAGE if augmentation_cls == A.FromFloat else SQUARE_UINT8_IMAGE
+def test_images_as_target(augmentation_cls, params):
+    image = RECTANGULAR_FLOAT_IMAGE if augmentation_cls == A.FromFloat else RECTANGULAR_UINT8_IMAGE
     image2 = image.copy()
 
     aug = A.Compose(

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -55,7 +55,7 @@ def test_crop_near_bbox(image, bboxes, keypoints):
 
     aug(image=image, bboxes=bboxes, target_bbox=[0, 5, 10, 20], keypoints=keypoints)
 
-    target_keys = {'image', 'bboxes', "labels", "mask", "masks", "keypoints", bbox_key}
+    target_keys = {'image', "images", 'bboxes', "labels", "mask", "masks", "keypoints", bbox_key}
 
     assert aug._available_keys == target_keys
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces the ability to apply transformations to multiple images at once by adding support for the 'images' key. It also includes enhancements to the transformation schema and classes, and updates to the test suite to cover the new functionality.

- **New Features**:
    - Added support for applying transformations to multiple images simultaneously by introducing the 'images' key.
- **Enhancements**:
    - Updated the `BaseTransformInitSchema` to use `ProbabilityType` for the `p` attribute.
    - Enhanced the `DualTransform` and `ImageOnlyTransform` classes to include the `apply_to_images` method for handling multiple images.
- **Tests**:
    - Added new test `test_additional_targets_vs_images` to verify transformations on multiple images.
    - Updated existing tests to include the 'images' key in the target keys.

<!-- Generated by sourcery-ai[bot]: end summary -->