### PR TITLE
Add `get_params_dependent_on_data` method to transform interface.

### DIFF
--- a/albumentations/augmentations/domain_adaptation.py
+++ b/albumentations/augmentations/domain_adaptation.py
@@ -202,19 +202,14 @@ class FDA(ImageOnlyTransform):
     ) -> np.ndarray:
         return fourier_domain_adaptation(img, target_image, beta)
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, np.ndarray]:
-        img = params["image"]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, np.ndarray]:
         target_img = self.read_fn(random.choice(self.reference_images))
-        target_img = cv2.resize(target_img, dsize=(img.shape[1], img.shape[0]))
+        target_img = cv2.resize(target_img, dsize=(params["shape"][1], params["shape"][0]))
 
         return {"target_image": target_img}
 
     def get_params(self) -> dict[str, float]:
         return {"beta": random.uniform(self.beta_limit[0], self.beta_limit[1])}
-
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
 
     def get_transform_init_args_names(self) -> tuple[str, str, str]:
         return "reference_images", "beta_limit", "read_fn"

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -275,7 +275,7 @@ class OverlayElements(ReferenceBasedTransform):
 
     @property
     def targets_as_params(self) -> list[str]:
-        return [self.metadata_key, "image"]
+        return [self.metadata_key]
 
     @staticmethod
     def preprocess_metadata(metadata: dict[str, Any], img_shape: SizeType) -> dict[str, Any]:
@@ -340,9 +340,9 @@ class OverlayElements(ReferenceBasedTransform):
 
         return result
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        metadata = params[self.metadata_key]
-        img_shape = params["image"].shape
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        metadata = data[self.metadata_key]
+        img_shape = params["shape"]
 
         if isinstance(metadata, list):
             overlay_data = [self.preprocess_metadata(md, img_shape) for md in metadata]

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -103,7 +103,6 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         if force_apply or (random.random() < self.p):
             params = self.get_params()
             params = self.update_params_shape(params=params, data=kwargs)
-            params = self.update_params(params, **kwargs)  # remove after move parameters like interpolation
 
             if self.targets_as_params:
                 missing_keys = set(self.targets_as_params).difference(kwargs.keys())
@@ -124,6 +123,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
 
     def apply_with_params(self, params: dict[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Apply transforms with parameters."""
+        params = self.update_params(params, **kwargs)  # remove after move parameters like interpolation
         res = {}
         for key, arg in kwargs.items():
             if key in self._key2func and arg is not None:

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -102,6 +102,8 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
 
         if force_apply or (random.random() < self.p):
             params = self.get_params()
+            params = self.update_params_shape(params=params, data=kwargs)
+            params = self.update_params(params, **kwargs)  # remove after move parameters like interpolation
 
             if self.targets_as_params:
                 missing_keys = set(self.targets_as_params).difference(kwargs.keys())
@@ -122,7 +124,6 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
 
     def apply_with_params(self, params: dict[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Apply transforms with parameters."""
-        params = self.update_params(params, **kwargs)
         res = {}
         for key, arg in kwargs.items():
             if key in self._key2func and arg is not None:
@@ -165,6 +166,18 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         """Returns parameters independent of input."""
         return {}
 
+    def update_params_shape(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        """Updates parameters with input image shape."""
+        # here we expects `image` or `images` in kwargs. it's checked at Compose._check_args
+        shape = data["image"].shape if "image" in data else data["images"][0].shape
+        params["shape"] = shape
+        params.update({"cols": shape[1], "rows": shape[0]})
+        return params
+
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        """Returns parameters dependent on input."""
+        return params
+
     @property
     def targets(self) -> dict[str, Callable[..., Any]]:
         # mapping for targets and methods for which they depend
@@ -191,7 +204,11 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         return self._available_keys
 
     def update_params(self, params: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
-        """Update parameters with transform specific params."""
+        """Update parameters with transform specific params.
+        This method is deprecated, use:
+        - `get_params` for transform specific params like interpolation and
+        - `update_params_shape` for data like shape.
+        """
         if hasattr(self, "interpolation"):
             params["interpolation"] = self.interpolation
         if hasattr(self, "fill_value"):
@@ -228,16 +245,18 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
 
     @property
     def targets_as_params(self) -> list[str]:
-        """Targets used to get params"""
+        """Targets used to get params dependent on targets.
+        This is used to check input has all required targets.
+        """
         return []
 
     def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        """Returns parameters dependent on targets.
+        """This method is deprecated.
+        Use `get_params_dependent_on_data` instead.
+        Returns parameters dependent on targets.
         Dependent target is defined in `self.targets_as_params`
         """
-        raise NotImplementedError(
-            "Method get_params_dependent_on_targets is not implemented in class " + self.__class__.__name__,
-        )
+        return {}
 
     @classmethod
     def get_class_fullname(cls) -> str:

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -104,12 +104,16 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
             params = self.get_params()
             params = self.update_params_shape(params=params, data=kwargs)
 
-            if self.targets_as_params:
+            if self.targets_as_params:  # check if all required targets are in kwargs.
                 missing_keys = set(self.targets_as_params).difference(kwargs.keys())
                 if missing_keys and not (missing_keys == {"image"} and "images" in kwargs):
                     msg = f"{self.__class__.__name__} requires {self.targets_as_params} missing keys: {missing_keys}"
                     raise ValueError(msg)
 
+            params_dependent_on_data = self.get_params_dependent_on_data(params=params, data=kwargs)
+            params.update(params_dependent_on_data)
+
+            if self.targets_as_params:  # this block will be removed after removing `get_params_dependent_on_targets`
                 targets_as_params = {k: kwargs.get(k, None) for k in self.targets_as_params}
                 if missing_keys:  # here we expecting case when missing_keys == {"image"} and "images" in kwargs
                     targets_as_params["image"] = kwargs["images"][0]


### PR DESCRIPTION
Add `get_params_dependent_on_data` method to transform interface.
It need to substitute `get_params_dependent_on_targets`, simplify code.
This is not braking changes, proposes for discuss.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new method `get_params_dependent_on_data` to the transform interface, deprecating the older `get_params_dependent_on_targets` method. It also includes enhancements to the parameter update process and refactors the code to improve clarity and maintainability.

- **New Features**:
    - Introduced `get_params_dependent_on_data` method to the transform interface for handling parameters dependent on input data.
- **Enhancements**:
    - Deprecated `get_params_dependent_on_targets` method in favor of the new `get_params_dependent_on_data` method.
    - Updated `update_params` method to include a deprecation notice and guidance on using `get_params` and `update_params_shape` for specific parameters.
    - Refactored code to use `update_params_shape` for updating parameters with input image shape.

<!-- Generated by sourcery-ai[bot]: end summary -->