### PR TITLE
Fix keypoint reflection in pad if needed

### DIFF
--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -1844,6 +1844,20 @@ def pad_keypoints(
 
 
 def validate_keypoints(keypoints: np.ndarray, image_shape: tuple[int, int]) -> np.ndarray:
+    """Validate keypoints and remove those that fall outside the image boundaries.
+
+    Args:
+        keypoints (np.ndarray): Array of keypoints with shape (N, M) where N is the number of keypoints
+                                and M >= 2. The first two columns represent x and y coordinates.
+        image_shape (tuple[int, int]): Shape of the image as (height, width).
+
+    Returns:
+        np.ndarray: Array of valid keypoints that fall within the image boundaries.
+
+    Note:
+        This function only checks the x and y coordinates (first two columns) of the keypoints.
+        Any additional columns (e.g., angle, scale) are preserved for valid keypoints.
+    """
     rows, cols = image_shape[:2]
 
     x, y = keypoints[:, 0], keypoints[:, 1]

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -1824,11 +1824,11 @@ def pad_keypoints(
         shift_vector = np.array([pad_left, pad_top])  # Only shift x and y
         return shift_keypoints(keypoints, shift_vector)
 
-    rows, cols = image_shape[:2]
-
     grid_dimensions = get_pad_grid_dimensions(pad_top, pad_bottom, pad_left, pad_right, image_shape)
 
-    keypoints = generate_reflected_keypoints(keypoints, grid_dimensions, rows, cols)
+    keypoints = generate_reflected_keypoints(keypoints, grid_dimensions, image_shape)
+
+    rows, cols = image_shape[:2]
 
     # Calculate the number of grid cells added on each side
     original_row, original_col = grid_dimensions["original_position"]
@@ -1876,16 +1876,17 @@ def shift_keypoints(keypoints: np.ndarray, shift_vector: np.ndarray) -> np.ndarr
 def generate_reflected_keypoints(
     keypoints: np.ndarray,
     grid_dims: dict[str, tuple[int, int]],
-    rows: int,
-    cols: int,
+    image_shape: tuple[int, int],
 ) -> np.ndarray:
     grid_rows, grid_cols = grid_dims["grid_shape"]
     original_row, original_col = grid_dims["original_position"]
 
     # Prepare flipped versions of keypoints
-    keypoints_hflipped = flip_keypoints(keypoints, flip_horizontal=True, rows=rows, cols=cols)
-    keypoints_vflipped = flip_keypoints(keypoints, flip_vertical=True, rows=rows, cols=cols)
-    keypoints_hvflipped = flip_keypoints(keypoints, flip_horizontal=True, flip_vertical=True, rows=rows, cols=cols)
+    keypoints_hflipped = flip_keypoints(keypoints, flip_horizontal=True, image_shape=image_shape)
+    keypoints_vflipped = flip_keypoints(keypoints, flip_vertical=True, image_shape=image_shape)
+    keypoints_hvflipped = flip_keypoints(keypoints, flip_horizontal=True, flip_vertical=True, image_shape=image_shape)
+
+    rows, cols = image_shape[:2]
 
     # Shift all versions to the original position
     shift_vector = np.array([original_col * cols, original_row * rows, 0, 0])  # Only shift x and y
@@ -1921,9 +1922,9 @@ def flip_keypoints(
     keypoints: np.ndarray,
     flip_horizontal: bool = False,
     flip_vertical: bool = False,
-    rows: int = 1,
-    cols: int = 1,
+    image_shape: tuple[int, int] = (0, 0),
 ) -> np.ndarray:
+    rows, cols = image_shape[:2]
     flipped_keypoints = keypoints.copy()
     if flip_horizontal:
         flipped_keypoints[:, 0] = cols - flipped_keypoints[:, 0]

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -1427,19 +1427,20 @@ def pad_bboxes(
     pad_left: int,
     pad_right: int,
     border_mode: int,
-    rows: int,
-    cols: int,
+    image_shape: tuple[int, int],
 ) -> np.ndarray:
     if border_mode not in {cv2.BORDER_REFLECT_101, cv2.BORDER_REFLECT101}:
         shift_vector = np.array([pad_left, pad_top, pad_left, pad_top])
         return shift_bboxes(bboxes, shift_vector)
 
-    grid_dimensions = get_pad_grid_dimensions(pad_top, pad_bottom, pad_left, pad_right, rows, cols)
+    grid_dimensions = get_pad_grid_dimensions(pad_top, pad_bottom, pad_left, pad_right, image_shape)
 
-    bboxes = generate_reflected_bboxes(bboxes, grid_dimensions, rows, cols)
+    bboxes = generate_reflected_bboxes(bboxes, grid_dimensions, image_shape)
 
     # Calculate the number of grid cells added on each side
     original_row, original_col = grid_dimensions["original_position"]
+
+    rows, cols = image_shape[:2]
 
     # Subtract the offset based on the number of added grid cells
     bboxes[:, 0] -= original_col * cols - pad_left  # x_min
@@ -1504,8 +1505,7 @@ def get_pad_grid_dimensions(
     pad_bottom: int,
     pad_left: int,
     pad_right: int,
-    rows: int,
-    cols: int,
+    image_shape: tuple[int, int],
 ) -> dict[str, tuple[int, int]]:
     """Calculate the dimensions of the grid needed for reflection padding and the position of the original image.
 
@@ -1514,8 +1514,7 @@ def get_pad_grid_dimensions(
         pad_bottom (int): Number of pixels to pad below the image.
         pad_left (int): Number of pixels to pad to the left of the image.
         pad_right (int): Number of pixels to pad to the right of the image.
-        rows (int): Height of the original image in pixels.
-        cols (int): Width of the original image in pixels.
+        image_shape (tuple[int, int]): Shape of the original image as (height, width).
 
     Returns:
         dict[str, tuple[int, int]]: A dictionary containing:
@@ -1526,6 +1525,8 @@ def get_pad_grid_dimensions(
                 - original_row (int): Row index of the original image in the grid.
                 - original_col (int): Column index of the original image in the grid.
     """
+    rows, cols = image_shape[:2]
+
     grid_rows = 1 + math.ceil(pad_top / rows) + math.ceil(pad_bottom / rows)
     grid_cols = 1 + math.ceil(pad_left / cols) + math.ceil(pad_right / cols)
     original_row = math.ceil(pad_top / rows)
@@ -1537,27 +1538,26 @@ def get_pad_grid_dimensions(
 def generate_reflected_bboxes(
     bboxes: np.ndarray,
     grid_dims: dict[str, tuple[int, int]],
-    rows: int,
-    cols: int,
+    image_shape: tuple[int, int],
 ) -> np.ndarray:
     """Generate reflected bounding boxes for the entire reflection grid.
 
     Args:
         bboxes (np.ndarray): Original bounding boxes.
         grid_dims (dict[str, tuple[int, int]]): Grid dimensions and original position.
-        rows (int): Height of the original image.
-        cols (int): Width of the original image.
+        image_shape (tuple[int, int]): Shape of the original image as (height, width).
 
     Returns:
         np.ndarray: Array of reflected and shifted bounding boxes for the entire grid.
     """
+    rows, cols = image_shape[:2]
     grid_rows, grid_cols = grid_dims["grid_shape"]
     original_row, original_col = grid_dims["original_position"]
 
     # Prepare flipped versions of bboxes
-    bboxes_hflipped = flip_bboxes(bboxes, flip_horizontal=True, rows=rows, cols=cols)
-    bboxes_vflipped = flip_bboxes(bboxes, flip_vertical=True, rows=rows, cols=cols)
-    bboxes_hvflipped = flip_bboxes(bboxes, flip_horizontal=True, flip_vertical=True, rows=rows, cols=cols)
+    bboxes_hflipped = flip_bboxes(bboxes, flip_horizontal=True, image_shape=image_shape)
+    bboxes_vflipped = flip_bboxes(bboxes, flip_vertical=True, image_shape=image_shape)
+    bboxes_hvflipped = flip_bboxes(bboxes, flip_horizontal=True, flip_vertical=True, image_shape=image_shape)
 
     # Shift all versions to the original position
     shift_vector = np.array([original_col * cols, original_row * rows, original_col * cols, original_row * rows])
@@ -1600,8 +1600,7 @@ def flip_bboxes(
     bboxes: np.ndarray,
     flip_horizontal: bool = False,
     flip_vertical: bool = False,
-    rows: int = 1,
-    cols: int = 1,
+    image_shape: tuple[int, int] = (0, 0),
 ) -> np.ndarray:
     """Flip bounding boxes horizontally and/or vertically.
 
@@ -1610,12 +1609,12 @@ def flip_bboxes(
             [x_min, y_min, x_max, y_max, ...].
         flip_horizontal (bool): Whether to flip horizontally.
         flip_vertical (bool): Whether to flip vertically.
-        rows (int): Height of the image.
-        cols (int): Width of the image.
+        image_shape (tuple[int, int]): Shape of the image as (height, width).
 
     Returns:
         np.ndarray: Flipped bounding boxes.
     """
+    rows, cols = image_shape[:2]
     flipped_bboxes = bboxes.copy()
     if flip_horizontal:
         flipped_bboxes[:, [0, 2]] = cols - flipped_bboxes[:, [2, 0]]
@@ -1810,3 +1809,112 @@ def generate_distorted_grid_polygons(dimensions: np.ndarray, magnitude: int) -> 
             polygons[i * grid_width + j, 0:2] += [dx, dy]
 
     return polygons
+
+
+def pad_keypoints(
+    keypoints: np.ndarray,
+    pad_top: int,
+    pad_bottom: int,
+    pad_left: int,
+    pad_right: int,
+    border_mode: int,
+    image_shape: tuple[int, int],
+) -> np.ndarray:
+    if border_mode not in {cv2.BORDER_REFLECT_101, cv2.BORDER_REFLECT101}:
+        shift_vector = np.array([pad_left, pad_top])  # Only shift x and y
+        return shift_keypoints(keypoints, shift_vector)
+
+    rows, cols = image_shape[:2]
+
+    grid_dimensions = get_pad_grid_dimensions(pad_top, pad_bottom, pad_left, pad_right, image_shape)
+
+    keypoints = generate_reflected_keypoints(keypoints, grid_dimensions, rows, cols)
+
+    # Calculate the number of grid cells added on each side
+    original_row, original_col = grid_dimensions["original_position"]
+
+    # Subtract the offset based on the number of added grid cells
+    keypoints[:, 0] -= original_col * cols - pad_left  # x
+    keypoints[:, 1] -= original_row * rows - pad_top  # y
+
+    new_height = pad_top + pad_bottom + rows
+    new_width = pad_left + pad_right + cols
+
+    return validate_keypoints(keypoints, (new_height, new_width))
+
+
+def validate_keypoints(keypoints: np.ndarray, image_shape: tuple[int, int]) -> np.ndarray:
+    rows, cols = image_shape[:2]
+
+    x, y = keypoints[:, 0], keypoints[:, 1]
+
+    valid_indices = (x >= 0) & (x < cols) & (y >= 0) & (y < rows)
+
+    return keypoints[valid_indices]
+
+
+def shift_keypoints(keypoints: np.ndarray, shift_vector: np.ndarray) -> np.ndarray:
+    shifted_keypoints = keypoints.copy()
+    shifted_keypoints[:, :2] += shift_vector[:2]  # Only shift x and y
+    return shifted_keypoints
+
+
+def generate_reflected_keypoints(
+    keypoints: np.ndarray,
+    grid_dims: dict[str, tuple[int, int]],
+    rows: int,
+    cols: int,
+) -> np.ndarray:
+    grid_rows, grid_cols = grid_dims["grid_shape"]
+    original_row, original_col = grid_dims["original_position"]
+
+    # Prepare flipped versions of keypoints
+    keypoints_hflipped = flip_keypoints(keypoints, flip_horizontal=True, rows=rows, cols=cols)
+    keypoints_vflipped = flip_keypoints(keypoints, flip_vertical=True, rows=rows, cols=cols)
+    keypoints_hvflipped = flip_keypoints(keypoints, flip_horizontal=True, flip_vertical=True, rows=rows, cols=cols)
+
+    # Shift all versions to the original position
+    shift_vector = np.array([original_col * cols, original_row * rows, 0, 0])  # Only shift x and y
+    keypoints_shifted = shift_keypoints(keypoints, shift_vector)
+    keypoints_hflipped_shifted = shift_keypoints(keypoints_hflipped, shift_vector)
+    keypoints_vflipped_shifted = shift_keypoints(keypoints_vflipped, shift_vector)
+    keypoints_hvflipped_shifted = shift_keypoints(keypoints_hvflipped, shift_vector)
+
+    new_keypoints = []
+
+    for grid_row in range(grid_rows):
+        for grid_col in range(grid_cols):
+            # Determine which version of keypoints to use based on grid position
+            if (grid_row - original_row) % 2 == 0 and (grid_col - original_col) % 2 == 0:
+                current_keypoints = keypoints_shifted
+            elif (grid_row - original_row) % 2 == 0:
+                current_keypoints = keypoints_hflipped_shifted
+            elif (grid_col - original_col) % 2 == 0:
+                current_keypoints = keypoints_vflipped_shifted
+            else:
+                current_keypoints = keypoints_hvflipped_shifted
+
+            # Shift to the current grid cell
+            cell_shift = np.array([(grid_col - original_col) * cols, (grid_row - original_row) * rows, 0, 0])
+            shifted_keypoints = shift_keypoints(current_keypoints, cell_shift)
+
+            new_keypoints.append(shifted_keypoints)
+
+    return np.vstack(new_keypoints)
+
+
+def flip_keypoints(
+    keypoints: np.ndarray,
+    flip_horizontal: bool = False,
+    flip_vertical: bool = False,
+    rows: int = 1,
+    cols: int = 1,
+) -> np.ndarray:
+    flipped_keypoints = keypoints.copy()
+    if flip_horizontal:
+        flipped_keypoints[:, 0] = cols - flipped_keypoints[:, 0]
+        flipped_keypoints[:, 2] = -flipped_keypoints[:, 2]  # Flip angle
+    if flip_vertical:
+        flipped_keypoints[:, 1] = rows - flipped_keypoints[:, 1]
+        flipped_keypoints[:, 2] = -flipped_keypoints[:, 2]  # Flip angle
+    return flipped_keypoints

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -1263,8 +1263,7 @@ class PadIfNeeded(DualTransform):
             Can be one of 'center', 'top_left', 'top_right', 'bottom_left', 'bottom_right', or 'random'.
             Default is 'center'.
         border_mode (int): Specifies the border mode to use if padding is required.
-            The default is `cv2.BORDER_REFLECT_101`. If `value` is provided and `border_mode` is set to a mode
-            that does not use a constant value, it should be manually set to `cv2.BORDER_CONSTANT`.
+            The default is `cv2.BORDER_REFLECT_101`.
         value (Union[int, float, list[int], list[float]], optional): Value to fill the border pixels if
             the border mode is `cv2.BORDER_CONSTANT`. Default is None.
         mask_value (Union[int, float, list[int], list[float]], optional): Similar to `value` but used for padding masks.
@@ -1335,9 +1334,6 @@ class PadIfNeeded(DualTransform):
             if (self.min_width is None) == (self.pad_width_divisor is None):
                 msg = "Only one of 'min_width' and 'pad_width_divisor' parameters must be set"
                 raise ValueError(msg)
-
-            if self.value is not None and self.border_mode in {cv2.BORDER_REFLECT_101, cv2.BORDER_REFLECT101}:
-                self.border_mode = cv2.BORDER_CONSTANT
 
             if self.border_mode == cv2.BORDER_CONSTANT and self.value is None:
                 msg = "If 'border_mode' is set to 'BORDER_CONSTANT', 'value' must be provided."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ format.skip-magic-trailing-comma = false
 # Like Black, automatically detect the appropriate line ending.
 lint.select = [ "ALL" ]
 lint.ignore = [
+  "ANN101",
   "ANN204",
   "ANN401",
   "ARG001",

--- a/tests/functional/test_affine.py
+++ b/tests/functional/test_affine.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 import skimage.transform
 import cv2
-import albumentations.augmentations.geometric.functional as FGeometric
+import albumentations.augmentations.geometric.functional as fgeometric
 import albumentations as A
 
 from itertools import product
@@ -38,7 +38,7 @@ def test_warp_affine(params, image_shape):
 
     aff_transform = skimage.transform.AffineTransform(rotation=np.deg2rad(angle), translation=translation, scale=(scale, scale), shear=np.deg2rad(shear))
     projective_transform = skimage.transform.ProjectiveTransform(matrix=aff_transform.params)
-    warped_img = FGeometric.warp_affine(image, projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, output_shape)
+    warped_img = fgeometric.warp_affine(image, projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, output_shape)
 
     assert warped_img.shape[:2] == output_shape, "Output shape does not match the expected shape."
 
@@ -62,7 +62,7 @@ def test_channel_integrity(image_shape):
     projective_transform = skimage.transform.ProjectiveTransform(matrix=aff_transform.params)
 
     # Apply the transformation
-    warped_img = FGeometric.warp_affine(image, projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, image.shape[:2])
+    warped_img = fgeometric.warp_affine(image, projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, image.shape[:2])
 
     # Verify that the channels remain unchanged
     assert np.array_equal(warped_img, image), "Channel integrity failed: Channels were altered by transformation."
@@ -85,7 +85,7 @@ def test_edge_padding(image_shape, translation, padding_value):
     projective_transform = skimage.transform.ProjectiveTransform(matrix=aff_transform.params)
 
     # Apply the transformation with specified padding
-    warped_img = FGeometric.warp_affine(image, projective_transform, cv2.INTER_LINEAR, padding_value, cv2.BORDER_CONSTANT, image.shape[:2])
+    warped_img = fgeometric.warp_affine(image, projective_transform, cv2.INTER_LINEAR, padding_value, cv2.BORDER_CONSTANT, image.shape[:2])
 
     # Check if the edge padding is correctly applied
     if translation[0] > 0:  # Right translation
@@ -144,10 +144,10 @@ def test_inverse_angle_scale(image_shape, angle, shape, scale):
     inverse_projective_transform = skimage.transform.ProjectiveTransform(matrix=inverse_transform.params)
 
     # Apply the forward transformation
-    warped_img = FGeometric.warp_affine(image, forward_projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, image_shape[:2])
+    warped_img = fgeometric.warp_affine(image, forward_projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, image_shape[:2])
 
     # Apply the inverse transformation
-    restored_img = FGeometric.warp_affine(warped_img, inverse_projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, image_shape[:2])
+    restored_img = fgeometric.warp_affine(warped_img, inverse_projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, image_shape[:2])
 
     # Adjust the assertion threshold based on expected discrepancies from complex transformations
     assert np.mean(np.abs(image - restored_img)) < 7, "Inverse transformation failed: The restored image is not close enough to the original."
@@ -162,7 +162,7 @@ def test_scale_with_warp_affine(img, expected):
     expected_shape = (int(img.shape[0] * scale), int(img.shape[1] * scale))
 
     # Apply scaling using warp_affine from the example provided
-    scaled_img = FGeometric.warp_affine(
+    scaled_img = fgeometric.warp_affine(
         img=img,
         matrix=transform,  # Use the top 2 rows of the 3x3 matrix
         interpolation=cv2.INTER_LINEAR,
@@ -196,7 +196,7 @@ def test_rotate_with_warp_affine(img, expected):
     transform, _ = create_centered_comprehensive_transform(img.shape[:2], angle, 0, (0, 0), 1)
 
     # Apply scaling using warp_affine from the example provided
-    scaled_img = FGeometric.warp_affine(
+    scaled_img = fgeometric.warp_affine(
         img=img,
         matrix=transform,  # Use the top 2 rows of the 3x3 matrix
         interpolation=cv2.INTER_LINEAR,
@@ -218,7 +218,7 @@ def test_translate_with_warp_affine(img, expected, translate):
     transform, _ = create_centered_comprehensive_transform(img.shape[:2], 0, 0, translate, 1)
 
     # Apply scaling using warp_affine from the example provided
-    scaled_img = FGeometric.warp_affine(
+    scaled_img = fgeometric.warp_affine(
         img=img,
         matrix=transform,  # Use the top 2 rows of the 3x3 matrix
         interpolation=cv2.INTER_LINEAR,
@@ -252,10 +252,10 @@ def test_inverse_shear(image_shape, shear, shape):
     inverse_projective_transform = skimage.transform.ProjectiveTransform(matrix=inverse_transform.params)
 
     # Apply the forward transformation
-    warped_img = FGeometric.warp_affine(image, forward_projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, image_shape[:2])
+    warped_img = fgeometric.warp_affine(image, forward_projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, image_shape[:2])
 
     # Apply the inverse transformation
-    restored_img = FGeometric.warp_affine(warped_img, inverse_projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, image_shape[:2])
+    restored_img = fgeometric.warp_affine(warped_img, inverse_projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, image_shape[:2])
 
     # Adjust the assertion threshold based on expected discrepancies from complex transformations
     assert np.array_equal(image - restored_img), "Inverse transformation failed: The restored image is not close enough to the original."
@@ -284,10 +284,10 @@ def test_inverse_shear(image_shape, translate, shape):
     inverse_projective_transform = skimage.transform.ProjectiveTransform(matrix=inverse_transform.params)
 
     # Apply the forward transformation
-    warped_img = FGeometric.warp_affine(image, forward_projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, image_shape[:2])
+    warped_img = fgeometric.warp_affine(image, forward_projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, image_shape[:2])
 
     # Apply the inverse transformation
-    restored_img = FGeometric.warp_affine(warped_img, inverse_projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, image_shape[:2])
+    restored_img = fgeometric.warp_affine(warped_img, inverse_projective_transform, cv2.INTER_LINEAR, 0, cv2.BORDER_CONSTANT, image_shape[:2])
 
     # Adjust the assertion threshold based on expected discrepancies from complex transformations
     assert np.array_equal(image, restored_img), "Inverse transformation failed: The restored image is not close enough to the original."
@@ -304,5 +304,5 @@ def test_keypoint_affine(keypoint, expected, angle, scale, dx, dy):
 
     transform = skimage.transform.ProjectiveTransform(matrix=centered_transform.params)
 
-    actual = FGeometric.keypoint_affine(keypoint, transform, {"x": keypoint[2], "y": keypoint[3]})
+    actual = fgeometric.keypoint_affine(keypoint, transform, {"x": keypoint[2], "y": keypoint[3]})
     np.testing.assert_allclose(actual[:2], expected[:2], rtol=1e-4)

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -640,48 +640,48 @@ def test_union_of_bboxes(bboxes, erosion_rate, expected):
     result = union_of_bboxes(bboxes, erosion_rate)
     assert result == expected or np.testing.assert_almost_equal(result, expected, decimal=6) is None
 
-@pytest.mark.parametrize("pad_top, pad_bottom, pad_left, pad_right, rows, cols, expected", [
+@pytest.mark.parametrize("pad_top, pad_bottom, pad_left, pad_right, image_shape, expected", [
     # Symmetric padding
-    (100, 100, 100, 100, 100, 100, {'grid_shape': (3, 3), 'original_position': (1, 1)}),  # Exact multiple
-    (150, 150, 150, 150, 100, 100, {'grid_shape': (5, 5), 'original_position': (2, 2)}),  # Rounded up
-    (50, 50, 50, 50, 100, 100, {'grid_shape': (3, 3), 'original_position': (1, 1)}),      # Less than image size
+    (100, 100, 100, 100, (100, 100), {'grid_shape': (3, 3), 'original_position': (1, 1)}),  # Exact multiple
+    (150, 150, 150, 150, (100, 100), {'grid_shape': (5, 5), 'original_position': (2, 2)}),  # Rounded up
+    (50, 50, 50, 50, (100, 100), {'grid_shape': (3, 3), 'original_position': (1, 1)}),      # Less than image size
 
     # Asymmetric padding
-    (100, 0, 100, 0, 100, 100, {'grid_shape': (2, 2), 'original_position': (1, 1)}),
-    (0, 100, 0, 100, 100, 100, {'grid_shape': (2, 2), 'original_position': (0, 0)}),
-    (100, 50, 75, 25, 100, 100, {'grid_shape': (3, 3), 'original_position': (1, 1)}),
+    (100, 0, 100, 0, (100, 100), {'grid_shape': (2, 2), 'original_position': (1, 1)}),
+    (0, 100, 0, 100, (100, 100), {'grid_shape': (2, 2), 'original_position': (0, 0)}),
+    (100, 50, 75, 25, (100, 100), {'grid_shape': (3, 3), 'original_position': (1, 1)}),
 
     # Edge cases
-    (0, 0, 0, 0, 100, 100, {'grid_shape': (1, 1), 'original_position': (0, 0)}),          # No padding
-    (1, 1, 1, 1, 100, 100, {'grid_shape': (3, 3), 'original_position': (1, 1)}),          # Minimal padding
+    (0, 0, 0, 0, (100, 100), {'grid_shape': (1, 1), 'original_position': (0, 0)}),          # No padding
+    (1, 1, 1, 1, (100, 100), {'grid_shape': (3, 3), 'original_position': (1, 1)}),          # Minimal padding
 
     # Different image dimensions
-    (100, 100, 50, 50, 50, 100, {'grid_shape': (5, 3), 'original_position': (2, 1)}),
+    (100, 100, 50, 50, (50, 100), {'grid_shape': (5, 3), 'original_position': (2, 1)}),
 
     # Large padding
-    (500, 500, 500, 500, 100, 100, {'grid_shape': (11, 11), 'original_position': (5, 5)}),
+    (500, 500, 500, 500, (100, 100), {'grid_shape': (11, 11), 'original_position': (5, 5)}),
 
     # Asymmetric image dimensions
-    (100, 100, 100, 100, 200, 100, {'grid_shape': (3, 3), 'original_position': (1, 1)}),
+    (100, 100, 100, 100, (200, 100), {'grid_shape': (3, 3), 'original_position': (1, 1)}),
 
     # Very small image dimensions
-    (10, 10, 10, 10, 5, 5, {'grid_shape': (5, 5), 'original_position': (2, 2)}),
+    (10, 10, 10, 10, (5, 5), {'grid_shape': (5, 5), 'original_position': (2, 2)}),
 
     # Very large image dimensions
-    (1000, 1000, 1000, 1000, 10000, 10000, {'grid_shape': (3, 3), 'original_position': (1, 1)}),
+    (1000, 1000, 1000, 1000, (10000, 10000), {'grid_shape': (3, 3), 'original_position': (1, 1)}),
 
     # Zero padding on some sides
-    (100, 0, 0, 100, 100, 100, {'grid_shape': (2, 2), 'original_position': (1, 0)}),
+    (100, 0, 0, 100, (100, 100), {'grid_shape': (2, 2), 'original_position': (1, 0)}),
 
     # Padding smaller than image on some sides, larger on others
-    (50, 150, 25, 175, 100, 100, {'grid_shape': (4, 4), 'original_position': (1, 1)}),
+    (50, 150, 25, 175, (100, 100), {'grid_shape': (4, 4), 'original_position': (1, 1)}),
 ])
-def test_get_pad_grid_dimensions(pad_top, pad_bottom, pad_left, pad_right, rows, cols, expected):
-    result = fgeometric.get_pad_grid_dimensions(pad_top, pad_bottom, pad_left, pad_right, rows, cols)
+def test_get_pad_grid_dimensions(pad_top, pad_bottom, pad_left, pad_right, image_shape, expected):
+    result = fgeometric.get_pad_grid_dimensions(pad_top, pad_bottom, pad_left, pad_right, image_shape)
     assert result == expected, f"Expected {expected}, but got {result}"
 
 def test_get_pad_grid_dimensions_float_values():
-    result = fgeometric.get_pad_grid_dimensions(10.5, 10.5, 10.5, 10.5, 100, 100)
+    result = fgeometric.get_pad_grid_dimensions(10.5, 10.5, 10.5, 10.5, (100, 100))
     assert result == {'grid_shape': (3, 3), 'original_position': (1, 1)}, "Function should handle float inputs by implicit conversion to int"
 
 
@@ -706,14 +706,13 @@ def test_get_pad_grid_dimensions_float_values():
 ])
 def test_pad_bboxes_with_reflection(image_shape, bboxes, pad_params, expected_bboxes):
     pad_top, pad_bottom, pad_left, pad_right = pad_params
-    rows, cols = image_shape[:2]
+    image_shape[:2]
 
     result = fgeometric.pad_bboxes(
         bboxes,
         pad_top, pad_bottom, pad_left, pad_right,
         border_mode=cv2.BORDER_REFLECT_101,
-        rows=rows,
-        cols=cols
+        image_shape=image_shape[:2]
     )
 
     np.testing.assert_array_almost_equal(result, expected_bboxes, decimal=1)
@@ -730,14 +729,12 @@ def test_pad_bboxes_with_reflection(image_shape, bboxes, pad_params, expected_bb
 ])
 def test_pad_bboxes_constant_border(image_shape, bboxes, pad_params, expected_bboxes):
     pad_top, pad_bottom, pad_left, pad_right = pad_params
-    rows, cols = image_shape[:2]
 
     result = fgeometric.pad_bboxes(
         bboxes,
         pad_top, pad_bottom, pad_left, pad_right,
         border_mode=cv2.BORDER_CONSTANT,
-        rows=rows,
-        cols=cols
+        image_shape=image_shape[:2]
     )
 
     np.testing.assert_array_almost_equal(result, expected_bboxes, decimal=1)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_array_almost_equal_nulp, assert_almost_equal
 import skimage
 
 import albumentations.augmentations.functional as F
-import albumentations.augmentations.geometric.functional as FGeometric
+import albumentations.augmentations.geometric.functional as fgeometric
 from albucore.utils import is_multispectral_image, MAX_VALUES_BY_DTYPE, get_num_channels
 
 from albumentations.core.types import d4_group_elements
@@ -19,7 +19,7 @@ def test_vflip(target):
     img = np.array([[1, 1, 1], [0, 1, 1], [0, 0, 1]], dtype=np.uint8)
     expected = np.array([[0, 0, 1], [0, 1, 1], [1, 1, 1]], dtype=np.uint8)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    flipped_img = FGeometric.vflip(img)
+    flipped_img = fgeometric.vflip(img)
     assert np.array_equal(flipped_img, expected)
 
 
@@ -28,7 +28,7 @@ def test_vflip_float(target):
     img = np.array([[0.4, 0.4, 0.4], [0.0, 0.4, 0.4], [0.0, 0.0, 0.4]], dtype=np.float32)
     expected = np.array([[0.0, 0.0, 0.4], [0.0, 0.4, 0.4], [0.4, 0.4, 0.4]], dtype=np.float32)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    flipped_img = FGeometric.vflip(img)
+    flipped_img = fgeometric.vflip(img)
     assert_array_almost_equal_nulp(flipped_img, expected)
 
 
@@ -37,7 +37,7 @@ def test_hflip(target):
     img = np.array([[1, 1, 1], [0, 1, 1], [0, 0, 1]], dtype=np.uint8)
     expected = np.array([[1, 1, 1], [1, 1, 0], [1, 0, 0]], dtype=np.uint8)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    flipped_img = FGeometric.hflip(img)
+    flipped_img = fgeometric.hflip(img)
     assert np.array_equal(flipped_img, expected)
 
 
@@ -46,43 +46,43 @@ def test_hflip_float(target):
     img = np.array([[0.4, 0.4, 0.4], [0.0, 0.4, 0.4], [0.0, 0.0, 0.4]], dtype=np.float32)
     expected = np.array([[0.4, 0.4, 0.4], [0.4, 0.4, 0.0], [0.4, 0.0, 0.0]], dtype=np.float32)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    flipped_img = FGeometric.hflip(img)
+    flipped_img = fgeometric.hflip(img)
     assert_array_almost_equal_nulp(flipped_img, expected)
 
 
 @pytest.mark.parametrize("target", ["image", "mask"])
 @pytest.mark.parametrize(
     ["code", "func"],
-    [[0, FGeometric.vflip], [1, FGeometric.hflip], [-1, lambda img: FGeometric.vflip(FGeometric.hflip(img))]],
+    [[0, fgeometric.vflip], [1, fgeometric.hflip], [-1, lambda img: fgeometric.vflip(fgeometric.hflip(img))]],
 )
 def test_random_flip(code, func, target):
     img = np.array([[1, 1, 1], [0, 1, 1], [0, 0, 1]], dtype=np.uint8)
     img = convert_2d_to_target_format([img], target=target)
-    assert np.array_equal(FGeometric.random_flip(img, code), func(img))
+    assert np.array_equal(fgeometric.random_flip(img, code), func(img))
 
 
 @pytest.mark.parametrize("target", ["image", "image_4_channels"])
 @pytest.mark.parametrize(
     ["code", "func"],
-    [[0, FGeometric.vflip], [1, FGeometric.hflip], [-1, lambda img: FGeometric.vflip(FGeometric.hflip(img))]],
+    [[0, fgeometric.vflip], [1, fgeometric.hflip], [-1, lambda img: fgeometric.vflip(fgeometric.hflip(img))]],
 )
 def test_random_flip_float(code, func, target):
     img = np.array([[0.4, 0.4, 0.4], [0.0, 0.4, 0.4], [0.0, 0.0, 0.4]], dtype=np.float32)
     img = convert_2d_to_target_format([img], target=target)
-    assert_array_almost_equal_nulp(FGeometric.random_flip(img, code), func(img))
+    assert_array_almost_equal_nulp(fgeometric.random_flip(img, code), func(img))
 
 
 @pytest.mark.parametrize(["input_shape", "expected_shape"], [[(128, 64), (64, 128)], [(128, 64, 3), (64, 128, 3)]])
 def test_transpose(input_shape, expected_shape):
     img = np.random.randint(low=0, high=256, size=input_shape, dtype=np.uint8)
-    transposed = FGeometric.transpose(img)
+    transposed = fgeometric.transpose(img)
     assert transposed.shape == expected_shape
 
 
 @pytest.mark.parametrize(["input_shape", "expected_shape"], [[(128, 64), (64, 128)], [(128, 64, 3), (64, 128, 3)]])
 def test_transpose_float(input_shape, expected_shape):
     img = np.random.uniform(low=0.0, high=1.0, size=input_shape).astype("float32")
-    transposed = FGeometric.transpose(img)
+    transposed = fgeometric.transpose(img)
     assert transposed.shape == expected_shape
 
 
@@ -91,7 +91,7 @@ def test_rot90(target):
     img = np.array([[0, 0, 1], [0, 0, 1], [0, 0, 1]], dtype=np.uint8)
     expected = np.array([[1, 1, 1], [0, 0, 0], [0, 0, 0]], dtype=np.uint8)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    rotated = FGeometric.rot90(img, factor=1)
+    rotated = fgeometric.rot90(img, factor=1)
     assert np.array_equal(rotated, expected)
 
 
@@ -100,7 +100,7 @@ def test_rot90_float(target):
     img = np.array([[0.0, 0.0, 0.4], [0.0, 0.0, 0.4], [0.0, 0.0, 0.4]], dtype=np.float32)
     expected = np.array([[0.4, 0.4, 0.4], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=np.float32)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    rotated = FGeometric.rot90(img, factor=1)
+    rotated = fgeometric.rot90(img, factor=1)
     assert_array_almost_equal_nulp(rotated, expected)
 
 
@@ -119,7 +119,7 @@ def test_compare_rotate_and_affine(image):
     rotation_matrix = generate_rotation_matrix(image, 60)
 
     # Apply rotation using FGeometric.rotate
-    rotated_img_1 = FGeometric.rotate(
+    rotated_img_1 = fgeometric.rotate(
         image, angle=60, border_mode=cv2.BORDER_CONSTANT, value=0, interpolation=cv2.INTER_LINEAR
     )
 
@@ -128,7 +128,7 @@ def test_compare_rotate_and_affine(image):
     projective_transform = skimage.transform.ProjectiveTransform(matrix=full_matrix)
 
     # Apply rotation using warp_affine
-    rotated_img_2 = FGeometric.warp_affine(
+    rotated_img_2 = fgeometric.warp_affine(
         img=image,
         matrix=projective_transform,
         interpolation=cv2.INTER_LINEAR,
@@ -146,7 +146,7 @@ def test_pad(target):
     img = np.array([[1, 2], [3, 4]], dtype=np.uint8)
     expected = np.array([[4, 3, 4, 3], [2, 1, 2, 1], [4, 3, 4, 3], [2, 1, 2, 1]], dtype=np.uint8)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    padded = FGeometric.pad(img, min_height=4, min_width=4, border_mode=cv2.BORDER_REFLECT_101, value=None)
+    padded = fgeometric.pad(img, min_height=4, min_width=4, border_mode=cv2.BORDER_REFLECT_101, value=None)
     assert np.array_equal(padded, expected)
 
 
@@ -157,7 +157,7 @@ def test_pad_float(target):
         [[0.4, 0.3, 0.4, 0.3], [0.2, 0.1, 0.2, 0.1], [0.4, 0.3, 0.4, 0.3], [0.2, 0.1, 0.2, 0.1]], dtype=np.float32
     )
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    padded_img = FGeometric.pad(img, min_height=4, min_width=4, value=None, border_mode=cv2.BORDER_REFLECT_101)
+    padded_img = fgeometric.pad(img, min_height=4, min_width=4, value=None, border_mode=cv2.BORDER_REFLECT_101)
     assert_array_almost_equal_nulp(padded_img, expected)
 
 
@@ -328,7 +328,7 @@ def test_scale(target):
     )
 
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    scaled = FGeometric.scale(img, scale=2, interpolation=cv2.INTER_LINEAR)
+    scaled = fgeometric.scale(img, scale=2, interpolation=cv2.INTER_LINEAR)
     assert np.array_equal(scaled, expected)
 
 
@@ -345,7 +345,7 @@ def test_longest_max_size(target):
     expected = np.array([[2, 3], [6, 7], [10, 11]], dtype=np.uint8)
 
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    scaled = FGeometric.longest_max_size(img, max_size=3, interpolation=cv2.INTER_LINEAR)
+    scaled = fgeometric.longest_max_size(img, max_size=3, interpolation=cv2.INTER_LINEAR)
     assert np.array_equal(scaled, expected)
 
 
@@ -357,7 +357,7 @@ def test_smallest_max_size(target):
     expected = np.array([[2, 4, 5, 7], [10, 11, 13, 14], [17, 19, 20, 22]], dtype=np.uint8)
 
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    scaled = FGeometric.smallest_max_size(img, max_size=3, interpolation=cv2.INTER_LINEAR)
+    scaled = fgeometric.smallest_max_size(img, max_size=3, interpolation=cv2.INTER_LINEAR)
     assert np.array_equal(scaled, expected)
 
 
@@ -380,7 +380,7 @@ def test_resize_linear_interpolation(target):
     img = np.array([[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]], dtype=np.uint8)
     expected = np.array([[2, 2], [4, 4]], dtype=np.uint8)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    resized_img = FGeometric.resize(img, 2, 2, interpolation=cv2.INTER_LINEAR)
+    resized_img = fgeometric.resize(img, 2, 2, interpolation=cv2.INTER_LINEAR)
     height, width = resized_img.shape[:2]
     assert height == 2
     assert width == 2
@@ -392,7 +392,7 @@ def test_resize_nearest_interpolation(target):
     img = np.array([[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]], dtype=np.uint8)
     expected = np.array([[1, 1], [3, 3]], dtype=np.uint8)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    resized_img = FGeometric.resize(img, 2, 2, interpolation=cv2.INTER_NEAREST)
+    resized_img = fgeometric.resize(img, 2, 2, interpolation=cv2.INTER_NEAREST)
     height, width = resized_img.shape[:2]
     assert height == 2
     assert width == 2
@@ -403,7 +403,7 @@ def test_resize_nearest_interpolation(target):
 def test_resize_different_height_and_width(target):
     img = np.ones((100, 100), dtype=np.uint8)
     img = convert_2d_to_target_format([img], target=target)
-    resized_img = FGeometric.resize(img, height=20, width=30, interpolation=cv2.INTER_LINEAR)
+    resized_img = fgeometric.resize(img, height=20, width=30, interpolation=cv2.INTER_LINEAR)
     height, width = resized_img.shape[:2]
     assert height == 20
     assert width == 30
@@ -419,7 +419,7 @@ def test_resize_default_interpolation_float(target):
     )
     expected = np.array([[0.15, 0.15], [0.35, 0.35]], dtype=np.float32)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    resized_img = FGeometric.resize(img, 2, 2, interpolation=cv2.INTER_LINEAR)
+    resized_img = fgeometric.resize(img, 2, 2, interpolation=cv2.INTER_LINEAR)
     height, width = resized_img.shape[:2]
     assert height == 2
     assert width == 2
@@ -433,7 +433,7 @@ def test_resize_nearest_interpolation_float(target):
     )
     expected = np.array([[0.1, 0.1], [0.3, 0.3]], dtype=np.float32)
     img, expected = convert_2d_to_target_format([img, expected], target=target)
-    resized_img = FGeometric.resize(img, 2, 2, interpolation=cv2.INTER_NEAREST)
+    resized_img = fgeometric.resize(img, 2, 2, interpolation=cv2.INTER_NEAREST)
     height, width = resized_img.shape[:2]
     assert height == 2
     assert width == 2
@@ -441,25 +441,25 @@ def test_resize_nearest_interpolation_float(target):
 
 
 def test_bbox_vflip():
-    assert FGeometric.bbox_vflip((0.1, 0.2, 0.6, 0.5), 100, 200) == (0.1, 0.5, 0.6, 0.8)
+    assert fgeometric.bbox_vflip((0.1, 0.2, 0.6, 0.5), 100, 200) == (0.1, 0.5, 0.6, 0.8)
 
 
 def test_bbox_hflip():
-    assert FGeometric.bbox_hflip((0.1, 0.2, 0.6, 0.5), 100, 200) == (0.4, 0.2, 0.9, 0.5)
+    assert fgeometric.bbox_hflip((0.1, 0.2, 0.6, 0.5), 100, 200) == (0.4, 0.2, 0.9, 0.5)
 
 
 @pytest.mark.parametrize(
     ["code", "func"],
     [
-        [0, FGeometric.bbox_vflip],
-        [1, FGeometric.bbox_hflip],
-        [-1, lambda bbox, rows, cols: FGeometric.bbox_vflip(FGeometric.bbox_hflip(bbox, rows, cols), rows, cols)],
+        [0, fgeometric.bbox_vflip],
+        [1, fgeometric.bbox_hflip],
+        [-1, lambda bbox, rows, cols: fgeometric.bbox_vflip(fgeometric.bbox_hflip(bbox, rows, cols), rows, cols)],
     ],
 )
 def test_bbox_flip(code, func):
     rows, cols = 100, 200
     bbox = [0.1, 0.2, 0.6, 0.5]
-    assert FGeometric.bbox_flip(bbox, code, rows, cols) == func(bbox, rows, cols)
+    assert fgeometric.bbox_flip(bbox, code, rows, cols) == func(bbox, rows, cols)
 
 
 @pytest.mark.parametrize("factor, expected_positions", [
@@ -475,10 +475,10 @@ def test_keypoint_image_rot90_match(factor, expected_positions):
     img[keypoint[1], keypoint[0]] = 1
 
     # Rotate the image
-    rotated_img = FGeometric.rot90(img, factor)
+    rotated_img = fgeometric.rot90(img, factor)
 
     # Rotate the keypoint
-    rotated_keypoint = FGeometric.keypoint_rot90(keypoint, factor, img.shape[0], img.shape[1])
+    rotated_keypoint = fgeometric.keypoint_rot90(keypoint, factor, img.shape[0], img.shape[1])
 
     # Assert that the rotated keypoint lands where expected
     assert rotated_img[rotated_keypoint[1], rotated_keypoint[0]] == 1, \
@@ -487,16 +487,16 @@ def test_keypoint_image_rot90_match(factor, expected_positions):
 
 
 def test_bbox_rot90():
-    assert FGeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 0, 100, 200) == (0.1, 0.2, 0.3, 0.4)
-    assert FGeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 1, 100, 200) == (0.2, 0.7, 0.4, 0.9)
-    assert FGeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 2, 100, 200) == (0.7, 0.6, 0.9, 0.8)
-    assert FGeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 3, 100, 200) == (0.6, 0.1, 0.8, 0.3)
+    assert fgeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 0, 100, 200) == (0.1, 0.2, 0.3, 0.4)
+    assert fgeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 1, 100, 200) == (0.2, 0.7, 0.4, 0.9)
+    assert fgeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 2, 100, 200) == (0.7, 0.6, 0.9, 0.8)
+    assert fgeometric.bbox_rot90((0.1, 0.2, 0.3, 0.4), 3, 100, 200) == (0.6, 0.1, 0.8, 0.3)
 
 
 def test_bbox_transpose():
-    assert np.allclose(FGeometric.bbox_transpose((0.7, 0.1, 0.8, 0.4), 100, 200), (0.1, 0.7, 0.4, 0.8))
-    rot90 = FGeometric.bbox_rot90((0.7, 0.1, 0.8, 0.4), 2, 100, 200)
-    reflected_anti_diagonal = FGeometric.bbox_transpose(rot90, 100, 200)
+    assert np.allclose(fgeometric.bbox_transpose((0.7, 0.1, 0.8, 0.4), 100, 200), (0.1, 0.7, 0.4, 0.8))
+    rot90 = fgeometric.bbox_rot90((0.7, 0.1, 0.8, 0.4), 2, 100, 200)
+    reflected_anti_diagonal = fgeometric.bbox_transpose(rot90, 100, 200)
     assert np.allclose(reflected_anti_diagonal, (0.6, 0.2, 0.9, 0.3))
 
 
@@ -504,7 +504,7 @@ def test_fun_max_size():
     target_width = 256
 
     img = np.empty((330, 49), dtype=np.uint8)
-    out = FGeometric.smallest_max_size(img, target_width, interpolation=cv2.INTER_LINEAR)
+    out = fgeometric.smallest_max_size(img, target_width, interpolation=cv2.INTER_LINEAR)
 
     assert out.shape == (1724, target_width)
 
@@ -741,7 +741,7 @@ def test_maybe_process_in_chunks():
 
     for i in range(1, image.shape[-1] + 1):
         before = image[:, :, :i]
-        after = FGeometric.rotate(before, angle=1, interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_REFLECT_101)
+        after = fgeometric.rotate(before, angle=1, interpolation=cv2.INTER_LINEAR, border_mode=cv2.BORDER_REFLECT_101)
         assert before.shape == after.shape
 
 
@@ -888,7 +888,7 @@ def test_shuffle_tiles_within_shape_groups(shape_groups, random_state, expected_
 ])
 def test_d4_transformations(group_member, expected):
     img = np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]], dtype=np.uint8)
-    transformed_img = FGeometric.d4(img, group_member)
+    transformed_img = fgeometric.d4(img, group_member)
     assert np.array_equal(transformed_img, expected), f"Failed for transformation {group_member}"
 
 
@@ -903,7 +903,7 @@ def get_md5_hash(image):
 def test_d4_unique(image):
     hashes = set()
     for element in d4_group_elements:
-        hashes.add(get_md5_hash(FGeometric.d4(image, element)))
+        hashes.add(get_md5_hash(fgeometric.d4(image, element)))
 
     assert len(hashes) == len(set(hashes)), "d4 should generate unique images for all group elements"
 
@@ -911,7 +911,7 @@ def test_d4_unique(image):
 @pytest.mark.parametrize("image", RECTANGULAR_IMAGES)
 @pytest.mark.parametrize("group_member", d4_group_elements)
 def test_d4_output_shape_with_group(image, group_member):
-    result = FGeometric.d4(image, group_member)
+    result = fgeometric.d4(image, group_member)
     if group_member in ['r90', 'r270', 't', 'hvt']:
         assert result.shape[:2] == image.shape[:2][::-1], "Output shape should be the transpose of input shape"
     else:
@@ -920,14 +920,14 @@ def test_d4_output_shape_with_group(image, group_member):
 
 @pytest.mark.parametrize("image", RECTANGULAR_IMAGES)
 def test_transpose_output_shape(image):
-    result = FGeometric.transpose(image)
+    result = fgeometric.transpose(image)
     assert result.shape[:2] == image.shape[:2][::-1], "Output shape should be the transpose of input shape"
 
 
 @pytest.mark.parametrize("image", RECTANGULAR_IMAGES)
 @pytest.mark.parametrize("factor", [0, 1, 2, 3])
 def test_d4_output_shape_with_factor(image, factor):
-    result = FGeometric.rot90(image, factor)
+    result = fgeometric.rot90(image, factor)
     if factor in {1, 3}:
         assert result.shape[:2] == image.shape[:2][::-1], "Output shape should be the transpose of input shape"
     else:
@@ -945,7 +945,7 @@ def test_d4_output_shape_with_factor(image, factor):
     ((0.05, 0.1, 0.55, 0.6), 'hvt', 200, 200, (1 - 0.6, 1 - 0.55, 1 - 0.1, 1 - 0.05)),  # Transpose around second diagonal
 ])
 def test_bbox_d4(bbox, group_member, rows, cols, expected):
-    result = FGeometric.bbox_d4(bbox, group_member, rows, cols)
+    result = fgeometric.bbox_d4(bbox, group_member, rows, cols)
     assert result == pytest.approx(expected, rel=1e-5), f"Failed for transformation {group_member} with bbox {bbox}"
 
 
@@ -957,15 +957,15 @@ def test_bbox_d4(bbox, group_member, rows, cols, expected):
 def test_keypoint_vh_flip_equivalence(keypoint, rows, cols):
 
     # Perform vertical and then horizontal flip
-    hflipped_keypoint = FGeometric.keypoint_hflip(keypoint, rows, cols)
-    vhflipped_keypoint = FGeometric.keypoint_vflip(hflipped_keypoint, rows, cols)
+    hflipped_keypoint = fgeometric.keypoint_hflip(keypoint, rows, cols)
+    vhflipped_keypoint = fgeometric.keypoint_vflip(hflipped_keypoint, rows, cols)
 
-    vflipped_keypoint = FGeometric.keypoint_vflip(keypoint, rows, cols)
-    hvflipped_keypoint = FGeometric.keypoint_hflip(vflipped_keypoint, rows, cols)
+    vflipped_keypoint = fgeometric.keypoint_vflip(keypoint, rows, cols)
+    hvflipped_keypoint = fgeometric.keypoint_hflip(vflipped_keypoint, rows, cols)
 
     assert vhflipped_keypoint == pytest.approx(hvflipped_keypoint), \
         "Sequential vflip + hflip not equivalent to hflip + vflip"
-    assert vhflipped_keypoint == pytest.approx(FGeometric.keypoint_rot90(keypoint, 2, rows, cols)), \
+    assert vhflipped_keypoint == pytest.approx(fgeometric.keypoint_rot90(keypoint, 2, rows, cols)), \
         "rot180 not equivalent to vflip + hflip"
 
 
@@ -993,8 +993,8 @@ def test_transpose_2(shape):
     expected_main = create_test_matrix(expected_main_diagonal, shape)
     expected_second = create_test_matrix(expected_second_diagonal, shape)
 
-    assert np.array_equal(FGeometric.transpose(img), expected_main)
-    transposed_axis1 = FGeometric.transpose(FGeometric.rot90(img, 2))
+    assert np.array_equal(fgeometric.transpose(img), expected_main)
+    transposed_axis1 = fgeometric.transpose(fgeometric.rot90(img, 2))
     assert np.array_equal(transposed_axis1, expected_second)
 
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -10,7 +10,7 @@ import pytest
 from deepdiff import DeepDiff
 
 import albumentations as A
-import albumentations.augmentations.geometric.functional as FGeometric
+import albumentations.augmentations.geometric.functional as fgeometric
 from albumentations.core.serialization import SERIALIZABLE_REGISTRY, shorten_class_name
 from albumentations.core.transforms_interface import ImageOnlyTransform
 
@@ -542,16 +542,16 @@ def test_additional_targets_for_image_only_serialization(augmentation_cls, param
 @pytest.mark.parametrize("image", IMAGES)
 def test_lambda_serialization(image, albumentations_bboxes, keypoints, seed, p):
     def vflip_image(image, **kwargs):
-        return FGeometric.vflip(image)
+        return fgeometric.vflip(image)
 
     def vflip_mask(mask, **kwargs):
-        return FGeometric.vflip(mask)
+        return fgeometric.vflip(mask)
 
     def vflip_bbox(bbox, **kwargs):
-        return FGeometric.bbox_vflip(bbox, kwargs["shape"][0], kwargs["shape"][1])
+        return fgeometric.bbox_vflip(bbox, kwargs["shape"][0], kwargs["shape"][1])
 
     def vflip_keypoint(keypoint, **kwargs):
-        return FGeometric.keypoint_vflip(keypoint, kwargs["shape"][0], kwargs["shape"][1])
+        return fgeometric.keypoint_vflip(keypoint, kwargs["shape"][0], kwargs["shape"][1])
 
     mask = image.copy()
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -14,7 +14,7 @@ from albumentations.core.bbox_utils import denormalize_bboxes, normalize_bboxes
 from albucore.utils import clip
 import albumentations as A
 import albumentations.augmentations.functional as F
-import albumentations.augmentations.geometric.functional as FGeometric
+import albumentations.augmentations.geometric.functional as fgeometric
 from albumentations.augmentations.transforms import ImageCompression, RandomRain
 from albumentations.core.transforms_interface import BasicTransform
 from albumentations.core.types import ImageCompressionType
@@ -41,8 +41,8 @@ def test_rotate_interpolation(interpolation):
     mask = np.random.randint(low=0, high=2, size=(100, 100), dtype=np.uint8)
     aug = A.Rotate(limit=(45, 45), interpolation=interpolation, p=1)
     data = aug(image=image, mask=mask)
-    expected_image = FGeometric.rotate(image, 45, interpolation=interpolation, border_mode=cv2.BORDER_REFLECT_101)
-    expected_mask = FGeometric.rotate(mask, 45, interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_REFLECT_101)
+    expected_image = fgeometric.rotate(image, 45, interpolation=interpolation, border_mode=cv2.BORDER_REFLECT_101)
+    expected_mask = fgeometric.rotate(mask, 45, interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_REFLECT_101)
     assert np.array_equal(data["image"], expected_image)
     assert np.array_equal(data["mask"], expected_mask)
 
@@ -63,10 +63,10 @@ def test_optical_distortion_interpolation(interpolation):
     mask = np.random.randint(low=0, high=2, size=(100, 100), dtype=np.uint8)
     aug = A.OpticalDistortion(distort_limit=(0.05, 0.05), shift_limit=(0, 0), interpolation=interpolation, p=1)
     data = aug(image=image, mask=mask)
-    expected_image = FGeometric.optical_distortion(
+    expected_image = fgeometric.optical_distortion(
         image, k=0.05, dx=0, dy=0, interpolation=interpolation, border_mode=cv2.BORDER_REFLECT_101
     )
-    expected_mask = FGeometric.optical_distortion(
+    expected_mask = fgeometric.optical_distortion(
         mask, k=0.05, dx=0, dy=0, interpolation=cv2.INTER_NEAREST, border_mode=cv2.BORDER_REFLECT_101
     )
     assert np.array_equal(data["image"], expected_image)
@@ -79,10 +79,10 @@ def test_grid_distortion_interpolation(interpolation):
     mask = np.random.randint(low=0, high=2, size=(100, 100), dtype=np.uint8)
     aug = A.GridDistortion(num_steps=1, distort_limit=(0.3, 0.3), interpolation=interpolation, p=1)
     data = aug(image=image, mask=mask)
-    expected_image = FGeometric.grid_distortion(
+    expected_image = fgeometric.grid_distortion(
         image, num_steps=1, xsteps=[1.3], ysteps=[1.3], interpolation=interpolation, border_mode=cv2.BORDER_REFLECT_101
     )
-    expected_mask = FGeometric.grid_distortion(
+    expected_mask = fgeometric.grid_distortion(
         mask,
         num_steps=1,
         xsteps=[1.3],
@@ -116,7 +116,7 @@ def test_elastic_transform_interpolation(monkeypatch, interpolation):
     aug = A.ElasticTransform(alpha=1, sigma=50, interpolation=interpolation, p=1)
 
     data = aug(image=image, mask=mask)
-    expected_image = FGeometric.elastic_transform(
+    expected_image = fgeometric.elastic_transform(
         image,
         alpha=1,
         sigma=50,
@@ -124,7 +124,7 @@ def test_elastic_transform_interpolation(monkeypatch, interpolation):
         border_mode=cv2.BORDER_REFLECT_101,
         random_state=np.random.RandomState(random_seed),
     )
-    expected_mask = FGeometric.elastic_transform(
+    expected_mask = fgeometric.elastic_transform(
         mask,
         alpha=1,
         sigma=50,
@@ -376,10 +376,10 @@ def test_lambda_transform():
         return new_mask
 
     def vflip_bbox(bbox, **kwargs):
-        return FGeometric.bbox_vflip(bbox, kwargs["shape"][0], kwargs["shape"][1])
+        return fgeometric.bbox_vflip(bbox, kwargs["shape"][0], kwargs["shape"][1])
 
     def vflip_keypoint(keypoint, **kwargs):
-        return FGeometric.keypoint_vflip(keypoint, kwargs["shape"][0], kwargs["shape"][1])
+        return fgeometric.keypoint_vflip(keypoint, kwargs["shape"][0], kwargs["shape"][1])
 
     aug = A.Lambda(
         image=negate_image, mask=partial(one_hot_mask, num_channels=16), bbox=vflip_bbox, keypoint=vflip_keypoint, p=1
@@ -393,8 +393,8 @@ def test_lambda_transform():
     )
     assert (output["image"] < 0).all()
     assert output["mask"].shape[2] == 16  # num_channels
-    assert output["bboxes"] == [FGeometric.bbox_vflip((10, 15, 25, 35), 10, 10)]
-    assert output["keypoints"] == [FGeometric.keypoint_vflip((20, 30, 40, 50), 10, 10)]
+    assert output["bboxes"] == [fgeometric.bbox_vflip((10, 15, 25, 35), 10, 10)]
+    assert output["keypoints"] == [fgeometric.keypoint_vflip((20, 30, 40, 50), 10, 10)]
 
 
 def test_channel_droput():
@@ -1981,11 +1981,11 @@ def test_rot90(bboxes, angle, keypoints):
 
     factor = angle2factor[angle]
 
-    image_rotated = FGeometric.rot90(image, factor)
-    mask_rotated = FGeometric.rot90(image, factor)
-    bboxes_rotated = [FGeometric.bbox_rot90(bbox, factor) for bbox in normalized_bboxes]
+    image_rotated = fgeometric.rot90(image, factor)
+    mask_rotated = fgeometric.rot90(image, factor)
+    bboxes_rotated = [fgeometric.bbox_rot90(bbox, factor) for bbox in normalized_bboxes]
     bboxes_rotated = denormalize_bboxes(bboxes_rotated, image_height, image_width)
-    keypoints_rotated = [FGeometric.keypoint_rot90(keypoint[:4], factor, image_height, image_width) for keypoint in keypoints]
+    keypoints_rotated = [fgeometric.keypoint_rot90(keypoint[:4], factor, image_height, image_width) for keypoint in keypoints]
 
     assert np.array_equal(transformed["image"], image_rotated)
     assert np.array_equal(transformed["mask"], mask_rotated)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1621,7 +1621,6 @@ def test_downscale_invalid_input(params):
     ({"position": "top_left"}, {"position": A.PadIfNeeded.PositionType.TOP_LEFT}),
     # Value handling when border_mode is BORDER_CONSTANT
     ({"border_mode": cv2.BORDER_CONSTANT, "value": 255}, {"border_mode": cv2.BORDER_CONSTANT, "value": 255}),
-    ({"border_mode": cv2.BORDER_REFLECT_101, "value": 255}, {"border_mode": cv2.BORDER_CONSTANT, "value": 255}),
     ({"border_mode": cv2.BORDER_CONSTANT, "value": [0, 0, 0]}, {"border_mode": cv2.BORDER_CONSTANT, "value": [0, 0, 0]}),
     # Mask value handling
     ({"border_mode": cv2.BORDER_CONSTANT, "value": [0, 0, 0], "mask_value": 128}, {"border_mode": cv2.BORDER_CONSTANT, "mask_value": 128, "value": [0, 0, 0]}),


### PR DESCRIPTION
Fixes  https://github.com/albumentations-team/albumentations/issues/804

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix keypoint reflection issue during padding by updating the logic to use image shape tuples. Refactor related functions for consistency and update tests to reflect these changes.

Bug Fixes:
- Fix keypoint reflection during padding by updating the logic to handle image shape correctly.

Enhancements:
- Refactor functions to use image shape tuples instead of separate row and column parameters for better consistency and readability.

Tests:
- Add tests for keypoint validation to ensure keypoints outside image boundaries are correctly removed.
- Update existing tests to reflect changes in function calls from FGeometric to fgeometric.

<!-- Generated by sourcery-ai[bot]: end summary -->