### PR TITLE
Fix histogram matching

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       types: [python]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.6
+    rev: v0.5.7
     hooks:
       # Run the linter.
       - id: ruff

--- a/albumentations/augmentations/domain_adaptation.py
+++ b/albumentations/augmentations/domain_adaptation.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import random
 from typing import Any, Callable, Literal, Sequence, Tuple, cast
+from typing_extensions import Annotated
 
 import cv2
 import numpy as np
 from albucore.utils import clip, is_grayscale_image, is_multispectral_image
-from pydantic import field_validator
+from pydantic import AfterValidator, field_validator
 
 from albumentations.augmentations.domain_adaptation_functional import (
     adapt_pixel_distribution,
@@ -18,7 +19,7 @@ from albumentations.core.transforms_interface import BaseTransformInitSchema, Im
 from albumentations.augmentations import functional as fmain
 
 
-from albumentations.core.pydantic import NonNegativeFloatRangeType, ZeroOneRangeType
+from albumentations.core.pydantic import NonNegativeFloatRangeType, check_01, nondecreasing
 from albumentations.core.types import ScaleFloatType
 
 
@@ -78,7 +79,10 @@ class HistogramMatching(ImageOnlyTransform):
 
     class InitSchema(BaseTransformInitSchema):
         reference_images: Sequence[Any]
-        blend_ratio: ZeroOneRangeType = (0.5, 1.0)
+        blend_ratio: Annotated[tuple[float, float], AfterValidator(nondecreasing), AfterValidator(check_01)] = (
+            0.5,
+            1.0,
+        )
         read_fn: Callable[[Any], np.ndarray]
 
     def __init__(
@@ -265,7 +269,10 @@ class PixelDistributionAdaptation(ImageOnlyTransform):
 
     class InitSchema(BaseTransformInitSchema):
         reference_images: Sequence[Any]
-        blend_ratio: ZeroOneRangeType = (0.25, 1.0)
+        blend_ratio: Annotated[tuple[float, float], AfterValidator(nondecreasing), AfterValidator(check_01)] = (
+            0.25,
+            1.0,
+        )
         read_fn: Callable[[Any], np.ndarray]
         transform_type: Literal["pca", "standard", "minmax"]
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -16,7 +16,6 @@ requirements:
     - python
     - numpy>=1.24.4
     - scipy
-    - scikit-learn
     - pydantic>=2.7
     - pytorch
     - typing_extensions
@@ -26,7 +25,6 @@ requirements:
     - python
     - numpy>=1.24.4
     - scipy
-    - scikit-learn
     - pydantic>=2.7
     - pytorch
     - typing_extensions

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest>=8.2.2
 pytest_cov>=5.0.0
 pytest_mock>=3.14.0
 requests>=2.31.0
-ruff>=0.5.6
+ruff>=0.5.7
 tomli>=2.0.1
 types-PyYAML
 types-setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ deepdiff>=6.7.1
 eval-type-backport
 mypy>=1.11.1
 pre_commit>=3.5.0
-pytest>=8.2.2
+pytest>=8.3.2
 pytest_cov>=5.0.0
 pytest_mock>=3.14.0
 requests>=2.31.0


### PR DESCRIPTION
Fixes https://github.com/albumentations-team/albumentations/issues/1869

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix histogram matching functionality and enhance the `apply_histogram` function. Update blend ratio validation in `HistogramMatching` and `PixelDistributionAdaptation` classes. Add comprehensive tests for histogram matching. Update pre-commit configuration to use Ruff v0.5.7 and remove `scikit-learn` dependency from conda recipe.

Bug Fixes:
- Fix histogram matching functionality to ensure correct application of histogram matching and blending.

Enhancements:
- Refactor `apply_histogram` function to improve handling of different image types and sizes, and ensure proper blending.
- Update `HistogramMatching` and `PixelDistributionAdaptation` classes to use validated blend ratio ranges.

CI:
- Update pre-commit configuration to use Ruff version v0.5.7.

Tests:
- Add comprehensive tests for `apply_histogram` function covering various image shapes, types, blend ratios, and edge cases.

Chores:
- Remove `scikit-learn` dependency from conda recipe.

<!-- Generated by sourcery-ai[bot]: end summary -->