### PR TITLE
Now works for empty bboxes and keypoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       types: [python]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.2
+    rev: v0.6.3
     hooks:
       # Run the linter.
       - id: ruff

--- a/albumentations/augmentations/crops/functional.py
+++ b/albumentations/augmentations/crops/functional.py
@@ -7,6 +7,7 @@ import numpy as np
 from albucore.utils import maybe_process_in_chunks, preserve_channel_dim
 
 from albumentations.augmentations.geometric import functional as fgeometric
+from albumentations.augmentations.utils import handle_empty_array
 from albumentations.core.bbox_utils import denormalize_bboxes, normalize_bboxes
 from albumentations.core.types import ColorType
 
@@ -88,6 +89,7 @@ def crop_bboxes_by_coords(
     return normalize_bboxes(cropped_bboxes, crop_shape)
 
 
+@handle_empty_array
 def crop_keypoints_by_coords(
     keypoints: np.ndarray,
     crop_coords: tuple[int, int, int, int],
@@ -101,9 +103,6 @@ def crop_keypoints_by_coords(
     Returns:
         np.ndarray: An array of cropped keypoints with the same shape as the input.
     """
-    if len(keypoints) == 0:
-        return keypoints
-
     x1, y1 = crop_coords[:2]
 
     cropped_keypoints = keypoints.copy()
@@ -203,6 +202,7 @@ def crop_and_pad_bboxes(
     return normalize_bboxes(denormalized_bboxes, result_shape)
 
 
+@handle_empty_array
 def crop_and_pad_keypoints(
     keypoints: np.ndarray,
     crop_params: tuple[int, int, int, int] | None = None,
@@ -224,9 +224,6 @@ def crop_and_pad_keypoints(
     Returns:
         np.ndarray: Array of transformed keypoints with the same shape as input.
     """
-    if len(keypoints) == 0:
-        return keypoints
-
     transformed_keypoints = keypoints.copy()
 
     if crop_params is not None:

--- a/albumentations/augmentations/crops/functional.py
+++ b/albumentations/augmentations/crops/functional.py
@@ -101,6 +101,9 @@ def crop_keypoints_by_coords(
     Returns:
         np.ndarray: An array of cropped keypoints with the same shape as the input.
     """
+    if len(keypoints) == 0:
+        return keypoints
+
     x1, y1 = crop_coords[:2]
 
     cropped_keypoints = keypoints.copy()
@@ -221,6 +224,9 @@ def crop_and_pad_keypoints(
     Returns:
         np.ndarray: Array of transformed keypoints with the same shape as input.
     """
+    if len(keypoints) == 0:
+        return keypoints
+
     transformed_keypoints = keypoints.copy()
 
     if crop_params is not None:

--- a/albumentations/augmentations/dropout/functional.py
+++ b/albumentations/augmentations/dropout/functional.py
@@ -5,6 +5,7 @@ from albucore.utils import MAX_VALUES_BY_DTYPE, is_grayscale_image, preserve_cha
 from typing_extensions import Literal
 
 from albumentations import random_utils
+from albumentations.augmentations.utils import handle_empty_array
 from albumentations.core.types import MONO_CHANNEL_DIMENSIONS, ColorType
 
 __all__ = ["cutout", "channel_dropout", "filter_keypoints_in_holes", "generate_random_fill"]
@@ -74,6 +75,7 @@ def cutout(
     return img
 
 
+@handle_empty_array
 def filter_keypoints_in_holes(keypoints: np.ndarray, holes: np.ndarray) -> np.ndarray:
     """Filter out keypoints that are inside any of the holes.
 

--- a/albumentations/augmentations/dropout/functional.py
+++ b/albumentations/augmentations/dropout/functional.py
@@ -26,13 +26,42 @@ def channel_dropout(
     return img
 
 
-def generate_random_fill(dtype: np.dtype, shape: tuple[int, ...]) -> np.ndarray:
-    """Generate a random fill based on dtype and target shape."""
+def generate_random_fill(
+    dtype: np.dtype,
+    shape: tuple[int, ...],
+    random_state: np.random.RandomState | None,
+) -> np.ndarray:
+    """Generate a random fill array based on the given dtype and target shape.
+
+    This function creates a numpy array filled with random values. The range and type of these values
+    depend on the input dtype. For integer dtypes, it generates random integers. For floating-point
+    dtypes, it generates random floats.
+
+    Args:
+        dtype (np.dtype): The data type of the array to be generated.
+        shape (tuple[int, ...]): The shape of the array to be generated.
+        random_state (np.random.RandomState | None): The random state to use for generating values.
+            If None, the default numpy random state is used.
+
+    Returns:
+        np.ndarray: A numpy array of the specified shape and dtype, filled with random values.
+
+    Raises:
+        ValueError: If the input dtype is neither integer nor floating-point.
+
+    Examples:
+        >>> import numpy as np
+        >>> random_state = np.random.RandomState(42)
+        >>> result = generate_random_fill(np.dtype('uint8'), (2, 2), random_state)
+        >>> print(result)
+        [[172 251]
+         [ 80 141]]
+    """
     max_value = MAX_VALUES_BY_DTYPE[dtype]
     if np.issubdtype(dtype, np.integer):
-        return random_utils.randint(0, max_value + 1, size=shape, dtype=dtype)
+        return random_utils.randint(0, max_value + 1, size=shape, dtype=dtype, random_state=random_state)
     if np.issubdtype(dtype, np.floating):
-        return random_utils.uniform(0, max_value, size=shape).astype(dtype)
+        return random_utils.uniform(0, max_value, size=shape, random_state=random_state).astype(dtype)
     raise ValueError(f"Unsupported dtype: {dtype}")
 
 
@@ -40,20 +69,39 @@ def cutout(
     img: np.ndarray,
     holes: np.ndarray,
     fill_value: ColorType | Literal["random"] = 0,
+    random_state: np.random.RandomState | None = None,
 ) -> np.ndarray:
     """Apply cutout augmentation to the image by cutting out holes and filling them
     with either a given value or random noise.
 
     Args:
-        img (np.ndarray): The image to augment.
+        img (np.ndarray): The image to augment. Can be a 2D (grayscale) or 3D (color) array.
         holes (np.ndarray): An array of holes with shape (num_holes, 4).
             Each hole is represented as [x1, y1, x2, y2].
-        fill_value (Union[ColorType, Literal["random"]]): The fill value to use for the hole. Can be
-            a single integer, a tuple or list of numbers for multichannel,
-            or the string "random" to fill with random noise.
+        fill_value (Union[ColorType, Literal["random"]], optional): The fill value to use for the holes.
+            Can be a single integer, a tuple or list of numbers for multichannel images,
+            or the string "random" to fill with random noise. Defaults to 0.
+        random_state (np.random.RandomState | None, optional): The random state to use for generating
+            random fill values. If None, a new random state will be used. Defaults to None.
 
     Returns:
-        np.ndarray: The augmented image.
+        np.ndarray: The augmented image with cutout holes applied.
+
+    Raises:
+        ValueError: If the fill_value is not of the expected type.
+
+    Note:
+        - The function creates a copy of the input image before applying the cutout.
+        - For multichannel images, the fill_value should match the number of channels.
+        - When using "random" fill, the random values are generated to match the image's dtype and shape.
+
+    Example:
+        >>> import numpy as np
+        >>> img = np.ones((100, 100, 3), dtype=np.uint8) * 255
+        >>> holes = np.array([[20, 20, 40, 40], [60, 60, 80, 80]])
+        >>> result = cutout(img, holes, fill_value=0)
+        >>> print(result.shape)
+        (100, 100, 3)
     """
     img = img.copy()
 
@@ -67,7 +115,7 @@ def cutout(
                 if img.ndim == MONO_CHANNEL_DIMENSIONS
                 else (y_max - y_min, x_max - x_min, img.shape[2])
             )
-            random_fill = generate_random_fill(img.dtype, shape)
+            random_fill = generate_random_fill(img.dtype, shape, random_state)
             img[y_min:y_max, x_min:x_max] = random_fill
         else:
             img[y_min:y_max, x_min:x_max] = fill_value

--- a/albumentations/augmentations/dropout/xy_masking.py
+++ b/albumentations/augmentations/dropout/xy_masking.py
@@ -197,6 +197,8 @@ class XYMasking(DualTransform):
         masks_y: list[tuple[int, int, int, int]],
         **params: Any,
     ) -> np.ndarray:
+        if len(keypoints) == 0:
+            return keypoints
         return filter_keypoints_in_holes(keypoints, np.array(masks_x + masks_y))
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:

--- a/albumentations/augmentations/dropout/xy_masking.py
+++ b/albumentations/augmentations/dropout/xy_masking.py
@@ -197,8 +197,6 @@ class XYMasking(DualTransform):
         masks_y: list[tuple[int, int, int, int]],
         **params: Any,
     ) -> np.ndarray:
-        if len(keypoints) == 0:
-            return keypoints
         return filter_keypoints_in_holes(keypoints, np.array(masks_x + masks_y))
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -84,6 +84,9 @@ def bboxes_rot90(bboxes: np.ndarray, factor: int) -> np.ndarray:
     if factor not in {0, 1, 2, 3}:
         raise ValueError("Parameter factor must be in set {0, 1, 2, 3}")
 
+    if len(bboxes) == 0:
+        return bboxes
+
     if factor == 0:
         return bboxes
 
@@ -136,6 +139,9 @@ def bboxes_d4(
       `bbox_d4((10, 20, 110, 120), 'r90')`
       This would rotate the bounding box 90 degrees within a 100x100 image.
     """
+    if len(bboxes) == 0:
+        return bboxes
+
     transformations = {
         "e": lambda x: x,  # Identity transformation
         "r90": lambda x: bboxes_rot90(x, 1),  # Rotate 90 degrees
@@ -177,6 +183,9 @@ def keypoints_rot90(
         raise ValueError("Parameter factor must be in set {0, 1, 2, 3}")
 
     if factor == 0:
+        return keypoints
+
+    if len(keypoints) == 0:
         return keypoints
 
     height, width = image_shape[:2]
@@ -230,6 +239,9 @@ def keypoints_d4(
       `keypoint_d4((50, 30), 'r90', 100, 100)`
       This would move the keypoint from (50, 30) to (70, 50) assuming standard coordinate transformations.
     """
+    if len(keypoints) == 0:
+        return keypoints
+
     rows, cols = image_shape[:2]
     transformations = {
         "e": lambda x: x,  # Identity transformation
@@ -295,6 +307,9 @@ def bboxes_rotate(
     Reference:
         https://arxiv.org/abs/2109.13488
     """
+    if len(bboxes) == 0:
+        return bboxes
+
     bboxes = bboxes.copy()
     rows, cols = image_shape[:2]
     x_min, y_min, x_max, y_max = bboxes[:, 0], bboxes[:, 1], bboxes[:, 2], bboxes[:, 3]
@@ -347,6 +362,9 @@ def keypoints_rotate(
     Note:
         The rotation is performed around the center of the image.
     """
+    if len(keypoints) == 0:
+        return keypoints
+
     image_center = center(image_shape)
     matrix = cv2.getRotationMatrix2D(image_center, angle, 1.0)
 
@@ -396,6 +414,9 @@ def keypoints_scale(keypoints: np.ndarray, scale_x: float, scale_y: float) -> np
     Returns:
         A numpy array of scaled keypoints with the same shape as input.
     """
+    if len(keypoints) == 0:
+        return keypoints
+
     # Extract x, y, angle, and scale
     x, y, angle, scale = keypoints[:, 0], keypoints[:, 1], keypoints[:, 2], keypoints[:, 3]
 
@@ -506,6 +527,9 @@ def perspective_bboxes(
         >>> matrix = np.array([[1.5, 0.2, -20], [-0.1, 1.3, -10], [0.002, 0.001, 1]])
         >>> transformed_bboxes = perspective_bboxes(bboxes, image_shape, matrix, 150, 150, False)
     """
+    if len(bboxes) == 0:
+        return bboxes
+
     height, width = image_shape[:2]
 
     # Create a copy of the input bboxes to avoid modifying the original array
@@ -565,6 +589,9 @@ def perspective_keypoints(
     max_height: int,
     keep_size: bool,
 ) -> np.ndarray:
+    if len(keypoints) == 0:
+        return keypoints
+
     keypoints = keypoints.copy().astype(np.float32)
     x, y, angle, scale = keypoints[:, 0], keypoints[:, 1], keypoints[:, 2], keypoints[:, 3]
 
@@ -695,6 +722,9 @@ def keypoints_affine(
         >>> scale = {'x': 1.5, 'y': 1.2}
         >>> transformed_keypoints = keypoints_affine(keypoints, matrix, (480, 640), scale, cv2.BORDER_REFLECT_101)
     """
+    if len(keypoints) == 0:
+        return keypoints
+
     keypoints = keypoints.copy().astype(np.float32)
 
     if is_identity_matrix(matrix):
@@ -803,6 +833,9 @@ def bboxes_affine_largest_box(bboxes: np.ndarray, matrix: skimage.transform.Proj
         [[ 25.  25.  45.  45.   1.]
          [ 65.  65.  85.  85.   2.]]
     """
+    if len(bboxes) == 0:
+        return bboxes
+
     # Extract corners of all bboxes
     x_min, y_min, x_max, y_max = bboxes[:, 0], bboxes[:, 1], bboxes[:, 2], bboxes[:, 3]
     corners = np.array([[x_min, y_min], [x_max, y_min], [x_max, y_max], [x_min, y_max]]).transpose(
@@ -859,6 +892,9 @@ def bboxes_affine_ellipse(bboxes: np.ndarray, matrix: skimage.transform.Projecti
         [[ 5.86  5.86 34.14 24.14  1.  ]
          [30.   30.   70.   70.    2.  ]]
     """
+    if len(bboxes) == 0:
+        return bboxes
+
     x_min, y_min, x_max, y_max = bboxes[:, 0], bboxes[:, 1], bboxes[:, 2], bboxes[:, 3]
     bbox_width = (x_max - x_min) / 2
     bbox_height = (y_max - y_min) / 2
@@ -917,6 +953,9 @@ def bboxes_affine(
     Returns:
         np.ndarray: Transformed and normalized bounding boxes
     """
+    if len(bboxes) == 0:
+        return bboxes
+
     if is_identity_matrix(matrix):
         return bboxes
 
@@ -1143,6 +1182,9 @@ def keypoints_piecewise_affine(
     if matrix is None:
         return keypoints
 
+    if len(keypoints) == 0:
+        return keypoints
+
     a, s = keypoints[:, 2], keypoints[:, 3]
 
     # Create distance maps for all keypoints
@@ -1172,6 +1214,9 @@ def bboxes_piecewise_affine(
     image_shape: tuple[int, int],
     keypoints_threshold: float,
 ) -> np.ndarray:
+    if len(bboxes) == 0:
+        return bboxes
+
     if matrix is None:
         return bboxes
 
@@ -1325,7 +1370,7 @@ def bboxes_vflip(bboxes: np.ndarray) -> np.ndarray:
     Returns:
         np.ndarray: A numpy array of vertically flipped bounding boxes with the same shape as input.
     """
-    if bboxes.size == 0:
+    if len(bboxes) == 0:
         return bboxes
 
     flipped_bboxes = bboxes.copy()
@@ -1345,7 +1390,7 @@ def bboxes_hflip(bboxes: np.ndarray) -> np.ndarray:
     Returns:
         np.ndarray: A numpy array of horizontally flipped bounding boxes with the same shape as input.
     """
-    if bboxes.size == 0:
+    if len(bboxes) == 0:
         return bboxes
 
     flipped_bboxes = bboxes.copy()
@@ -1370,6 +1415,9 @@ def bboxes_flip(bboxes: np.ndarray, d: int) -> np.ndarray:
         ValueError: if value of `d` is not -1, 0 or 1.
 
     """
+    if len(bboxes) == 0:
+        return bboxes
+
     if d == 0:
         return bboxes_vflip(bboxes)
     if d == 1:
@@ -1391,6 +1439,9 @@ def bboxes_transpose(bboxes: np.ndarray) -> np.ndarray:
     Returns:
         np.ndarray: A numpy array of transposed bounding boxes with the same shape as input.
     """
+    if len(bboxes) == 0:
+        return bboxes
+
     transposed_bboxes = bboxes.copy()
     transposed_bboxes[:, [0, 1, 2, 3]] = bboxes[:, [1, 0, 3, 2]]
 
@@ -1408,6 +1459,9 @@ def keypoints_vflip(keypoints: np.ndarray, rows: int) -> np.ndarray:
     Returns:
         np.ndarray: An array of flipped keypoints with the same shape as the input.
     """
+    if len(keypoints) == 0:
+        return keypoints
+
     flipped_keypoints = keypoints.copy().astype(np.float32)
 
     # Flip y-coordinates
@@ -1430,6 +1484,9 @@ def keypoints_hflip(keypoints: np.ndarray, cols: int) -> np.ndarray:
     Returns:
         np.ndarray: An array of flipped keypoints with the same shape as the input.
     """
+    if len(keypoints) == 0:
+        return keypoints
+
     flipped_keypoints = keypoints.copy().astype(np.float32)
 
     # Flip x-coordinates
@@ -1460,6 +1517,9 @@ def keypoints_flip(keypoints: np.ndarray, d: int, image_shape: tuple[int, int]) 
         ValueError: if value of `d` is not -1, 0 or 1.
 
     """
+    if len(keypoints) == 0:
+        return keypoints
+
     rows, cols = image_shape[:2]
 
     if d == 0:
@@ -1483,6 +1543,9 @@ def keypoints_transpose(keypoints: np.ndarray) -> np.ndarray:
     Returns:
         np.ndarray: An array of transposed keypoints with the same shape as the input.
     """
+    if len(keypoints) == 0:
+        return keypoints
+
     transposed_keypoints = keypoints.copy()
 
     # Swap x and y coordinates
@@ -1819,6 +1882,9 @@ def pad_bboxes(
     border_mode: int,
     image_shape: tuple[int, int],
 ) -> np.ndarray:
+    if len(bboxes) == 0:
+        return bboxes
+
     if border_mode not in REFLECT_BORDER_MODES:
         shift_vector = np.array([pad_left, pad_top, pad_left, pad_top])
         return shift_bboxes(bboxes, shift_vector)
@@ -2231,6 +2297,9 @@ def pad_keypoints(
     border_mode: int,
     image_shape: tuple[int, int],
 ) -> np.ndarray:
+    if len(keypoints) == 0:
+        return keypoints
+
     if border_mode not in {cv2.BORDER_REFLECT_101, cv2.BORDER_REFLECT101}:
         shift_vector = np.array([pad_left, pad_top])  # Only shift x and y
         return shift_keypoints(keypoints, shift_vector)
@@ -2362,6 +2431,9 @@ def flip_keypoints(
     flip_vertical: bool = False,
     image_shape: tuple[int, int] = (0, 0),
 ) -> np.ndarray:
+    if len(keypoints) == 0:
+        return keypoints
+
     rows, cols = image_shape[:2]
     flipped_keypoints = keypoints.copy()
     if flip_horizontal:
@@ -2517,6 +2589,9 @@ def bboxes_optical_distortion(
     border_mode: int,
     image_shape: tuple[int, int],
 ) -> np.ndarray:
+    if len(bboxes) == 0:
+        return bboxes
+
     height, width = image_shape[:2]
 
     # Denormalize bboxes
@@ -2555,6 +2630,9 @@ def bbox_elastic_transform(
     random_seed: int,
     image_shape: tuple[int, int],
 ) -> np.ndarray:
+    if len(bboxes) == 0:
+        return bboxes
+
     bboxes = bboxes.copy()
     bboxes_denorm = denormalize_bboxes(bboxes, image_shape)
     # Create a mask for each bbox
@@ -2588,6 +2666,9 @@ def bboxes_grid_distortion(
     border_mode: int,
     image_shape: tuple[int, int],
 ) -> np.ndarray:
+    if len(bboxes) == 0:
+        return bboxes
+
     bboxes_denorm = denormalize_bboxes(bboxes, image_shape)
 
     # Create a mask for each bbox

--- a/albumentations/augmentations/utils.py
+++ b/albumentations/augmentations/utils.py
@@ -28,6 +28,8 @@ __all__ = [
 
 P = ParamSpec("P")
 
+TWO = 2
+
 
 def read_bgr_image(path: str | Path) -> np.ndarray:
     return cv2.imread(str(path), cv2.IMREAD_COLOR)
@@ -48,7 +50,8 @@ def angle_2pi_range(
     @wraps(func)
     def wrapped_function(keypoints: np.ndarray, *args: P.args, **kwargs: P.kwargs) -> np.ndarray:
         result = func(keypoints, *args, **kwargs)
-        result[:, 2] = angle_to_2pi_range(result[:, 2])
+        if len(result) > 0 and result.shape[1] > TWO:
+            result[:, 2] = angle_to_2pi_range(result[:, 2])
         return result
 
     return wrapped_function

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest>=8.3.2
 pytest_cov>=5.0.0
 pytest_mock>=3.14.0
 requests>=2.31.0
-ruff>=0.6.2
+ruff>=0.6.3
 tomli>=2.0.1
 types-PyYAML
 types-setuptools

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ INSTALL_REQUIRES = [
     "numpy>=1.24.4", "scipy>=1.10.0", "scikit-image>=0.21.0",
     "PyYAML", "typing-extensions>=4.9.0",
     "pydantic>=2.7.0",
-    "albucore>=0.0.13",
+    "albucore>=0.0.14",
     "eval-type-backport"
 ]
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -784,7 +784,8 @@ def test_contiguous_output_dual(augmentation_cls, params):
             A.RandomSizedBBoxSafeCrop,
             A.CropNonEmptyMaskIfExists,
             A.OverlayElements,
-            A.TextImage
+            A.TextImage,
+            A.FromFloat,
         },
     ),
 )

--- a/tests/test_functional_cutout.py
+++ b/tests/test_functional_cutout.py
@@ -45,8 +45,6 @@ def test_cutout_with_various_fill_values(img, fill_value):
 
 @pytest.mark.parametrize("dtype, max_value", [
     (np.uint8, MAX_VALUES_BY_DTYPE[np.uint8]),
-    (np.uint16, MAX_VALUES_BY_DTYPE[np.uint16]),
-    (np.uint32, MAX_VALUES_BY_DTYPE[np.uint32]),
     (np.float32, MAX_VALUES_BY_DTYPE[np.float32]),
 ])
 @pytest.mark.parametrize("shape", [

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1146,7 +1146,7 @@ def test_safe_rotate(angle: float, targets: dict, expected: dict):
     res = t(image=image, **targets)
 
     for key, value in expected.items():
-        np.testing.assert_allclose(value, res[key]), key
+        np.testing.assert_almost_equal(value, res[key]), key
 
 
 @pytest.mark.parametrize(

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1146,7 +1146,7 @@ def test_safe_rotate(angle: float, targets: dict, expected: dict):
     res = t(image=image, **targets)
 
     for key, value in expected.items():
-        np.testing.assert_almost_equal(value, res[key]), key
+        np.testing.assert_allclose(value, res[key], atol=1e-6, rtol=1e-6), key
 
 
 @pytest.mark.parametrize(

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -2089,3 +2089,54 @@ def test_padding_color(transform, num_channels):
     for channel_id, channel in enumerate(channels):
         unique_values = np.unique(channel)
         assert set(unique_values) == {0, 128}, f"{channel_id}"
+
+
+
+@pytest.mark.parametrize(
+    ["augmentation_cls", "params"],
+    get_dual_transforms(
+        custom_arguments={
+            A.Crop: {"y_min": 0, "y_max": 10, "x_min": 0, "x_max": 10},
+            A.CenterCrop: {"height": 10, "width": 10},
+            A.CropNonEmptyMaskIfExists: {"height": 10, "width": 10},
+            A.RandomCrop: {"height": 10, "width": 10},
+            A.RandomResizedCrop: {"height": 10, "width": 10},
+            A.RandomSizedCrop: {"min_max_height": (4, 8), "height": 10, "width": 10},
+            A.CropAndPad: {"px": 10},
+            A.Resize: {"height": 10, "width": 10},
+            A.PixelDropout: {"dropout_prob": 0.5, "mask_drop_value": 10, "drop_value": 20},
+            A.XYMasking: {
+                "num_masks_x": (1, 3),
+                "num_masks_y": (1, 3),
+                "mask_x_length": 10,
+                "mask_y_length": 10,
+                "mask_fill_value": 1,
+                "fill_value": 0,
+            },
+            A.D4: {},
+            A.GridElasticDeform: {"num_grid_xy": (10, 10), "magnitude": 10},
+        },
+        except_augmentations={A.RandomCropNearBBox, A.RandomSizedBBoxSafeCrop, A.BBoxSafeRandomCrop,
+                              A.MixUp, A.MaskDropout, A.OverlayElements, A.GridElasticDeform, A.CropNonEmptyMaskIfExists},
+    ),
+)
+def test_empty_bboxes_keypoints(augmentation_cls, params):
+    aug = A.Compose([augmentation_cls(p=1, **params)], bbox_params=A.BboxParams(format="pascal_voc", label_fields=["labels"]), keypoint_params=A.KeypointParams(format="xyas"))
+    image = SQUARE_UINT8_IMAGE
+    data = {
+        "image": image,
+        "bboxes": [],
+        "labels": [],
+        "keypoints": [],
+    }
+
+    if augmentation_cls == A.OverlayElements:
+        data = {
+            "image": image,
+            "overlay_metadata": []
+        }
+
+    data = aug(**data)
+
+    np.testing.assert_array_equal(data["bboxes"], np.array([]))
+    np.testing.assert_array_equal(data["keypoints"], np.array([]))


### PR DESCRIPTION
Fixes https://github.com/albumentations-team/albumentations/issues/1910

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix handling of empty bounding boxes and keypoints in geometric transformations by adding early return checks. Add corresponding tests to ensure robustness and update dependencies and pre-commit configuration.

Bug Fixes:
- Ensure functions handling bounding boxes and keypoints return early when provided with empty inputs, preventing errors and improving robustness.

Tests:
- Add tests to verify the correct handling of empty bounding boxes and keypoints across various transformations, ensuring no errors occur and outputs are as expected.

Chores:
- Update the pre-commit configuration to use Ruff version v0.6.3.
- Update the dependency version of albucore to 0.0.14 in setup.py.

<!-- Generated by sourcery-ai[bot]: end summary -->