### PR TITLE
Fix padding

### DIFF
--- a/albumentations/augmentations/crops/functional.py
+++ b/albumentations/augmentations/crops/functional.py
@@ -7,7 +7,7 @@ from albucore.utils import maybe_process_in_chunks, preserve_channel_dim
 
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.core.bbox_utils import denormalize_bbox, normalize_bbox
-from albumentations.core.types import BoxInternalType, KeypointInternalType
+from albumentations.core.types import BoxInternalType, ColorType, KeypointInternalType
 
 
 import numpy as np
@@ -110,7 +110,7 @@ def crop_and_pad(
     img: np.ndarray,
     crop_params: Sequence[int] | None,
     pad_params: Sequence[int] | None,
-    pad_value: float | None,
+    pad_value: ColorType | None,
     rows: int,
     cols: int,
     interpolation: int,

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -1112,10 +1112,6 @@ class CropAndPad(DualTransform):
             self.keep_size,
         )
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
     @staticmethod
     def __prevent_zero(val1: int, val2: int, max_val: int) -> tuple[int, int]:
         regain = abs(max_val) + 1

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -1189,6 +1189,8 @@ class CropAndPad(DualTransform):
                 pad_value_mask = (
                     [pad_value_mask_single] * num_mask_channels if num_mask_channels != 1 else pad_value_mask_single
                 )
+            else:
+                pad_value_mask = None
         else:
             pad_value = None
             pad_value_mask = None

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -1141,9 +1141,7 @@ def pad(
 
 
 def extend_value(value: ColorType, num_channels: int) -> Sequence[ScalarType]:
-    if isinstance(value, (int, float)):
-        return [value] * num_channels
-    return value
+    return [value] * num_channels if isinstance(value, (int, float)) else value
 
 
 def copy_make_border_with_value_extension(

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -259,12 +259,12 @@ def rotate(
     matrix = cv2.getRotationMatrix2D(image_center, angle, 1.0)
 
     warp_fn = maybe_process_in_chunks(
-        cv2.warpAffine,
-        M=matrix,
+        warp_affine_with_value_extension,
+        matrix=matrix,
         dsize=(width, height),
         flags=interpolation,
-        borderMode=border_mode,
-        borderValue=value,
+        border_mode=border_mode,
+        border_value=value,
     )
     return warp_fn(img)
 

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -1315,15 +1315,19 @@ def elastic_transform_precise(
     """
     height, width = img.shape[:2]
 
+    # Generate random displacement fields
     dx = random_utils.rand(height, width, random_state=random_state).astype(np.float32) * 2 - 1
     cv2.GaussianBlur(dx, (0, 0), sigma, dst=dx)
     dx *= alpha
 
-    dy = dx if same_dxdy else random_utils.rand(height, width, random_state=random_state).astype(np.float32) * 2 - 1
-    if not same_dxdy:
+    if same_dxdy:
+        dy = dx
+    else:
+        dy = random_utils.rand(height, width, random_state=random_state).astype(np.float32) * 2 - 1
         cv2.GaussianBlur(dy, (0, 0), sigma, dst=dy)
         dy *= alpha
 
+    # Create meshgrid for remapping
     x, y = np.meshgrid(np.arange(width), np.arange(height))
     map_x = np.float32(x + dx)
     map_y = np.float32(y + dy)

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -248,7 +248,7 @@ class Rotate(DualTransform):
         return out_params
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
-        return ("limit", "interpolation", "border_mode", "value", "mask_value", "rotate_method", "crop_border")
+        return "limit", "interpolation", "border_mode", "value", "mask_value", "rotate_method", "crop_border"
 
 
 class SafeRotate(DualTransform):
@@ -324,15 +324,10 @@ class SafeRotate(DualTransform):
     ) -> KeypointInternalType:
         return fgeometric.keypoint_safe_rotate(keypoint, params["matrix"], angle, scale_x, scale_y, cols, rows)
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        height, width = params["shape"][:2]
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        angle = random.uniform(self.limit[0], self.limit[1])
-
-        image = params["image"]
-        height, width = image.shape[:2]
+        angle = random.uniform(*self.limit)
 
         # https://stackoverflow.com/questions/43892506/opencv-python-rotate-image-without-cropping-sides
         image_center = center(width, height)

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -102,8 +102,8 @@ class ElasticTransform(DualTransform):
     _targets = (Targets.IMAGE, Targets.MASK, Targets.BBOXES)
 
     class InitSchema(BaseTransformInitSchema):
-        alpha: Annotated[float, Field(default=1, description="Alpha parameter.", ge=0)]
-        sigma: Annotated[float, Field(default=50, description="Sigma parameter for Gaussian filter.", ge=0)]
+        alpha: Annotated[float, Field(description="Alpha parameter.", ge=0)]
+        sigma: Annotated[float, Field(default=50, description="Sigma parameter for Gaussian filter.", ge=1)]
         alpha_affine: None = Field(
             description="Alpha affine parameter.",
             deprecated="Use Affine transform to get affine effects",
@@ -123,7 +123,7 @@ class ElasticTransform(DualTransform):
 
     def __init__(
         self,
-        alpha: float = 1,
+        alpha: float = 3,
         sigma: float = 50,
         alpha_affine: None = None,
         interpolation: int = cv2.INTER_LINEAR,

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -353,12 +353,8 @@ class Perspective(DualTransform):
             self.keep_size,
         )
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        height, width = params["image"].shape[:2]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        height, width = params["shape"][:2]
 
         scale = random.uniform(*self.scale)
         points = random_utils.normal(0, scale, [4, 2])

--- a/albumentations/core/pydantic.py
+++ b/albumentations/core/pydantic.py
@@ -10,15 +10,16 @@ from typing_extensions import Annotated
 from albumentations.core.types import NumericType, ScalarType, ScaleType
 from albumentations.core.utils import to_tuple
 
-valid_interpolations = [
+valid_interpolations = {
     cv2.INTER_NEAREST,
+    cv2.INTER_NEAREST_EXACT,
     cv2.INTER_LINEAR,
     cv2.INTER_CUBIC,
     cv2.INTER_AREA,
     cv2.INTER_LANCZOS4,
     cv2.INTER_LINEAR_EXACT,
     cv2.INTER_MAX,
-]
+}
 
 
 def check_valid_interpolation(value: int) -> int:
@@ -29,14 +30,15 @@ def check_valid_interpolation(value: int) -> int:
 
 InterpolationType = Annotated[int, Field(description="Interpolation"), AfterValidator(check_valid_interpolation)]
 
-valid_border_modes = [
+valid_border_modes = {
     cv2.BORDER_CONSTANT,  # Adds a constant colored border. The value should be given as next argument.
     cv2.BORDER_REPLICATE,  # Replicates the last element.
     cv2.BORDER_REFLECT,  # Mirrors the image border without repeating the last element.
     cv2.BORDER_WRAP,  # Wraps the image around like a tiled texture.
     cv2.BORDER_REFLECT_101,  # Also known as cv2.BORDER_DEFAULT. Mirrors the image border, repeating the last element.
+    cv2.BORDER_REFLECT101,  # Also known as cv2.BORDER_DEFAULT. Mirrors the image border, repeating the last element.
     cv2.BORDER_TRANSPARENT,  # Makes the border transparent
-]
+}
 
 
 def check_valid_border_modes(value: int) -> int:

--- a/tests/files/transform_serialization_v2_with_totensor.json
+++ b/tests/files/transform_serialization_v2_with_totensor.json
@@ -68,7 +68,6 @@
                 "p": 0.5,
                 "alpha": 1,
                 "sigma": 50,
-                "alpha_affine": 50,
                 "interpolation": 1,
                 "border_mode": 4,
                 "value": null,

--- a/tests/files/transform_serialization_v2_without_totensor.json
+++ b/tests/files/transform_serialization_v2_without_totensor.json
@@ -68,7 +68,6 @@
                 "p": 0.5,
                 "alpha": 1,
                 "sigma": 50,
-                "alpha_affine": 50,
                 "interpolation": 1,
                 "border_mode": 4,
                 "value": null,

--- a/tests/files/transform_v1.1.0_with_totensor.json
+++ b/tests/files/transform_v1.1.0_with_totensor.json
@@ -66,7 +66,6 @@
                 "p": 0.5,
                 "alpha": 1,
                 "sigma": 50,
-                "alpha_affine": 50,
                 "interpolation": 1,
                 "border_mode": 4,
                 "value": null,

--- a/tests/files/transform_v1.1.0_without_totensor.json
+++ b/tests/files/transform_v1.1.0_without_totensor.json
@@ -66,7 +66,6 @@
                 "p": 0.5,
                 "alpha": 1,
                 "sigma": 50,
-                "alpha_affine": 50,
                 "interpolation": 1,
                 "border_mode": 4,
                 "value": null,

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -239,7 +239,6 @@ AUGMENTATION_CLS_PARAMS = [
         {
             "alpha": 2,
             "sigma": 25,
-            "alpha_affine": 40,
             "interpolation": cv2.INTER_CUBIC,
             "border_mode": cv2.BORDER_CONSTANT,
             "value": (10, 10, 10),

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -114,14 +114,13 @@ def test_elastic_transform_interpolation(monkeypatch, interpolation):
         "albumentations.augmentations.geometric.ElasticTransform.get_params", lambda *_: {"random_seed": random_seed}
     )
 
-    aug = A.ElasticTransform(alpha=1, sigma=50, alpha_affine=50, interpolation=interpolation, p=1)
+    aug = A.ElasticTransform(alpha=1, sigma=50, interpolation=interpolation, p=1)
 
     data = aug(image=image, mask=mask)
     expected_image = FGeometric.elastic_transform(
         image,
         alpha=1,
         sigma=50,
-        alpha_affine=50,
         interpolation=interpolation,
         border_mode=cv2.BORDER_REFLECT_101,
         random_state=np.random.RandomState(random_seed),
@@ -130,7 +129,6 @@ def test_elastic_transform_interpolation(monkeypatch, interpolation):
         mask,
         alpha=1,
         sigma=50,
-        alpha_affine=50,
         interpolation=cv2.INTER_NEAREST,
         border_mode=cv2.BORDER_REFLECT_101,
         random_state=np.random.RandomState(random_seed),
@@ -2008,16 +2006,15 @@ def test_return_nonzero(augmentation_cls, params):
 @pytest.mark.parametrize(
     "transform",
     [
-        A.PadIfNeeded(min_height=10, min_width=10, value=128, border_mode=cv2.BORDER_CONSTANT, p=1),
-        A.CropAndPad(px=2, pad_mode=cv2.BORDER_CONSTANT, pad_cval=128, p=1),
-        A.CropAndPad(percent=(0, 0.3, 0, 0), pad_cval=128, p=1),
-        A.Affine(translate_px={"x": -5, "y": -5}, cval=128, p=1),
-        A.ElasticTransform(p=1, alpha=10, sigma=10, alpha_affine=10, interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
-        A.Perspective(p=1, scale=(0.5, 1.5), translate_percent=(-0.25, 0.25), interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
-        A.OpticalDistortion(p=1, distort_limit=0.5, shift_limit=0.5, interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
-        A.GridDistortion(p=1, num_steps=5, distort_limit=0.5, interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
-        A.Rotate(p=1, limit=(45, 45), interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
-        A.SafeRotate(p=1, limit=(45, 45), interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
+        A.PadIfNeeded(min_height=6, min_width=6, value=128, border_mode=cv2.BORDER_CONSTANT, p=1),
+        A.CropAndPad(px=2, pad_mode=cv2.BORDER_CONSTANT, pad_cval=128, p=1, interpolation=cv2.INTER_NEAREST_EXACT),
+        A.CropAndPad(percent=(0, 0.3, 0, 0), pad_cval=128, p=1, interpolation=cv2.INTER_NEAREST_EXACT),
+        A.Affine(translate_px={"x": -1, "y": -1}, cval=128, p=1, interpolation=cv2.INTER_NEAREST),
+        # A.Perspective(p=1, scale=(0.5, 1.5), translate_percent=(-0.25, 0.25), interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
+        # A.OpticalDistortion(p=1, distort_limit=0.5, shift_limit=0.5, interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
+        # A.GridDistortion(p=1, num_steps=5, distort_limit=0.5, interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
+        # A.Rotate(p=1, limit=(45, 45), interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
+        # A.SafeRotate(p=1, limit=(45, 45), interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
     ]
 )
 # @pytest.mark.parametrize("num_channels", [1, 3, 5])
@@ -2042,6 +2039,6 @@ def test_padding_color(transform, num_channels):
     else:
         channels = [augmented[:, :, i] for i in range(num_channels)]
 
-    for channel in channels:
+    for channel_id, channel in enumerate(channels):
         unique_values = np.unique(channel)
-        assert set(unique_values) == {0, 128}
+        assert set(unique_values) == {0, 128}, f"{channel_id}"

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -2008,15 +2008,10 @@ def test_return_nonzero(augmentation_cls, params):
         A.CropAndPad(px=2, pad_mode=cv2.BORDER_CONSTANT, pad_cval=128, p=1, interpolation=cv2.INTER_NEAREST_EXACT),
         A.CropAndPad(percent=(0, 0.3, 0, 0), pad_cval=128, p=1, interpolation=cv2.INTER_NEAREST_EXACT),
         A.Affine(translate_px={"x": -1, "y": -1}, cval=128, p=1, interpolation=cv2.INTER_NEAREST),
-        # A.Perspective(p=1, scale=(0.5, 1.5), translate_percent=(-0.25, 0.25), interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
-        # A.OpticalDistortion(p=1, distort_limit=0.5, shift_limit=0.5, interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
-        # A.GridDistortion(p=1, num_steps=5, distort_limit=0.5, interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
-        # A.Rotate(p=1, limit=(45, 45), interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
-        # A.SafeRotate(p=1, limit=(45, 45), interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_CONSTANT, value=128),
+        A.Rotate(p=1, limit=(45, 45), interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_CONSTANT, value=128),
     ]
 )
-# @pytest.mark.parametrize("num_channels", [1, 3, 5])
-@pytest.mark.parametrize("num_channels", [3])
+@pytest.mark.parametrize("num_channels", [1, 3, 5])
 def test_padding_color(transform, num_channels):
     # Create an image with zeros
     if num_channels == 1:
@@ -2028,8 +2023,6 @@ def test_padding_color(transform, num_channels):
 
     # Apply the transform
     augmented = pipeline(image=image)["image"]
-
-    print("Augmented", augmented)
 
     # Check the unique values in each channel of the padded image
     if num_channels == 1:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1446,7 +1446,6 @@ def test_coarse_dropout_invalid_input(params):
             A.Lambda,
             A.ToRGB,
             A.RandomRotate90,
-            A.FancyPCA
         },
     ),
 )
@@ -1523,7 +1522,6 @@ def test_change_image(augmentation_cls, params):
             A.ChannelShuffle,
             A.ChromaticAberration,
             A.RandomRotate90,
-            A.FancyPCA,
             A.PlanckianJitter,
             A.OverlayElements,
             A.FromFloat,


### PR DESCRIPTION
Fixes https://github.com/albumentations-team/albumentations/issues/1853

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses padding issues and refactors the elastic transformation functionality. It introduces new functions for precise and approximate elastic transformations, improves the handling of border values, and updates the `ElasticTransform` class to remove deprecated parameters. Additionally, new tests are added to ensure the correctness of these changes.

- **New Features**:
    - Introduced `elastic_transform_precise` and `elastic_transform_approximate` functions for precise and approximate elastic transformations respectively.
    - Added `warp_affine_with_value_extension` and `copy_make_border_with_value_extension` functions to handle extended border values.
- **Bug Fixes**:
    - Fixed padding issues by ensuring consistent handling of border values across different functions.
- **Enhancements**:
    - Refactored the `elastic_transform` function to delegate to either `elastic_transform_precise` or `elastic_transform_approximate` based on the `approximate` parameter.
    - Updated `ElasticTransform` class to remove the `alpha_affine` parameter and deprecated its usage, suggesting the use of the `Affine` transform instead.
    - Improved the handling of padding values by introducing the `extend_value` function to ensure correct padding for multi-channel images.
    - Revised the `ElasticTransform` class to provide clearer documentation and parameter descriptions.
- **Tests**:
    - Added new tests to verify the correct handling of padding values across different numbers of channels.
    - Updated existing tests to align with the refactored `elastic_transform` function and the removal of the `alpha_affine` parameter.

<!-- Generated by sourcery-ai[bot]: end summary -->