### PR TITLE
Remove scikit learn

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       types: [python]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.1
+    rev: v0.5.4
     hooks:
       # Run the linter.
       - id: ruff
@@ -74,7 +74,7 @@ repos:
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.1
+    rev: v1.11.0
     hooks:
       - id: mypy
         files: ^albumentations/

--- a/albumentations/augmentations/domain_adaptation_functional.py
+++ b/albumentations/augmentations/domain_adaptation_functional.py
@@ -8,7 +8,6 @@ import numpy as np
 from albucore.functions import add_weighted
 from albucore.utils import clip, clipped, is_multispectral_image, preserve_channel_dim
 from skimage.exposure import match_histograms
-from sklearn.decomposition import PCA
 from typing_extensions import Protocol
 
 from albumentations.augmentations.functional import center
@@ -103,6 +102,61 @@ class StandardScaler(BaseScaler):
                 "Call 'fit' with appropriate arguments before using this estimator.",
             )
         return (x * self.scale) + self.mean
+
+
+class PCA:
+    def __init__(self, n_components: int | None = None) -> None:
+        if n_components is not None and n_components <= 0:
+            raise ValueError("Number of components must be greater than zero.")
+        self.n_components = n_components
+        self.mean: np.ndarray | None = None
+        self.components_: np.ndarray | None = None
+        self.explained_variance_: np.ndarray | None = None
+
+    def fit(self, x: np.ndarray) -> None:
+        x = x.astype(np.float64)
+        n_samples, n_features = x.shape
+
+        # Determine the number of components if not set
+        if self.n_components is None:
+            self.n_components = min(n_samples, n_features)
+
+        self.mean, eigenvectors, eigenvalues = cv2.PCACompute2(x, mean=None, maxComponents=self.n_components)
+        self.components_ = eigenvectors
+        self.explained_variance_ = eigenvalues.flatten()
+
+    def transform(self, x: np.ndarray) -> np.ndarray:
+        if self.components_ is None:
+            raise ValueError(
+                "This PCA instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before using this estimator.",
+            )
+        x = x.astype(np.float64)
+        return cv2.PCAProject(x, self.mean, self.components_)
+
+    def fit_transform(self, x: np.ndarray) -> np.ndarray:
+        self.fit(x)
+        return self.transform(x)
+
+    def inverse_transform(self, x: np.ndarray) -> np.ndarray:
+        if self.components_ is None:
+            raise ValueError(
+                "This PCA instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before using this estimator.",
+            )
+        return cv2.PCABackProject(x, self.mean, self.components_)
+
+    def explained_variance_ratio(self) -> np.ndarray:
+        if self.explained_variance_ is None:
+            raise ValueError(
+                "This PCA instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before using this method.",
+            )
+        total_variance = np.sum(self.explained_variance_)
+        return self.explained_variance_ / total_variance
+
+    def cumulative_explained_variance_ratio(self) -> np.ndarray:
+        return np.cumsum(self.explained_variance_ratio())
 
 
 class TransformerInterface(Protocol):

--- a/albumentations/augmentations/domain_adaptation_functional.py
+++ b/albumentations/augmentations/domain_adaptation_functional.py
@@ -9,7 +9,6 @@ from albucore.functions import add_weighted
 from albucore.utils import clip, clipped, is_multispectral_image, preserve_channel_dim
 from skimage.exposure import match_histograms
 from sklearn.decomposition import PCA
-from sklearn.preprocessing import MinMaxScaler, StandardScaler
 from typing_extensions import Protocol
 
 from albumentations.augmentations.functional import center
@@ -21,6 +20,89 @@ __all__ = [
     "apply_histogram",
     "adapt_pixel_distribution",
 ]
+
+
+class BaseScaler:
+    def __init__(self) -> None:
+        self.data_min: np.ndarray | None = None
+        self.data_max: np.ndarray | None = None
+        self.mean: np.ndarray | None = None
+        self.var: np.ndarray | None = None
+        self.scale: np.ndarray | None = None
+
+    def fit(self, x: np.ndarray) -> None:
+        raise NotImplementedError
+
+    def transform(self, x: np.ndarray) -> np.ndarray:
+        raise NotImplementedError
+
+    def fit_transform(self, x: np.ndarray) -> np.ndarray:
+        self.fit(x)
+        return self.transform(x)
+
+    def inverse_transform(self, x: np.ndarray) -> np.ndarray:
+        raise NotImplementedError
+
+
+class MinMaxScaler(BaseScaler):
+    def __init__(self, feature_range: tuple[float, float] = (0.0, 1.0)) -> None:
+        super().__init__()
+        self.min: float = feature_range[0]
+        self.max: float = feature_range[1]
+        self.data_range: np.ndarray | None = None
+
+    def fit(self, x: np.ndarray) -> None:
+        self.data_min = np.min(x, axis=0)
+        self.data_max = np.max(x, axis=0)
+        self.data_range = self.data_max - self.data_min
+        # Handle case where data_min equals data_max
+        self.data_range[self.data_range == 0] = 1
+
+    def transform(self, x: np.ndarray) -> np.ndarray:
+        if self.data_min is None or self.data_max is None or self.data_range is None:
+            raise ValueError(
+                "This MinMaxScaler instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before using this estimator.",
+            )
+        x_std = (x - self.data_min) / self.data_range
+        return x_std * (self.max - self.min) + self.min
+
+    def inverse_transform(self, x: np.ndarray) -> np.ndarray:
+        if self.data_min is None or self.data_max is None or self.data_range is None:
+            raise ValueError(
+                "This MinMaxScaler instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before using this estimator.",
+            )
+        x_std = (x - self.min) / (self.max - self.min)
+        return x_std * self.data_range + self.data_min
+
+
+class StandardScaler(BaseScaler):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def fit(self, x: np.ndarray) -> None:
+        self.mean = np.mean(x, axis=0)
+        self.var = np.var(x, axis=0)
+        self.scale = np.sqrt(self.var)
+        # Handle case where variance is zero
+        self.scale[self.scale == 0] = 1
+
+    def transform(self, x: np.ndarray) -> np.ndarray:
+        if self.mean is None or self.scale is None:
+            raise ValueError(
+                "This StandardScaler instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before using this estimator.",
+            )
+        return (x - self.mean) / self.scale
+
+    def inverse_transform(self, x: np.ndarray) -> np.ndarray:
+        if self.mean is None or self.scale is None:
+            raise ValueError(
+                "This StandardScaler instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before using this estimator.",
+            )
+        return (x * self.scale) + self.mean
 
 
 class TransformerInterface(Protocol):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 deepdiff>=6.7.1
 eval-type-backport
-mypy>=1.10.1
+mypy>=1.11.0
 pre_commit>=3.5.0
 pytest>=8.2.2
 pytest_cov>=5.0.0
 pytest_mock>=3.14.0
 requests>=2.31.0
-ruff>=0.5.0
+ruff>=0.5.4
 tomli>=2.0.1
 types-pkg-resources
 types-PyYAML

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 INSTALL_REQUIRES = [
     "numpy>=1.24.4", "scipy>=1.10.0", "scikit-image>=0.21.0",
-    "PyYAML", "typing-extensions>=4.9.0", "scikit-learn>=1.3.2",
+    "PyYAML", "typing-extensions>=4.9.0",
     "pydantic>=2.7.0",
     "albucore>=0.0.11",
     "eval-type-backport"


### PR DESCRIPTION
Fixes https://github.com/albumentations-team/albumentations/issues/1736

and

https://github.com/albumentations-team/albumentations/issues/1425

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Replaced scikit-learn dependency with custom implementations of MinMaxScaler, StandardScaler, and PCA. Removed scikit-learn from the project dependencies and updated pre-commit hooks for ruff and mypy.

- **Enhancements**:
    - Implemented custom MinMaxScaler, StandardScaler, and PCA classes to replace scikit-learn functionality.
- **Chores**:
    - Removed scikit-learn from the list of dependencies in setup.py.
    - Updated pre-commit hooks for ruff and mypy to newer versions in .pre-commit-config.yaml.

<!-- Generated by sourcery-ai[bot]: end summary -->