### PR TITLE
Fix parameter canonicalization in `ColorJitter` (#1870)

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -2489,10 +2489,11 @@ class ColorJitter(ImageOnlyTransform):
             if isinstance(value, numbers.Number):
                 if value < 0:
                     raise ValueError(f"If {info.field_name} is a single number, it must be non negative.")
-                value = [bias - value, bias + value]
+                left = bias - value
                 if clip:
-                    value[0] = max(value[0], 0)
-            elif isinstance(value, (tuple, list)) and len(value) == PAIR:
+                    left = max(left, 0)
+                value = (left, bias + value)
+            elif isinstance(value, tuple) and len(value) == PAIR:
                 check_range(value, *bounds, info.field_name)
 
             return cast(Tuple[float, float], value)


### PR DESCRIPTION
Solves #1870.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix parameter canonicalization in `ColorJitter` to correctly handle single number inputs and ensure non-negative values, addressing issue #1870.

Bug Fixes:
- Fix parameter canonicalization in `ColorJitter` to correctly handle single number inputs and ensure non-negative values.

<!-- Generated by sourcery-ai[bot]: end summary -->