### PR TITLE
Remove `get_params_dependent_on_targets`

### DIFF
--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -328,10 +328,8 @@ class GlassBlur(ImageOnlyTransform):
 
         return fblur.glass_blur(img, self.sigma, self.max_delta, self.iterations, dxy, self.mode)
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, np.ndarray]:
-        img = params["image"]
-
-        height, width = img.shape[:2]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, np.ndarray]:
+        height, width = params["shape"][:2]
 
         # generate array containing all necessary values for transformations
         width_pixels = height - self.max_delta * 2
@@ -343,10 +341,6 @@ class GlassBlur(ImageOnlyTransform):
 
     def get_transform_init_args_names(self) -> tuple[str, str, str, str]:
         return ("sigma", "max_delta", "iterations", "mode")
-
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
 
 
 class AdvancedBlur(ImageOnlyTransform):

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -77,10 +77,6 @@ class _BaseCrop(DualTransform):
         y_max = crop_coords[3]
         return fcrops.crop(img, x_min=x_min, y_min=y_min, x_max=x_max, y_max=y_max)
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
     def apply_to_bbox(
         self,
         bbox: BoxInternalType,
@@ -122,15 +118,19 @@ class RandomCrop(_BaseCrop):
         self.height = height
         self.width = width
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, tuple[int, int, int, int]]:
-        img = params["image"]
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, tuple[int, int, int, int]]:
+        shape = params["shape"]
 
-        image_height, image_width = img.shape[:2]
+        image_height, image_width = shape[:2]
 
         if self.height > image_height or self.width > image_width:
             raise CropSizeError(
                 f"Crop size (height, width) exceeds image dimensions (height, width):"
-                f" {(self.height, self.width)} vs {img.shape[:2]}",
+                f" {(self.height, self.width)} vs {shape[:2]}",
             )
 
         h_start = random.random()
@@ -169,10 +169,12 @@ class CenterCrop(_BaseCrop):
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return "height", "width"
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, tuple[int, int, int, int]]:
-        img = params["image"]
-
-        image_height, image_width = img.shape[:2]
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, tuple[int, int, int, int]]:
+        image_height, image_width = params["shape"][:2]
         crop_coords = fcrops.get_center_crop_coords(image_height, image_width, self.height, self.width)
 
         return {"crop_coords": crop_coords}
@@ -230,7 +232,11 @@ class Crop(_BaseCrop):
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return "x_min", "y_min", "x_max", "y_max"
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, tuple[int, int, int, int]]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, tuple[int, int, int, int]]:
         return {"crop_coords": (self.x_min, self.y_min, self.x_max, self.y_max)}
 
 
@@ -330,9 +336,6 @@ class CropNonEmptyMaskIfExists(_BaseCrop):
         params["crop_coords"] = crop_coords
         return params
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, int | float]:
-        return params
-
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return "height", "width", "ignore_values", "ignore_channels"
 
@@ -374,10 +377,6 @@ class _BaseRandomSizedCrop(DualTransform):
     ) -> np.ndarray:
         crop = fcrops.crop(img, *crop_coords)
         return fgeometric.resize(crop, self.size[0], self.size[1], interpolation)
-
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
 
     def apply_to_bbox(
         self,
@@ -478,8 +477,12 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
         self.min_max_height = min_max_height
         self.w2h_ratio = w2h_ratio
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, tuple[int, int, int, int]]:
-        image_height, image_width = params["image"].shape[:2]
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, tuple[int, int, int, int]]:
+        image_height, image_width = params["shape"][:2]
 
         crop_height = random.randint(self.min_max_height[0], self.min_max_height[1])
         crop_width = int(crop_height * self.w2h_ratio)
@@ -569,9 +572,12 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
         self.scale = scale
         self.ratio = ratio
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, tuple[int, int, int, int]]:
-        img = params["image"]
-        image_height, image_width = img.shape[:2]
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, tuple[int, int, int, int]]:
+        image_height, image_width = params["shape"][:2]
         area = image_height * image_width
 
         for _ in range(10):
@@ -684,10 +690,14 @@ class RandomCropNearBBox(_BaseCrop):
         y_max = np.clip(y_max, y_min, height)
         return x_min, y_min, x_max, y_max
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, tuple[float, ...]]:
-        bbox = params[self.cropping_bbox_key]
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, tuple[float, ...]]:
+        bbox = data[self.cropping_bbox_key]
 
-        height, width = params["image"].shape[:2]
+        height, width = params["shape"][:2]
 
         bbox = self._clip_bbox(bbox, height, width)
 
@@ -709,7 +719,7 @@ class RandomCropNearBBox(_BaseCrop):
 
     @property
     def targets_as_params(self) -> list[str]:
-        return ["image", self.cropping_bbox_key]
+        return [self.cropping_bbox_key]
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return "max_part_shift", "cropping_bbox_key"
@@ -756,14 +766,18 @@ class BBoxSafeRandomCrop(_BaseCrop):
 
         return fcrops.get_crop_coords(image_height, image_width, crop_height, crop_width, h_start, w_start)
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, tuple[int, int, int, int]]:
-        image_height, image_width = params["image"].shape[:2]
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, tuple[int, int, int, int]]:
+        image_height, image_width = params["shape"][:2]
 
-        if len(params["bboxes"]) == 0:  # less likely, this class is for use with bboxes.
+        if len(data["bboxes"]) == 0:  # less likely, this class is for use with bboxes.
             crop_coords = self._get_coords_no_bbox(image_height, image_width)
             return {"crop_coords": crop_coords}
 
-        bbox_union = union_of_bboxes(bboxes=params["bboxes"], erosion_rate=self.erosion_rate)
+        bbox_union = union_of_bboxes(bboxes=data["bboxes"], erosion_rate=self.erosion_rate)
 
         if bbox_union is None:
             crop_coords = self._get_coords_no_bbox(image_height, image_width)
@@ -788,7 +802,7 @@ class BBoxSafeRandomCrop(_BaseCrop):
 
     @property
     def targets_as_params(self) -> list[str]:
-        return ["image", "bboxes"]
+        return ["bboxes"]
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return ("erosion_rate",)
@@ -1335,8 +1349,12 @@ class RandomCropFromBorders(_BaseCrop):
         self.crop_top = crop_top
         self.crop_bottom = crop_bottom
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, tuple[int, int, int, int]]:
-        height, width = params["image"].shape[:2]
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, tuple[int, int, int, int]]:
+        height, width = params["shape"][:2]
 
         x_min = random.randint(0, int(self.crop_left * width))
         x_max = random.randint(max(x_min + 1, int((1 - self.crop_right) * width)), width)

--- a/albumentations/augmentations/dropout/channel_dropout.py
+++ b/albumentations/augmentations/dropout/channel_dropout.py
@@ -5,6 +5,7 @@ from typing import Any, Mapping
 
 from typing_extensions import Annotated
 
+from albucore import get_num_channels
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
 
 from .functional import channel_dropout
@@ -57,7 +58,8 @@ class ChannelDropout(ImageOnlyTransform):
         return channel_dropout(img, channels_to_drop, self.fill_value)
 
     def get_params_dependent_on_data(self, params: Mapping[str, Any], data: Mapping[str, Any]) -> dict[str, Any]:
-        num_channels = params["shape"][-1]
+        image = data["image"] if "image" in data else data["images"][0]
+        num_channels = get_num_channels(image)
 
         if num_channels == 1:
             msg = "Images has one channel. ChannelDropout is not defined."

--- a/albumentations/augmentations/dropout/channel_dropout.py
+++ b/albumentations/augmentations/dropout/channel_dropout.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import random
 from typing import Any, Mapping
 
-from albucore.utils import is_grayscale_image
 from typing_extensions import Annotated
 
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
@@ -57,11 +56,10 @@ class ChannelDropout(ImageOnlyTransform):
     def apply(self, img: np.ndarray, channels_to_drop: tuple[int, ...], **params: Any) -> np.ndarray:
         return channel_dropout(img, channels_to_drop, self.fill_value)
 
-    def get_params_dependent_on_targets(self, params: Mapping[str, Any]) -> dict[str, Any]:
-        img = params["image"]
-        num_channels = img.shape[-1]
+    def get_params_dependent_on_data(self, params: Mapping[str, Any], data: Mapping[str, Any]) -> dict[str, Any]:
+        num_channels = params["shape"][-1]
 
-        if is_grayscale_image(img):
+        if num_channels == 1:
             msg = "Images has one channel. ChannelDropout is not defined."
             raise NotImplementedError(msg)
 
@@ -77,7 +75,3 @@ class ChannelDropout(ImageOnlyTransform):
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return "channel_drop_range", "fill_value"
-
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]

--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -223,9 +223,8 @@ class CoarseDropout(DualTransform):
             hole_width = int(width * random.uniform(width_range[0], width_range[1]))
         return hole_height, hole_width
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        img = params["image"]
-        height, width = img.shape[:2]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        height, width = params["shape"][:2]
 
         holes = []
         num_holes = random.randint(self.num_holes_range[0], self.num_holes_range[1])
@@ -245,10 +244,6 @@ class CoarseDropout(DualTransform):
             holes.append((x1, y1, x2, y2))
 
         return {"holes": holes}
-
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
 
     def apply_to_keypoints(
         self,

--- a/albumentations/augmentations/dropout/grid_dropout.py
+++ b/albumentations/augmentations/dropout/grid_dropout.py
@@ -151,9 +151,8 @@ class GridDropout(DualTransform):
 
         return fdropout.cutout(mask, holes, self.mask_fill_value)
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        img = params["image"]
-        height, width = img.shape[:2]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        height, width = params["shape"][:2]
         unit_width, unit_height = self._calculate_unit_dimensions(width, height)
         hole_width, hole_height = self._calculate_hole_dimensions(unit_width, unit_height)
         shift_x, shift_y = self._calculate_shifts(unit_width, unit_height, hole_width, hole_height)
@@ -243,10 +242,6 @@ class GridDropout(DualTransform):
                 y2 = min(y1 + hole_height, height)
                 holes.append((x1, y1, x2, y2))
         return holes
-
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return (

--- a/albumentations/augmentations/dropout/mask_dropout.py
+++ b/albumentations/augmentations/dropout/mask_dropout.py
@@ -73,8 +73,8 @@ class MaskDropout(DualTransform):
     def targets_as_params(self) -> list[str]:
         return ["mask"]
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        mask = params["mask"]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        mask = data["mask"]
 
         label_image, num_labels = label(mask, return_num=True)
 
@@ -93,7 +93,6 @@ class MaskDropout(DualTransform):
                     dropout_mask |= label_image == label_index
 
         params.update({"dropout_mask": dropout_mask})
-        del params["mask"]
         return params
 
     def apply(self, img: np.ndarray, dropout_mask: np.ndarray, **params: Any) -> np.ndarray:

--- a/albumentations/augmentations/dropout/xy_masking.py
+++ b/albumentations/augmentations/dropout/xy_masking.py
@@ -143,9 +143,12 @@ class XYMasking(DualTransform):
             elif mask_length < 0 or mask_length > dimension_size:
                 raise ValueError(f"{dimension_name} {mask_length} exceeds image {dimension_name} {dimension_size}")
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, list[tuple[int, int, int, int]]]:
-        img = params["image"]
-        height, width = img.shape[:2]
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, list[tuple[int, int, int, int]]]:
+        height, width = params["shape"][:2]
 
         # Use the helper method to validate mask lengths against image dimensions
         self.validate_mask_length(self.mask_x_length, width, "mask_x_length")
@@ -189,10 +192,6 @@ class XYMasking(DualTransform):
 
             masks.append((x1, y1, x2, y2))
         return masks
-
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
 
     def apply_to_keypoints(
         self,

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -233,14 +233,10 @@ class Rotate(DualTransform):
             "y_max": min(height, int(height / 2 + hr / 2)),
         }
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
         out_params = {"angle": random.uniform(self.limit[0], self.limit[1])}
         if self.crop_border:
-            height, width = params["image"].shape[:2]
+            height, width = params["shape"][:2]
             out_params.update(self._rotated_rect_with_max_area(height, width, out_params["angle"]))
         else:
             out_params.update({"x_min": -1, "x_max": -1, "y_min": -1, "y_max": -1})

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -1954,12 +1954,8 @@ class GridDistortion(DualTransform):
 
         return {"stepsx": xsteps, "stepsy": ysteps}
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        height, width = params["image"].shape[:2]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        height, width = params["shape"][:2]
 
         stepsx = [1 + random.uniform(self.distort_limit[0], self.distort_limit[1]) for _ in range(self.num_steps + 1)]
         stepsy = [1 + random.uniform(self.distort_limit[0], self.distort_limit[1]) for _ in range(self.num_steps + 1)]

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -764,10 +764,6 @@ class Affine(DualTransform):
 
         return fgeometric.keypoint_affine(keypoint, matrix=matrix, scale=scale)
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
     @staticmethod
     def get_scale(scale: dict[str, tuple[float, float]], keep_ratio: bool, balanced_scale: bool) -> dict[str, float]:
         result_scale = {}
@@ -794,8 +790,8 @@ class Affine(DualTransform):
 
         return result_scale
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        height, width = params["image"].shape[:2]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        height, width = params["shape"][:2]
 
         translate: dict[str, int | float]
         if self.translate_px is not None:
@@ -849,9 +845,9 @@ class Affine(DualTransform):
         )
 
         if self.fit_output:
-            matrix, output_shape = self._compute_affine_warp_output_shape(matrix, params["image"].shape)
+            matrix, output_shape = self._compute_affine_warp_output_shape(matrix, params["shape"])
         else:
-            output_shape = params["image"].shape
+            output_shape = params["shape"]
 
         return {
             "rotate": rotate,
@@ -1163,12 +1159,8 @@ class PiecewiseAffine(DualTransform):
             "keypoints_threshold",
         )
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        height, width = params["image"].shape[:2]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        height, width = params["shape"][:2]
 
         nb_rows = np.clip(random.randint(*self.nb_rows), 2, None)
         nb_cols = np.clip(random.randint(*self.nb_cols), 2, None)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1317,14 +1317,8 @@ class RandomToneCurve(ImageOnlyTransform):
     ) -> np.ndarray:
         return fmain.move_tone_curve(img, low_y, high_y)
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        image = params["image"]
-
-        num_channels = get_num_channels(image)
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        num_channels = params["shape"][-1]
 
         if self.per_channel and num_channels != 1:
             return {

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1069,13 +1069,8 @@ class RandomSunFlare(ImageOnlyTransform):
             circles,
         )
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        img = params["image"]
-        height, width = img.shape[:2]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        height, width = params["shape"][:2]
 
         angle = 2 * math.pi * random.uniform(*self.angle_range)
 
@@ -1227,13 +1222,8 @@ class RandomShadow(ImageOnlyTransform):
     def apply(self, img: np.ndarray, vertices_list: list[np.ndarray], **params: Any) -> np.ndarray:
         return fmain.add_shadow(img, vertices_list)
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, list[np.ndarray]]:
-        img = params["image"]
-        height, width = img.shape[:2]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, list[np.ndarray]]:
+        height, width = params["shape"][:2]
 
         num_shadows = random.randint(self.num_shadows_limit[0], self.num_shadows_limit[1])
 

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -2388,23 +2388,17 @@ class MultiplicativeNoise(ImageOnlyTransform):
     ) -> np.ndarray:
         return multiply(img, multiplier)
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
         if self.multiplier[0] == self.multiplier[1]:
             return {"multiplier": self.multiplier[0]}
 
-        img = params["image"]
+        img_shape = params["shape"]
 
-        num_channels = get_num_channels(img)
-
-        shape = img.shape if self.elementwise else [num_channels]
+        shape = img_shape if self.elementwise else [img_shape[-1]]
 
         multiplier = random_utils.uniform(self.multiplier[0], self.multiplier[1], shape).astype(np.float32)
 
         return {"multiplier": multiplier}
-
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return "multiplier", "elementwise"

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -594,13 +594,8 @@ class RandomGravel(ImageOnlyTransform):
             gravels_infos = []
         return fmain.add_gravel(img, gravels_infos)
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, np.ndarray]:
-        img = params["image"]
-        height, width = img.shape[:2]
+    def get_params_dependent_on_dat(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, np.ndarray]:
+        height, width = params["shape"][:2]
 
         x_min, y_min, x_max, y_max = self.gravel_roi
         x_min = int(x_min * width)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1859,16 +1859,11 @@ class ChannelShuffle(ImageOnlyTransform):
 
     """
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
     def apply(self, img: np.ndarray, channels_shuffled: tuple[int, ...], **params: Any) -> np.ndarray:
         return fmain.channel_shuffle(img, channels_shuffled)
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        img = params["image"]
-        ch_arr = list(range(img.shape[2]))
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        ch_arr = list(range(params["shape"][2]))
         ch_arr = random_utils.shuffle(ch_arr)
         return {"channels_shuffled": ch_arr}
 

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -3102,8 +3102,8 @@ class PixelDropout(DualTransform):
     def apply_to_keypoint(self, keypoint: KeypointInternalType, **params: Any) -> KeypointInternalType:
         return keypoint
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        img = params["image"]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        img = data["image"] if "image" in data else data["images"][0]
         shape = img.shape if self.per_channel else img.shape[:2]
 
         rnd = np.random.RandomState(random.randint(0, 1 << 31))
@@ -3126,10 +3126,6 @@ class PixelDropout(DualTransform):
             drop_value = self.drop_value
 
         return {"drop_mask": drop_mask, "drop_value": drop_value}
-
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
 
     def get_transform_init_args_names(self) -> tuple[str, str, str, str]:
         return ("dropout_prob", "per_channel", "drop_value", "mask_drop_value")

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -198,8 +198,8 @@ class RandomGridShuffle(DualTransform):
         )
         return keypoint
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, np.ndarray]:
-        height, width = params["image"].shape[:2]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, np.ndarray]:
+        height, width = params["shape"][:2]
         random_state = random_utils.get_random_state()
         original_tiles = fmain.split_uniform_grid(
             (height, width),
@@ -210,10 +210,6 @@ class RandomGridShuffle(DualTransform):
         mapping = fmain.shuffle_tiles_within_shape_groups(shape_groups, random_state=random_state)
 
         return {"tiles": original_tiles, "mapping": mapping}
-
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return ("grid",)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -2829,8 +2829,8 @@ class TemplateTransform(ImageOnlyTransform):
             "template_weight": random.uniform(self.template_weight[0], self.template_weight[1]),
         }
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        img = params["image"]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        img = data["image"] if "image" in data else data["images"][0]
         template = random.choice(self.templates)
 
         if self.template_transform is not None:
@@ -2862,10 +2862,6 @@ class TemplateTransform(ImageOnlyTransform):
     @classmethod
     def is_serializable(cls) -> bool:
         return False
-
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
 
     def to_dict_private(self) -> dict[str, Any]:
         if self.name is None:

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -594,7 +594,7 @@ class RandomGravel(ImageOnlyTransform):
             gravels_infos = []
         return fmain.add_gravel(img, gravels_infos)
 
-    def get_params_dependent_on_dat(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, np.ndarray]:
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, np.ndarray]:
         height, width = params["shape"][:2]
 
         x_min, y_min, x_max, y_max = self.gravel_roi
@@ -772,15 +772,10 @@ class RandomRain(ImageOnlyTransform):
             rain_drops,
         )
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        img = params["image"]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
         slant = int(random.uniform(*self.slant_range))
 
-        height, width = img.shape[:2]
+        height, width = params["shape"][:2]
         area = height * width
 
         if self.rain_type == "drizzle":
@@ -896,15 +891,10 @@ class RandomFog(ImageOnlyTransform):
     ) -> np.ndarray:
         return fmain.add_fog(img, fog_coef, self.alpha_coef, haze_list)
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        img = params["image"]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
         fog_coef = random.uniform(*self.fog_coef_range)
 
-        height, width = imshape = img.shape[:2]
+        height, width = imshape = params["shape"][:2]
 
         hw = max(1, int(width // 3 * fog_coef))
 

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1709,24 +1709,24 @@ class GaussNoise(ImageOnlyTransform):
         return fmain.add_noise(img, gauss)
 
     def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, float]:
-        shape = params["shape"]
+        image = data["image"] if "image" in data else data["images"][0]
         var = random.uniform(self.var_limit[0], self.var_limit[1])
         sigma = math.sqrt(var)
 
         if self.per_channel:
-            target_shape = shape
+            target_shape = image.shape
             if self.noise_scale_factor == 1:
                 gauss = random_utils.normal(self.mean, sigma, target_shape)
             else:
                 gauss = fmain.generate_approx_gaussian_noise(target_shape, self.mean, sigma, self.noise_scale_factor)
         else:
-            target_shape = shape[:2]
+            target_shape = image.shape[:2]
             if self.noise_scale_factor == 1:
                 gauss = random_utils.normal(self.mean, sigma, target_shape)
             else:
                 gauss = fmain.generate_approx_gaussian_noise(target_shape, self.mean, sigma, self.noise_scale_factor)
 
-            if shape[-1] > MONO_CHANNEL_DIMENSIONS:
+            if image.ndim > MONO_CHANNEL_DIMENSIONS:
                 gauss = np.expand_dims(gauss, -1)
 
         return {"gauss": gauss}

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -2393,9 +2393,8 @@ class MultiplicativeNoise(ImageOnlyTransform):
         if self.multiplier[0] == self.multiplier[1]:
             return {"multiplier": self.multiplier[0]}
 
-        img_shape = params["shape"]
-
-        shape = img_shape if self.elementwise else [img_shape[-1]]
+        img = data["image"] if "image" in data else data["images"][0]
+        shape = img.shape if self.elementwise else get_num_channels(img)
 
         multiplier = random_utils.uniform(self.multiplier[0], self.multiplier[1], shape).astype(np.float32)
 

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -3255,12 +3255,8 @@ class Spatter(ImageOnlyTransform):
     ) -> np.ndarray:
         return fmain.spatter(img, non_mud, mud, drops, mode)
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
-
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, Any]:
-        height, width = params["image"].shape[:2]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        height, width = params["shape"][:2]
 
         mean = random.uniform(self.mean[0], self.mean[1])
         std = random.uniform(self.std[0], self.std[1])

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1707,32 +1707,28 @@ class GaussNoise(ImageOnlyTransform):
     def apply(self, img: np.ndarray, gauss: np.ndarray, **params: Any) -> np.ndarray:
         return fmain.add_noise(img, gauss)
 
-    def get_params_dependent_on_targets(self, params: dict[str, Any]) -> dict[str, float]:
-        image = params["image"]
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, float]:
+        shape = params["shape"]
         var = random.uniform(self.var_limit[0], self.var_limit[1])
         sigma = math.sqrt(var)
 
         if self.per_channel:
-            target_shape = image.shape
+            target_shape = shape
             if self.noise_scale_factor == 1:
                 gauss = random_utils.normal(self.mean, sigma, target_shape)
             else:
                 gauss = fmain.generate_approx_gaussian_noise(target_shape, self.mean, sigma, self.noise_scale_factor)
         else:
-            target_shape = image.shape[:2]
+            target_shape = shape[:2]
             if self.noise_scale_factor == 1:
                 gauss = random_utils.normal(self.mean, sigma, target_shape)
             else:
                 gauss = fmain.generate_approx_gaussian_noise(target_shape, self.mean, sigma, self.noise_scale_factor)
 
-            if image.ndim > MONO_CHANNEL_DIMENSIONS:
+            if shape[-1] > MONO_CHANNEL_DIMENSIONS:
                 gauss = np.expand_dims(gauss, -1)
 
         return {"gauss": gauss}
-
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["image"]
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return "var_limit", "per_channel", "mean", "noise_scale_factor"

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1318,7 +1318,8 @@ class RandomToneCurve(ImageOnlyTransform):
         return fmain.move_tone_curve(img, low_y, high_y)
 
     def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
-        num_channels = params["shape"][-1]
+        image = data["image"] if "image" in data else data["images"][0]
+        num_channels = get_num_channels(image)
 
         if self.per_channel and num_channels != 1:
             return {

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -686,7 +686,10 @@ def test_grid_dropout_params(ratio, holes_number_xy, unit_size_range, shift_xy):
     # with fill_value = 0 the sum of pixels is smaller
     assert result.sum() < img.sum()
     assert result.shape == img.shape
-    params = aug.get_params_dependent_on_targets({"image": img})
+    params = aug.get_params_dependent_on_data(
+        params={"shape": img.shape},
+        data={"image": img},
+    )
     holes = params["holes"]
     assert len(holes[0]) == 4
     # check grid offsets
@@ -757,7 +760,10 @@ def test_grid_dropout_holes_generation(params, expected_holes):
     transform = A.GridDropout(p=1, **params)
     image = np.zeros((20, 30, 3), dtype=np.uint8)
 
-    holes = transform.get_params_dependent_on_targets({"image": image})["holes"]
+    holes = transform.get_params_dependent_on_data(
+        params={"shape": image.shape},
+        data={"image": image},
+    )["holes"]
 
     assert holes == expected_holes, f"Failed on holes generation with value {holes}"
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -987,7 +987,10 @@ def test_template_transform(img_weight, template_weight, template_transform, ima
 
     assert result.shape == img.shape
 
-    params = aug.get_params_dependent_on_targets({"image": img})
+    params = aug.get_params_dependent_on_data(
+        params={},
+        data={"image": img},
+    )
     template = params["template"]
     assert template.shape == img.shape
     assert template.dtype == img.dtype

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1228,6 +1228,7 @@ def test_non_rgb_transform_warning(augmentation, img_channels):
     message = "This transformation expects 3-channel images"
     assert str(exc_info.value).startswith(message)
 
+
 @pytest.mark.parametrize("height, width", [(100, 200), (200, 100)])
 @pytest.mark.parametrize("scale", [(0.08, 1.0), (0.5, 1.0)])
 @pytest.mark.parametrize("ratio", [(0.75, 1.33), (1.0, 1.0)])
@@ -1575,6 +1576,7 @@ def test_downscale_functionality(params, expected):
     for key, value in expected.items():
         assert aug_dict[key] == value, f"Failed on {key} with value {value}"
 
+
 @pytest.mark.parametrize("params", [
     ({"scale_range": (0.9, 0.1)}),  # Invalid range, max < min
     ({"scale_range": (1.1, 1.2)}),  # Values outside valid scale range (0, 1)
@@ -1609,6 +1611,7 @@ def test_pad_if_needed_functionality(params, expected):
     # Assert each expected key/value pair
     for key, value in expected.items():
         assert aug_dict[key] == value, f"Failed on {key} with value {value}"
+
 
 @pytest.mark.parametrize("params, expected", [
     # Test default initialization values
@@ -1839,6 +1842,7 @@ def test_random_fog_initialization(params, expected):
     for key, value in expected.items():
         assert getattr(img_fog, key) == value, f"Failed on {key} with value {value}"
 
+
 @pytest.mark.parametrize("params", [
     ({"fog_coef_range": (1.2, 1.5)}),  # Invalid fog coefficient range -> upper bound
     ({"fog_coef_range": (0.9, 0.7)}),  # Invalid range  -> decreasing
@@ -1854,7 +1858,10 @@ def test_gauss_noise(mean, image):
     set_seed(42)
     aug = A.GaussNoise(p=1, noise_scale_factor=1.0, mean=mean)
 
-    apply_params = aug.get_params_dependent_on_targets(params = {"image":image })
+    apply_params = aug.get_params_dependent_on_data(
+        params={"shape": image.shape},
+        data={"image": image},
+    )
 
     assert np.abs(mean - apply_params["gauss"].mean()) < 0.5
     result = A.Compose([aug])(image=image)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1015,8 +1015,12 @@ def test_affine_scale_ratio(params):
     set_seed(0)
     aug = A.Affine(**params, p=1.0)
     image = SQUARE_UINT8_IMAGE
-    target = {"image": image}
-    apply_params = aug.get_params_dependent_on_targets(target)
+
+    data = {"image": image}
+    call_params = aug.get_params()
+    call_params = aug.update_params_shape(call_params, data)
+
+    apply_params = aug.get_params_dependent_on_data(params=call_params, data=data)
 
     if "keep_ratio" not in params:
         # default(keep_ratio=False)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -567,7 +567,10 @@ def test_resize_keypoints():
 def test_multiplicative_noise_grayscale(image):
     m = 0.5
     aug = A.MultiplicativeNoise((m, m), elementwise=False, p=1)
-    params = aug.get_params_dependent_on_targets({"image": image})
+    params = aug.get_params_dependent_on_data(
+        params={"shape": image.shape},
+        data={"image": image},
+    )
     assert m == params["multiplier"]
     result_e = aug(image=image)["image"]
 
@@ -576,24 +579,31 @@ def test_multiplicative_noise_grayscale(image):
     assert np.allclose(clip(expected, image.dtype), result_e)
 
     aug = A.MultiplicativeNoise((m, m), elementwise=True, p=1)
-    params = aug.get_params_dependent_on_targets({"image": image})
+    params = aug.get_params_dependent_on_data(
+        params={"shape": image.shape},
+        data={"image": image},
+    )
     result_ne = aug.apply(image, params["multiplier"])
 
     expected = image.astype(np.float32) * params["multiplier"]
 
     assert np.allclose(clip(expected, image.dtype), result_ne)
 
+
 @pytest.mark.parametrize(
     "image", IMAGES
 )
 @pytest.mark.parametrize(
-    "elementwise", ( True, False )
+    "elementwise", (True, False)
 )
 def test_multiplicative_noise_rgb(image, elementwise):
     dtype = image.dtype
 
     aug = A.MultiplicativeNoise(multiplier=(0.9, 1.1), elementwise=elementwise, p=1)
-    params = aug.get_params_dependent_on_targets({"image": image})
+    params = aug.get_params_dependent_on_data(
+        params={"shape": image.shape},
+        data={"image": image},
+    )
     mul = params["multiplier"]
 
     if elementwise:


### PR DESCRIPTION
Change `get_params_dependent_on_targets` to `get_params_dependent_on_data`
Now only `Equalize` uses it.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request refactors the method `get_params_dependent_on_targets` to `get_params_dependent_on_data` across various augmentation and transformation classes. It also updates the parameter handling to use `params['shape']` instead of `params['image']` for improved generalization.

- **Enhancements**:
    - Renamed `get_params_dependent_on_targets` to `get_params_dependent_on_data` across multiple files for consistency and clarity.
    - Replaced usage of `params['image']` with `params['shape']` to generalize parameter handling and improve flexibility.

<!-- Generated by sourcery-ai[bot]: end summary -->