### PR TITLE
Added extra test for affine

### DIFF
--- a/tests/functional/test_affine.py
+++ b/tests/functional/test_affine.py
@@ -497,9 +497,10 @@ def test_calculate_affine_transform_padding_properties():
     [
         (A.Affine, {"rotate": (90, 90)}),
         (A.Rotate, {"limit": (90, 90)}),
+        (A.RandomRotate90, {}),
     ]
 )
-def test_rotate_by_90_bboxes(transform_class, transform_params, format, bbox):
+def test_rotate_by_90_bboxes_symmetric_bbox(transform_class, transform_params, format, bbox):
 
     bbox_params = A.BboxParams(format=format, label_fields=['cl'])
 


### PR DESCRIPTION
Added tests to doublecheck for:

https://github.com/albumentations-team/albumentations/issues/748

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add new tests to verify the correctness of affine transformations on bounding boxes, specifically focusing on rotations by 90 degrees.

Tests:
- Add parameterized tests to verify the behavior of affine transformations on bounding boxes when rotated by 90 degrees.

<!-- Generated by sourcery-ai[bot]: end summary -->