### PR TITLE
Extent fancy pca to multichannel and float32

### DIFF
--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -489,7 +489,7 @@ class AdvancedBlur(ImageOnlyTransform):
         always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p, always_apply)
+        super().__init__(p=p, always_apply=always_apply)
 
         if sigmaX_limit is not None:
             warnings.warn("sigmaX_limit is deprecated; use sigma_x_limit instead.", DeprecationWarning, stacklevel=2)

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -1241,67 +1241,71 @@ def mask_from_bbox(img: np.ndarray, bbox: tuple[int, int, int, int]) -> np.ndarr
 
 
 @clipped
-def fancy_pca(img: np.ndarray, alpha: float = 0.1) -> np.ndarray:
-    """Perform 'Fancy PCA' augmentation
+@preserve_channel_dim
+def fancy_pca(img: np.ndarray, alpha_vector: np.ndarray) -> np.ndarray:
+    """Perform 'Fancy PCA' augmentation on an image with any number of channels.
 
     Args:
-        img: numpy array with (h, w, rgb) shape, as ints between 0-255
-        alpha: how much to perturb/scale the eigen vectors and values
-                the paper used std=0.1
+        img (np.ndarray): Input image of shape (height, width, channels) or (height, width).
+                          Can be uint8 ([0, 255] range) or float32 ([0, 1] range).
+        alpha_vector (np.ndarray): Vector of scale factors for each principal component.
+                                   Should have the same length as the number of channels in the image.
 
     Returns:
-        numpy image-like array as uint8 range(0, 255)
+        np.ndarray: Augmented image of the same shape, type, and range as the input.
+
+    Note:
+        - This function generalizes the Fancy PCA augmentation to work with any number of channels.
+        - It preserves the original range of the image ([0, 255] for uint8, [0, 1] for float32).
+        - For single-channel images, the augmentation is applied directly.
+        - For multi-channel images, PCA is performed on the entire image, treating each pixel
+          as a point in N-dimensional space (where N is the number of channels).
+        - The augmentation preserves the correlation between channels while adding controlled noise.
+        - Computation time may increase significantly for images with a large number of channels.
 
     Reference:
-        http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf
+        Krizhevsky, A., Sutskever, I., & Hinton, G. E. (2012).
+        ImageNet classification with deep convolutional neural networks.
+        In Advances in neural information processing systems (pp. 1097-1105).
     """
-    if not is_rgb_image(img) or img.dtype != np.uint8:
-        msg = "Image must be RGB image in uint8 format."
-        raise TypeError(msg)
+    orig_shape = img.shape
+    num_channels = get_num_channels(img)
 
-    orig_img = img.astype(float).copy()
+    # Convert to float32 and scale to [0, 1] if necessary
+    if img.dtype == np.uint8:
+        img = to_float(img)
 
-    img = to_float(img)  # rescale to 0 to 1 range
+    # Reshape image to 2D array of pixels
+    img_reshaped = img.reshape(-1, num_channels)
 
-    # flatten image to columns of RGB
-    img_rs = img.reshape(-1, 3)
-    # img_rs shape (640000, 3)
+    # Center the pixel values
+    img_mean = np.mean(img_reshaped, axis=0)
+    img_centered = img_reshaped - img_mean
 
-    # center mean
-    img_centered = img_rs - np.mean(img_rs, axis=0)
-
-    # paper says 3x3 covariance matrix
+    # Compute covariance matrix
     img_cov = np.cov(img_centered, rowvar=False)
 
-    # eigen values and eigen vectors
+    # Compute eigenvectors & eigenvalues of the covariance matrix
     eig_vals, eig_vecs = np.linalg.eigh(img_cov)
 
-    # sort values and vector
+    # Sort eigenvectors by eigenvalues in descending order
     sort_perm = eig_vals[::-1].argsort()
-    eig_vals[::-1].sort()
+    eig_vals = eig_vals[sort_perm]
     eig_vecs = eig_vecs[:, sort_perm]
 
-    # > get [p1, p2, p3]
-    m1 = np.column_stack(eig_vecs)
+    # Create noise vector
+    noise = np.dot(eig_vecs, alpha_vector * eig_vals)
 
-    # get 3x1 matrix of eigen values multiplied by random variable draw from normal
-    # distribution with mean of 0 and standard deviation of 0.1
-    m2 = np.zeros((3, 1))
-    # according to the paper alpha should only be draw once per augmentation (not once per channel)
-    # > alpha = np.random.normal(0, alpha_std)
+    # Add noise to the image
+    img_pca = img_reshaped + noise
 
-    # broad cast to speed things up
-    m2[:, 0] = alpha * eig_vals[:]
+    # Reshape back to original shape
+    img_pca = img_pca.reshape(orig_shape)
 
-    # this is the vector that we're going to add to each pixel in a moment
-    add_vect = np.array(m1) @ np.array(m2)
+    # Clip values to [0, 1] range
+    img_pca = np.clip(img_pca, 0, 1)
 
-    for idx in range(3):  # RGB
-        orig_img[..., idx] += add_vect[idx] * 255
-
-    # for image processing it was found that working with float 0.0 to 1.0
-    # was easier than integers between 0-255
-    return orig_img
+    return from_float(img_pca, dtype=img.dtype) if img.dtype == np.uint8 else img_pca
 
 
 @preserve_channel_dim

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -1274,10 +1274,11 @@ def fancy_pca(img: np.ndarray, alpha_vector: np.ndarray) -> np.ndarray:
         In Advances in neural information processing systems (pp. 1097-1105).
     """
     orig_shape = img.shape
+    orig_dtype = img.dtype
     num_channels = get_num_channels(img)
 
     # Convert to float32 and scale to [0, 1] if necessary
-    if img.dtype == np.uint8:
+    if orig_dtype == np.uint8:
         img = to_float(img)
 
     # Reshape image to 2D array of pixels
@@ -1315,7 +1316,7 @@ def fancy_pca(img: np.ndarray, alpha_vector: np.ndarray) -> np.ndarray:
     # Clip values to [0, 1] range
     img_pca = np.clip(img_pca, 0, 1)
 
-    return from_float(img_pca, dtype=img.dtype) if img.dtype == np.uint8 else img_pca
+    return from_float(img_pca, dtype=orig_dtype) if orig_dtype == np.uint8 else img_pca
 
 
 @preserve_channel_dim

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -2601,23 +2601,49 @@ class MultiplicativeNoise(ImageOnlyTransform):
 
 
 class FancyPCA(ImageOnlyTransform):
-    """Augment RGB image using FancyPCA from Krizhevsky's paper
-    "ImageNet Classification with Deep Convolutional Neural Networks"
+    """Apply Fancy PCA augmentation to the input image.
+
+    This augmentation technique applies PCA (Principal Component Analysis) to the image's color channels,
+    then adds multiples of the principal components to the image, with magnitudes proportional to the
+    corresponding eigenvalues times a random variable drawn from a Gaussian with mean 0 and standard
+    deviation 'alpha'.
 
     Args:
-        alpha:  how much to perturb/scale the eigen vectors and eigenvalues.
-            scale is samples from gaussian distribution (mu=0, sigma=alpha)
+        alpha (float or tuple of float): Standard deviation of the Gaussian distribution used to generate
+            random noise for each principal component. If a single float is provided, it will be used for
+            all channels. If a tuple of two floats (min, max) is provided, the standard deviation will be
+            uniformly sampled from this range for each run. Default: 0.1.
+        always_apply (bool): If True, the transform will always be applied. Default: False.
+        p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
         image
 
     Image types:
-        float32, uint8
+        uint8, float32
 
-    Credit:
-        http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf
-        https://deshanadesai.github.io/notes/Fancy-PCA-with-Scikit-Image
-        https://pixelatedbrian.github.io/2018-04-29-fancy_pca/
+    Number of channels:
+        any
+
+    Note:
+        - This augmentation is particularly effective for RGB images but can work with any number of channels.
+        - For grayscale images, it applies a simplified version of the augmentation.
+        - The transform preserves the mean of the image while adjusting the color/intensity variation.
+        - This implementation is based on the paper by Krizhevsky et al. and is similar to the one used
+          in the original AlexNet paper.
+
+    Example:
+        >>> import numpy as np
+        >>> import albumentations as A
+        >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+        >>> transform = A.FancyPCA(alpha=0.1, p=1.0)
+        >>> result = transform(image=image)
+        >>> augmented_image = result["image"]
+
+    References:
+        - Krizhevsky, A., Sutskever, I., & Hinton, G. E. (2012). ImageNet classification with deep
+          convolutional neural networks. In Advances in neural information processing systems (pp. 1097-1105).
+        - https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf
 
     """
 

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -85,7 +85,6 @@ def test_image_only_augmentations_mask_persists(augmentation_cls, params):
             A.TextImage: dict(font_path="./tests/files/LiberationSerif-Bold.ttf")
         },
         except_augmentations={
-            A.FancyPCA,
             A.FromFloat,
             A.Posterize,
         },
@@ -311,7 +310,6 @@ def test_augmentations_wont_change_input(augmentation_cls, params):
             A.GridElasticDeform: {"num_grid_xy": (10, 10), "magnitude": 10},
         },
         except_augmentations={
-            A.FancyPCA,
             A.Posterize,
             A.RandomSizedBBoxSafeCrop,
             A.BBoxSafeRandomCrop,
@@ -374,7 +372,6 @@ def test_augmentations_wont_change_float_input(augmentation_cls, params):
         except_augmentations={
             A.ChannelDropout,
             A.ChannelShuffle,
-            A.FancyPCA,
             A.ISONoise,
             A.RandomCropNearBBox,
             A.RandomSizedBBoxSafeCrop,
@@ -618,7 +615,6 @@ def test_mask_fill_value(augmentation_cls, params):
             A.ToFloat,
             A.ToRGB,
             A.ToSepia,
-            A.FancyPCA,
             A.PixelDistributionAdaptation,
             A.Spatter,
             A.ChromaticAberration,
@@ -707,7 +703,6 @@ def test_multichannel_image_augmentations(augmentation_cls, params):
             A.ToRGB,
             A.ToSepia,
             A.Equalize,
-            A.FancyPCA,
             A.Posterize,
             A.PixelDistributionAdaptation,
             A.Spatter,
@@ -873,7 +868,6 @@ def test_multichannel_image_augmentations_diff_channels(augmentation_cls, params
             A.ToRGB,
             A.ToSepia,
             A.Equalize,
-            A.FancyPCA,
             A.Posterize,
             A.FDA,
             A.HistogramMatching,

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1137,3 +1137,29 @@ def test_clahe(shape, dtype, clip_limit, tile_grid_size):
     assert result.shape == img.shape
     assert result.dtype == img.dtype
     assert np.any(result != img)  # Ensure the image has changed
+
+
+@pytest.mark.parametrize("shape", [(100, 100, 3), (100, 100, 1), (100, 100, 5)])
+def test_fancy_pca_mean_preservation(shape):
+    image = np.random.rand(*shape).astype(np.float32)
+    alpha_vector = np.random.uniform(-0.1, 0.1, shape[-1])
+    result = F.fancy_pca(image, alpha_vector)
+    np.testing.assert_almost_equal(np.mean(image), np.mean(result), decimal=5)
+
+
+@pytest.mark.parametrize("shape, dtype", [
+    ((100, 100, 3), np.uint8),
+    ((100, 100, 3), np.float32),
+    ((100, 100, 1), np.uint8),
+    ((100, 100, 1), np.float32),
+    ((100, 100, 5), np.float32),
+])
+def test_fancy_pca_zero_alpha(shape, dtype):
+    image = np.random.randint(0, 256, shape).astype(dtype)
+    if dtype == np.float32:
+        image = image / 255.0
+
+    alpha_vector = np.zeros(shape[-1])
+    result = F.fancy_pca(image, alpha_vector)
+
+    np.testing.assert_array_equal(image, result)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1566,7 +1566,6 @@ def test_change_image(augmentation_cls, params):
             A.OverlayElements,
             A.FromFloat,
             A.TextImage,
-            A.FancyPCA
         },
     ),
 )


### PR DESCRIPTION
- Now works with any number of channels
- Supports both float32 and uint8

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Extend the Fancy PCA augmentation to support multi-channel images and float32 data types, refactor the function to use an alpha vector for scaling, and add tests to ensure correct functionality.

New Features:
- Extend the Fancy PCA augmentation to support images with any number of channels and both uint8 and float32 data types.

Enhancements:
- Refactor the Fancy PCA function to use an alpha vector for scaling principal components, allowing for more flexible augmentation across different channels.

Tests:
- Add tests to verify that the Fancy PCA augmentation preserves the mean of the image and correctly handles zero alpha vectors across various image shapes and data types.

<!-- Generated by sourcery-ai[bot]: end summary -->