### PR TITLE
Add multichannel support to RandomShadow (#1735)

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1131,7 +1131,9 @@ class RandomSunFlare(ImageOnlyTransform):
 
 
 class RandomShadow(ImageOnlyTransform):
-    """Simulates shadows for the image
+    """Simulates shadows for the image by reducing the brightness of the image in the shadow regions.
+
+    Works for both single and multi-channel images.
 
     Args:
         shadow_roi: region of the image where shadows

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1230,7 +1230,6 @@ def test_motion_blur_allow_shifted(seed):
         A.RandomRain(),
         A.RandomFog(),
         A.RandomSunFlare(),
-        A.RandomShadow(),
         A.Spatter(),
         A.ChromaticAberration(),
     ],


### PR DESCRIPTION
closes #1735

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add multichannel support to the RandomShadow transformation by updating the add_shadow function to handle images with more than three channels. Adjust the mask creation process to ensure compatibility with multichannel images and update relevant documentation.

New Features:
- Add support for multichannel images in the RandomShadow transformation, allowing shadows to be applied to images with more than three channels.

Enhancements:
- Modify the add_shadow function to handle multichannel images by adjusting the mask creation process to match the number of channels in the input image.

Tests:
- Remove the RandomShadow transformation from the list of transformations in a specific test, possibly to update or replace the test with a new one that supports multichannel images.

<!-- Generated by sourcery-ai[bot]: end summary -->