### PR TITLE
Reflection padding works correctly for keypoints in Affine

### DIFF
--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -542,7 +542,39 @@ def keypoints_affine(
     scale: dict[str, Any],
     mode: int,
 ) -> np.ndarray:
+    """Apply an affine transformation to keypoints.
+
+    This function transforms keypoints using the given affine transformation matrix.
+    It handles reflection padding if necessary, updates coordinates, angles, and scales.
+
+    Args:
+        keypoints (np.ndarray): Array of keypoints with shape (N, 4+) where N is the number of keypoints.
+                                Each keypoint is represented as [x, y, angle, scale, ...].
+        matrix (skimage.transform.ProjectiveTransform): The affine transformation matrix.
+        image_shape (tuple[int, int]): Shape of the image (height, width).
+        scale (dict[str, Any]): Dictionary containing scale factors for x and y directions.
+                                Expected keys are 'x' and 'y'.
+        mode (int): Border mode for handling keypoints near image edges.
+                    Use cv2.BORDER_REFLECT_101, cv2.BORDER_REFLECT, etc.
+
+    Returns:
+        np.ndarray: Transformed keypoints array with the same shape as input.
+
+    Notes:
+        - The function applies reflection padding if the mode is in REFLECT_BORDER_MODES.
+        - Coordinates (x, y) are transformed using the affine matrix.
+        - Angles are adjusted based on the rotation component of the affine transformation.
+        - Scales are multiplied by the maximum of x and y scale factors.
+        - The @angle_2pi_range decorator ensures angles remain in the [0, 2π] range.
+
+    Example:
+        >>> keypoints = np.array([[100, 100, 0, 1]])
+        >>> matrix = skimage.transform.ProjectiveTransform(...)
+        >>> scale = {'x': 1.5, 'y': 1.2}
+        >>> transformed_keypoints = keypoints_affine(keypoints, matrix, (480, 640), scale, cv2.BORDER_REFLECT_101)
+    """
     keypoints = keypoints.copy().astype(np.float32)
+
     if is_identity_matrix(matrix):
         return keypoints
 

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -542,6 +542,7 @@ def keypoints_affine(
     scale: dict[str, Any],
     mode: int,
 ) -> np.ndarray:
+    keypoints = keypoints.copy().astype(np.float32)
     if is_identity_matrix(matrix):
         return keypoints
 
@@ -564,7 +565,8 @@ def keypoints_affine(
     keypoints[:, 2] = keypoints[:, 2] + angle_adjustment
 
     # Update scales
-    max_scale = np.max([scale["x"], scale["y"]])
+    max_scale = max(scale["x"], scale["y"])
+
     keypoints[:, 3] *= max_scale
 
     # Update x, y coordinates

--- a/albumentations/augmentations/utils.py
+++ b/albumentations/augmentations/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, TypeVar, cast, overload
 
 import cv2
 import numpy as np
@@ -13,11 +13,11 @@ from albucore.utils import (
 from typing_extensions import Concatenate, ParamSpec
 
 from albumentations.core.keypoints_utils import angle_to_2pi_range
+from albumentations.core.types import KeypointInternalType
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from albumentations.core.types import KeypointInternalType
 
 __all__ = [
     "read_bgr_image",
@@ -43,13 +43,36 @@ def read_grayscale(path: str | Path) -> np.ndarray:
     return cv2.imread(str(path), cv2.IMREAD_GRAYSCALE)
 
 
+T = TypeVar("T", KeypointInternalType, np.ndarray)
+
+
+@overload
 def angle_2pi_range(
     func: Callable[Concatenate[KeypointInternalType, P], KeypointInternalType],
-) -> Callable[Concatenate[KeypointInternalType, P], KeypointInternalType]:
+) -> Callable[Concatenate[KeypointInternalType, P], KeypointInternalType]: ...
+
+
+@overload
+def angle_2pi_range(
+    func: Callable[Concatenate[np.ndarray, P], np.ndarray],
+) -> Callable[Concatenate[np.ndarray, P], np.ndarray]: ...
+
+
+def angle_2pi_range(func: Callable[Concatenate[T, P], T]) -> Callable[Concatenate[T, P], T]:
     @wraps(func)
-    def wrapped_function(keypoint: KeypointInternalType, *args: P.args, **kwargs: P.kwargs) -> KeypointInternalType:
-        (x, y, a, s) = func(keypoint, *args, **kwargs)[:4]
-        return (x, y, angle_to_2pi_range(a), s)
+    def wrapped_function(keypoints: T, *args: P.args, **kwargs: P.kwargs) -> T:
+        result = func(keypoints, *args, **kwargs)
+
+        if isinstance(result, np.ndarray):
+            # Handle numpy array of shape (num_keypoints, 4+)
+            result[:, 2] = angle_to_2pi_range(result[:, 2])
+        else:
+            # Handle individual keypoint (tuple)
+            result_list = list(result)
+            result_list[2] = angle_to_2pi_range(result_list[2])
+            return cast(T, tuple(result_list))
+
+        return result
 
     return wrapped_function
 

--- a/albumentations/core/keypoints_utils.py
+++ b/albumentations/core/keypoints_utils.py
@@ -197,7 +197,7 @@ def convert_keypoint_to_albumentations(
 
     # if we do not truncate keypoints to integer values, they get into wrong positions after the rotation
     # https://github.com/albumentations-team/albumentations/issues/1819
-    keypoint = (int(x), int(y), angle_to_2pi_range(a), s, *tail)
+    keypoint = (x, y, angle_to_2pi_range(a), s, *tail)
     if check_validity:
         check_keypoint(keypoint, image_shape)
     return keypoint

--- a/albumentations/core/types.py
+++ b/albumentations/core/types.py
@@ -1,6 +1,7 @@
 from enum import Enum, IntEnum
 from typing import Any, List, Literal, Sequence, Tuple, TypeVar, Union
 
+import cv2
 import numpy as np
 from albucore.utils import MAX_VALUES_BY_DTYPE
 from typing_extensions import NotRequired, TypedDict
@@ -112,3 +113,10 @@ PxType = Union[
         Union[int, Tuple[int, int], List[int]],
     ],
 ]
+
+
+REFLECT_BORDER_MODES = {
+    cv2.BORDER_REFLECT101,
+    cv2.BORDER_REFLECT_101,
+    cv2.BORDER_REFLECT,
+}

--- a/tests/functional/test_affine.py
+++ b/tests/functional/test_affine.py
@@ -296,7 +296,7 @@ def test_inverse_shear(image_shape, translate, shape):
 
 @pytest.mark.parametrize(
     ["keypoint", "expected", "angle", "scale", "dx", "dy"],
-    [[[50, 50, 0, 5], [118, -40, math.pi / 2, 10], 90, 2, 0.1, 0.1]],
+    [[[50, 50, 0, 5], [118.5, -39.5, 3 * math.pi / 2, 10], 90, 2, 0.1, 0.1]],
 )
 def test_keypoint_affine(keypoint, expected, angle, scale, dx, dy):
     height, width = 100, 200
@@ -305,10 +305,12 @@ def test_keypoint_affine(keypoint, expected, angle, scale, dx, dy):
 
     transform = skimage.transform.ProjectiveTransform(matrix=centered_transform.params)
 
+    print(transform)
+
     keypoints = np.array([keypoint])
 
-    actual = fgeometric.keypoints_affine(keypoints, transform, (height, width), {"x": keypoint[2], "y": keypoint[3]}, cv2.BORDER_CONSTANT)
-    np.testing.assert_allclose(actual[0, :2], expected[:2], rtol=1e-4), f"Expected: {expected}, Actual: {actual}"
+    actual = fgeometric.keypoints_affine(keypoints, transform, (height, width), {"x": scale, "y": scale}, cv2.BORDER_CONSTANT)
+    np.testing.assert_allclose(actual[0], expected, rtol=1e-4), f"Expected: {expected}, Actual: {actual}"
 
 
 

--- a/tests/functional/test_affine.py
+++ b/tests/functional/test_affine.py
@@ -305,8 +305,6 @@ def test_keypoint_affine(keypoint, expected, angle, scale, dx, dy):
 
     transform = skimage.transform.ProjectiveTransform(matrix=centered_transform.params)
 
-    print(transform)
-
     keypoints = np.array([keypoint])
 
     actual = fgeometric.keypoints_affine(keypoints, transform, (height, width), {"x": scale, "y": scale}, cv2.BORDER_CONSTANT)

--- a/tests/functional/test_affine.py
+++ b/tests/functional/test_affine.py
@@ -305,8 +305,10 @@ def test_keypoint_affine(keypoint, expected, angle, scale, dx, dy):
 
     transform = skimage.transform.ProjectiveTransform(matrix=centered_transform.params)
 
-    actual = fgeometric.keypoint_affine(keypoint, transform, {"x": keypoint[2], "y": keypoint[3]})
-    np.testing.assert_allclose(actual[:2], expected[:2], rtol=1e-4)
+    keypoints = np.array([keypoint])
+
+    actual = fgeometric.keypoints_affine(keypoints, transform, (height, width), {"x": keypoint[2], "y": keypoint[3]}, cv2.BORDER_CONSTANT)
+    np.testing.assert_allclose(actual[0, :2], expected[:2], rtol=1e-4), f"Expected: {expected}, Actual: {actual}"
 
 
 
@@ -467,22 +469,20 @@ def test_center_remains_stationary(image_shape, transform_params):
 def test_calculate_affine_transform_padding(image_shape, transform_params, expected_padding):
     bbox_shift = center_bbox(image_shape)
 
-    print(transform_params, bbox_shift)
-
     transform = fgeometric.create_affine_transformation_matrix(**transform_params, shift=(bbox_shift[0], bbox_shift[1]))
 
     padding = fgeometric.calculate_affine_transform_padding(transform, image_shape)
 
     np.testing.assert_allclose(padding, expected_padding, atol=1)
 
-# def test_calculate_affine_transform_padding_properties():
-#     # Test that padding is always non-negative
-#     image_shape = (100, 100)
-#     transform = skimage.transform.AffineTransform(rotation=np.pi/3, scale=(1.5, 1.5), translation=(-50, -50))
-#     padding = fgeometric.calculate_affine_transform_padding(transform, image_shape)
-#     assert all(p >= 0 for p in padding), "Padding values should be non-negative"
+def test_calculate_affine_transform_padding_properties():
+    # Test that padding is always non-negative
+    image_shape = (100, 100)
+    transform = skimage.transform.AffineTransform(rotation=np.pi/3, scale=(1.5, 1.5), translation=(-50, -50))
+    padding = fgeometric.calculate_affine_transform_padding(transform, image_shape)
+    assert all(p >= 0 for p in padding), "Padding values should be non-negative"
 
-#     # Test that padding is zero for identity transformation
-#     identity_transform = skimage.transform.AffineTransform()
-#     identity_padding = fgeometric.calculate_affine_transform_padding(identity_transform, image_shape)
-#     assert identity_padding == (0, 0, 0, 0), "Identity transform should require no padding"
+    # Test that padding is zero for identity transformation
+    identity_transform = skimage.transform.AffineTransform()
+    identity_padding = fgeometric.calculate_affine_transform_padding(identity_transform, image_shape)
+    assert identity_padding == (0, 0, 0, 0), "Identity transform should require no padding"


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactor the affine transformation functions to support reflection padding for keypoints, improve handling of multiple keypoints, and enhance the angle_2pi_range decorator. Update tests to verify the new functionality and ensure correctness.

Enhancements:
- Refactor the keypoint affine transformation to handle multiple keypoints as a numpy array, improving efficiency and consistency.
- Introduce reflection padding for keypoints in affine transformations, ensuring correct handling of keypoints when using reflection border modes.
- Update the angle_2pi_range decorator to handle both individual keypoints and numpy arrays of keypoints, enhancing flexibility.
- Refactor the generate_reflected_keypoints and generate_reflected_bboxes functions to simplify the shifting logic and improve readability.

Tests:
- Add tests for the calculate_affine_transform_padding function to ensure padding values are non-negative and zero for identity transformations.
- Update existing tests to accommodate changes in the keypoints_affine function, ensuring correct transformation of keypoints.

<!-- Generated by sourcery-ai[bot]: end summary -->