### PR TITLE
if no `image` input but `images` use first element of `images`

### DIFF
--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -199,18 +199,13 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         if hasattr(self, "mask_fill_value"):
             params["mask_fill_value"] = self.mask_fill_value
 
-        image_shape = self.get_image_shape(kwargs)
-        params.update({"cols": image_shape[1], "rows": image_shape[0]})
+        # here we expects `image` or `images` in kwargs. it's checked at Compose._check_args
+        shape = kwargs["image"].shape if "image" in kwargs else kwargs["images"][0].shape
+        params.update({"cols": shape[1], "rows": shape[0]})
         return params
 
-    def get_image_shape(self, data: dict[str, Any]) -> tuple[int, int]:
-        """Get image shape from data. If no `image` key in data, uses `images` first element."""
-        if "image" in data:  # expecting `image` or `images`, else will raise KeyError
-            return data["image"].shape[:2]
-        return data["images"][0].shape[:2]
-
     def add_targets(self, additional_targets: dict[str, str]) -> None:
-        """Add targets to transform them the same way as one of existing targets
+        """Add targets to transform them the same way as one of existing targetss
         ex: {'target_image': 'image'}
         ex: {'obj1_mask': 'mask', 'obj2_mask': 'mask'}
         by the way you must have at least one object with key 'image'

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -105,14 +105,9 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
 
             if self.targets_as_params:
                 missing_keys = set(self.targets_as_params).difference(kwargs.keys())
-                if missing_keys:
-                    if missing_keys == {"image"} and "images" in kwargs:
-                        pass
-                    else:
-                        msg = (
-                            f"{self.__class__.__name__} requires {self.targets_as_params} missing keys: {missing_keys}"
-                        )
-                        raise ValueError(msg)
+                if missing_keys and not (missing_keys == {"image"} and "images" in kwargs):
+                    msg = f"{self.__class__.__name__} requires {self.targets_as_params} missing keys: {missing_keys}"
+                    raise ValueError(msg)
 
                 targets_as_params = {k: kwargs.get(k, None) for k in self.targets_as_params}
                 if missing_keys:  # here we expecting case when missing_keys == {"image"} and "images" in kwargs
@@ -210,11 +205,9 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
 
     def get_image_shape(self, data: dict[str, Any]) -> tuple[int, int]:
         """Get image shape from data. If no `image` key in data, uses `images` first element."""
-        if "image" in data:
+        if "image" in data:  # expecting `image` or `images`, else will raise KeyError
             return data["image"].shape[:2]
-        if "images" in data:
-            return data["images"][0].shape[:2]
-        return 0, 0
+        return data["images"][0].shape[:2]
 
     def add_targets(self, additional_targets: dict[str, str]) -> None:
         """Add targets to transform them the same way as one of existing targets


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhanced the handling of input data by using the first element of 'images' when 'image' is not provided. Refactored the code to improve readability and maintainability by introducing a helper function for getting image shape.

- **Enhancements**:
    - Updated the logic to handle cases where 'image' is not provided but 'images' is, by using the first element of 'images'.
    - Refactored the method to get image shape, adding a new helper function 'get_image_shape' to centralize the logic.

<!-- Generated by sourcery-ai[bot]: end summary -->