### PR TITLE
Fix in Affine fit_output

### DIFF
--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -848,6 +848,7 @@ class Affine(DualTransform):
 
         if self.fit_output:
             matrix, output_shape = self._compute_affine_warp_output_shape(matrix, params["shape"])
+            bbox_matrix, _ = self._compute_affine_warp_output_shape(bbox_matrix, params["shape"])
         else:
             output_shape = params["shape"]
 

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -795,56 +795,16 @@ class Affine(DualTransform):
     def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
         height, width = params["shape"][:2]
 
-        translate: dict[str, int | float]
-        if self.translate_px is not None:
-            translate = {key: random.randint(*value) for key, value in self.translate_px.items()}
-        elif self.translate_percent is not None:
-            translate = {key: random.uniform(*value) for key, value in self.translate_percent.items()}
-            translate["x"] = translate["x"] * width
-            translate["y"] = translate["y"] * height
-        else:
-            translate = {"x": 0, "y": 0}
-
-        shear = {key: -random.uniform(*value) for key, value in self.shear.items()}
-
+        translate = self._get_translate_params(width, height)
+        shear = self._get_shear_params()
         scale = self.get_scale(self.scale, self.keep_ratio, self.balanced_scale)
         rotate = -random.uniform(*self.rotate)
 
-        shift_x, shift_y = center(width, height)
-        shift_x_bbox, shift_y_bbox = center_bbox(width, height)
+        image_shift = center(width, height)
+        bbox_shift = center_bbox(width, height)
 
-        # Image transformation matrix
-        matrix_to_topleft = skimage.transform.SimilarityTransform(translation=[-shift_x, -shift_y])
-        matrix_shear_y_rot = skimage.transform.AffineTransform(rotation=-np.pi / 2)
-        matrix_shear_y = skimage.transform.AffineTransform(shear=np.deg2rad(shear["y"]))
-        matrix_shear_y_rot_inv = skimage.transform.AffineTransform(rotation=np.pi / 2)
-        matrix_transforms = skimage.transform.AffineTransform(
-            scale=(scale["x"], scale["y"]),
-            translation=(translate["x"], translate["y"]),
-            rotation=np.deg2rad(rotate),
-            shear=np.deg2rad(shear["x"]),
-        )
-        matrix_to_center = skimage.transform.SimilarityTransform(translation=[shift_x, shift_y])
-        matrix = (
-            matrix_to_topleft
-            + matrix_shear_y_rot
-            + matrix_shear_y
-            + matrix_shear_y_rot_inv
-            + matrix_transforms
-            + matrix_to_center
-        )
-
-        # Bounding box transformation matrix
-        matrix_to_topleft_bbox = skimage.transform.SimilarityTransform(translation=[-shift_x_bbox, -shift_y_bbox])
-        matrix_to_center_bbox = skimage.transform.SimilarityTransform(translation=[shift_x_bbox, shift_y_bbox])
-        bbox_matrix = (
-            matrix_to_topleft_bbox
-            + matrix_shear_y_rot
-            + matrix_shear_y
-            + matrix_shear_y_rot_inv
-            + matrix_transforms
-            + matrix_to_center_bbox
-        )
+        matrix = self._create_transformation_matrix(translate, shear, scale, rotate, image_shift)
+        bbox_matrix = self._create_transformation_matrix(translate, shear, scale, rotate, bbox_shift)
 
         if self.fit_output:
             matrix, output_shape = self._compute_affine_warp_output_shape(matrix, params["shape"])
@@ -859,6 +819,46 @@ class Affine(DualTransform):
             "bbox_matrix": bbox_matrix,
             "output_shape": output_shape,
         }
+
+    def _get_translate_params(self, width: int, height: int) -> dict[str, float]:
+        if self.translate_px is not None:
+            return {key: random.randint(*value) for key, value in self.translate_px.items()}
+        if self.translate_percent is not None:
+            translate = {key: random.uniform(*value) for key, value in self.translate_percent.items()}
+            return {"x": translate["x"] * width, "y": translate["y"] * height}
+        return {"x": 0, "y": 0}
+
+    def _get_shear_params(self) -> dict[str, float]:
+        return {key: -random.uniform(*value) for key, value in self.shear.items()}
+
+    @staticmethod
+    def _create_transformation_matrix(
+        translate: dict[str, float],
+        shear: dict[str, float],
+        scale: dict[str, float],
+        rotate: float,
+        shift: tuple[float, float],
+    ) -> skimage.transform.ProjectiveTransform:
+        matrix_to_topleft = skimage.transform.SimilarityTransform(translation=[-shift[0], -shift[1]])
+        matrix_shear_y_rot = skimage.transform.AffineTransform(rotation=-np.pi / 2)
+        matrix_shear_y = skimage.transform.AffineTransform(shear=np.deg2rad(shear["y"]))
+        matrix_shear_y_rot_inv = skimage.transform.AffineTransform(rotation=np.pi / 2)
+        matrix_transforms = skimage.transform.AffineTransform(
+            scale=(scale["x"], scale["y"]),
+            translation=(translate["x"], translate["y"]),
+            rotation=np.deg2rad(rotate),
+            shear=np.deg2rad(shear["x"]),
+        )
+        matrix_to_center = skimage.transform.SimilarityTransform(translation=shift)
+
+        return (
+            matrix_to_topleft
+            + matrix_shear_y_rot
+            + matrix_shear_y
+            + matrix_shear_y_rot_inv
+            + matrix_transforms
+            + matrix_to_center
+        )
 
     @staticmethod
     def _compute_affine_warp_output_shape(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ format.skip-magic-trailing-comma = false
 lint.select = [ "ALL" ]
 lint.ignore = [
   "ANN101",
+  "ANN102",
   "ANN204",
   "ANN401",
   "ARG001",

--- a/tests/functional/test_affine.py
+++ b/tests/functional/test_affine.py
@@ -306,26 +306,3 @@ def test_keypoint_affine(keypoint, expected, angle, scale, dx, dy):
 
     actual = fgeometric.keypoint_affine(keypoint, transform, {"x": keypoint[2], "y": keypoint[3]})
     np.testing.assert_allclose(actual[:2], expected[:2], rtol=1e-4)
-
-
-def test_affine_with_fit_output():
-    image = np.zeros((100, 100, 3), dtype=np.uint8)
-    bbox = [10, 10, 90, 90]  # [x_min, y_min, x_max, y_max]
-
-    transform = A.Affine(rotate=45, scale=1.5, fit_output=True, p=1.0)
-    transformed = transform(image=image, bboxes=[bbox])
-
-    assert transformed['image'].shape != image.shape
-    assert transformed['bboxes'][0] != bbox
-
-
-def test_affine_translation_with_fit_output():
-    image = np.zeros((100, 100, 3), dtype=np.uint8)
-    bbox = [25, 25, 75, 75]
-
-    transform = A.Affine(translate_percent={'x': 0.5, 'y': 0.5}, fit_output=True, p=1.0)
-    transformed = transform(image=image, bboxes=[bbox])
-
-    # Check if bbox has moved in the correct direction
-    t_bbox = transformed['bboxes'][0]
-    assert t_bbox[0] >= bbox[0] and t_bbox[1] >= bbox[1]

--- a/tests/functional/test_affine.py
+++ b/tests/functional/test_affine.py
@@ -306,3 +306,26 @@ def test_keypoint_affine(keypoint, expected, angle, scale, dx, dy):
 
     actual = fgeometric.keypoint_affine(keypoint, transform, {"x": keypoint[2], "y": keypoint[3]})
     np.testing.assert_allclose(actual[:2], expected[:2], rtol=1e-4)
+
+
+def test_affine_with_fit_output():
+    image = np.zeros((100, 100, 3), dtype=np.uint8)
+    bbox = [10, 10, 90, 90]  # [x_min, y_min, x_max, y_max]
+
+    transform = A.Affine(rotate=45, scale=1.5, fit_output=True, p=1.0)
+    transformed = transform(image=image, bboxes=[bbox])
+
+    assert transformed['image'].shape != image.shape
+    assert transformed['bboxes'][0] != bbox
+
+
+def test_affine_translation_with_fit_output():
+    image = np.zeros((100, 100, 3), dtype=np.uint8)
+    bbox = [25, 25, 75, 75]
+
+    transform = A.Affine(translate_percent={'x': 0.5, 'y': 0.5}, fit_output=True, p=1.0)
+    transformed = transform(image=image, bboxes=[bbox])
+
+    # Check if bbox has moved in the correct direction
+    t_bbox = transformed['bboxes'][0]
+    assert t_bbox[0] >= bbox[0] and t_bbox[1] >= bbox[1]


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/1876

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the Affine transformation to correctly adjust bounding boxes when fit_output is enabled and add corresponding tests to ensure the transformation behaves as expected.

Bug Fixes:
- Fix the handling of bounding boxes in the Affine transformation when the fit_output parameter is set to true.

Tests:
- Add tests to verify the correct behavior of the Affine transformation with fit_output enabled, including checks for image shape changes and bounding box adjustments.

<!-- Generated by sourcery-ai[bot]: end summary -->