### PR TITLE
Remove unnecessary call to random.random() in deterministic cases

### DIFF
--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -98,7 +98,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
 
             return kwargs
 
-        if force_apply or (random.random() < self.p):
+        if force_apply or self.p >= 1.0 or (random.random() < self.p):
             params = self.get_params()
             params = self.update_params_shape(params=params, data=kwargs)
 

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -93,17 +93,8 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
                 return self.apply_with_params(self.params, **kwargs)
 
             return kwargs
-        
-        if force_apply:
-            apply = True
-        elif self.p >= 1.0:
-            apply = True
-        elif self.p <= 0.0:
-            apply = False
-        else:
-            apply = random.random() < self.p
 
-        if apply:
+        if self.whether_to_apply(force_apply=force_apply):
             params = self.get_params()
             params = self.update_params_shape(params=params, data=kwargs)
 
@@ -127,6 +118,13 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
             return self.apply_with_params(params, **kwargs)
 
         return kwargs
+
+    def whether_to_apply(self, force_apply: bool = False) -> bool:
+        if self.p <= 0.0:
+            return False
+        if self.p >= 1.0 or force_apply:
+            return True
+        return random.random() < self.p
 
     def apply_with_params(self, params: dict[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Apply transforms with parameters."""

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -94,7 +94,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
 
             return kwargs
 
-        if self.whether_to_apply(force_apply=force_apply):
+        if self.should_apply(force_apply=force_apply):
             params = self.get_params()
             params = self.update_params_shape(params=params, data=kwargs)
 
@@ -119,7 +119,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
 
         return kwargs
 
-    def whether_to_apply(self, force_apply: bool = False) -> bool:
+    def should_apply(self, force_apply: bool = False) -> bool:
         if self.p <= 0.0:
             return False
         if self.p >= 1.0 or force_apply:

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -97,8 +97,17 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
                 return self.apply_with_params(self.params, **kwargs)
 
             return kwargs
+        
+        if force_apply:
+            apply = True
+        elif self.p >= 1.0:
+            apply = True
+        elif self.p <= 0.0:
+            apply = False
+        else:
+            apply = random.random() < self.p
 
-        if force_apply or self.p >= 1.0 or (random.random() < self.p):
+        if apply:
             params = self.get_params()
             params = self.update_params_shape(params=params, data=kwargs)
 

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -1008,7 +1008,7 @@ def test_pad_if_needed_position(params, image_shape):
         assert (image_padded == true_result).all()
 
     elif params["position"] == "random":
-        true_result[0:5, -7:-1] = 0
+        true_result[5:, 0:6] = 0
         assert (image_padded == true_result).all()
 
 


### PR DESCRIPTION
Since `p` is a probability, we should not need to "roll the dice" if p = 1.
This would be beneficial to enforce the reproducibility aspect.
A compelling example is:
- We have a **stochastic** pipeline of augmentations for the training samples.
- We have a **deterministic** pipeline of augmentations for the validation samples.
- Two training runs w/ identical training data would **diverge** w.r.t. their stochastic augmentations on the training data in the event where the number of validation samples would not be different.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Optimize the transformation application logic by introducing a method to handle deterministic cases, avoiding unnecessary randomness when the probability is 1 or 0, and update related tests accordingly.

Enhancements:
- Introduce a new method `whether_to_apply` to determine if a transformation should be applied, optimizing for deterministic cases by avoiding unnecessary calls to `random.random()`.

Tests:
- Update test case in `test_pad_if_needed_position` to reflect changes in augmentation logic.

<!-- Generated by sourcery-ai[bot]: end summary -->