### PR TITLE
moved to and from float to albucore

### DIFF
--- a/albumentations/augmentations/domain_adaptation.py
+++ b/albumentations/augmentations/domain_adaptation.py
@@ -5,11 +5,11 @@ from typing import Any, Callable, Literal, Sequence, Tuple, cast
 
 import cv2
 import numpy as np
+from albucore.functions import to_float
 from albucore.utils import clip, is_grayscale_image, is_multispectral_image
 from pydantic import AfterValidator, field_validator
 from typing_extensions import Annotated
 
-from albumentations.augmentations import functional as fmain
 from albumentations.augmentations.domain_adaptation_functional import (
     adapt_pixel_distribution,
     apply_histogram,
@@ -320,7 +320,7 @@ class PixelDistributionAdaptation(ImageOnlyTransform):
             transform_type=self.transform_type,
         )
 
-        return fmain.to_float(adapted) if needs_reconvert else adapted
+        return to_float(adapted) if needs_reconvert else adapted
 
     def get_params(self) -> dict[str, Any]:
         return {

--- a/albumentations/augmentations/domain_adaptation_functional.py
+++ b/albumentations/augmentations/domain_adaptation_functional.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 import cv2
 import numpy as np
-from albucore.functions import add_weighted
+from albucore.functions import add_weighted, to_float
 from albucore.utils import clip, clipped, preserve_channel_dim
 from skimage.exposure import match_histograms
 from typing_extensions import Protocol
@@ -139,7 +139,7 @@ class DomainAdapter:
 
     def flatten(self, img: np.ndarray) -> np.ndarray:
         img = self.to_colorspace(img)
-        img = fmain.to_float(img)
+        img = to_float(img)
         return img.reshape(-1, 3)
 
     def reconstruct(self, pixels: np.ndarray, height: int, width: int) -> np.ndarray:

--- a/albumentations/augmentations/text/functional.py
+++ b/albumentations/augmentations/text/functional.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 import cv2
 import numpy as np
+from albucore.functions import from_float, to_float
 from albucore.utils import MONO_CHANNEL_DIMENSIONS, NUM_MULTI_CHANNEL_DIMENSIONS, NUM_RGB_CHANNELS, preserve_channel_dim
 
-import albumentations.augmentations.functional as fmain
 from albumentations.core.types import PAIR
 
 # Importing wordnet and other dependencies only for type checking
@@ -115,7 +115,7 @@ def render_text(image: np.ndarray, metadata_list: list[dict[str, Any]], clear_bg
     original_dtype = image.dtype
 
     if original_dtype == np.float32:
-        image = fmain.from_float(image, dtype=np.uint8)
+        image = from_float(image, dtype=np.uint8)
 
     # First clean background under boxes using seamless clone if clear_bg is True
     if clear_bg:
@@ -130,7 +130,7 @@ def render_text(image: np.ndarray, metadata_list: list[dict[str, Any]], clear_bg
     else:
         result = draw_text_on_multi_channel_image(image, metadata_list)
 
-    return fmain.to_float(result) if original_dtype == np.float32 else result
+    return to_float(result) if original_dtype == np.float32 else result
 
 
 def inpaint_text_background(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 INSTALL_REQUIRES = [
     "numpy>=1.24.4", "scipy>=1.10.0", "scikit-image>=0.21.0",
     "PyYAML",
-    "typing-extensions>=4.9.0; python_version<'3.10'"
+    "typing-extensions>=4.9.0; python_version<'3.10'",
     "pydantic>=2.7.0",
     "albucore>=0.0.15",
     "eval-type-backport"

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,10 @@ from setuptools import find_packages, setup
 
 INSTALL_REQUIRES = [
     "numpy>=1.24.4", "scipy>=1.10.0", "scikit-image>=0.21.0",
-    "PyYAML", "typing-extensions>=4.9.0",
+    "PyYAML",
+    "typing-extensions>=4.9.0; python_version<'3.10'"
     "pydantic>=2.7.0",
-    "albucore>=0.0.14",
+    "albucore>=0.0.15",
     "eval-type-backport"
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,11 @@ import sys
 import numpy as np
 import pytest
 
+from tests.utils import set_seed
+
+
+set_seed(42)
+
 @pytest.fixture
 def global_label():
     return np.array([1, 0, 0])

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -12,6 +12,7 @@ from torchvision import transforms as torch_transforms
 from albumentations.core.bbox_utils import denormalize_bboxes, normalize_bboxes
 
 from albucore.utils import clip
+from albucore.functions import to_float
 import albumentations as A
 import albumentations.augmentations.functional as F
 import albumentations.augmentations.geometric.functional as fgeometric
@@ -359,10 +360,10 @@ def test_image_invert():
     for _ in range(10):
         # test for np.uint8 dtype
         image1 = np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
-        image2 = A.to_float(image1)
+        image2 = to_float(image1)
         r_int = F.invert(F.invert(image1))
         r_float = F.invert(F.invert(image2))
-        r_to_float = A.to_float(r_int)
+        r_to_float = to_float(r_int)
         assert np.allclose(r_float, r_to_float, atol=0.01)
 
 
@@ -819,7 +820,7 @@ def test_unsharp_mask_float_uint8_diff_less_than_two(val_uint8):
     diff = np.abs(usm_uint8 - usm_float32 * 255)
 
     # The difference between the results of float32 and uint8 will be at most 2.
-    assert np.all(diff <= 2.0)
+    assert np.all(diff <= 2.0), f"Max difference: {diff.max()}"
 
 
 @pytest.mark.parametrize(
@@ -2050,6 +2051,7 @@ def test_rot90(bboxes, angle, keypoints):
 )
 def test_return_nonzero(augmentation_cls, params):
     """Checks whether we can use augmentations in multiprocessing environments"""
+    set_seed(42)
     image = SQUARE_FLOAT_IMAGE if augmentation_cls == A.FromFloat else SQUARE_UINT8_IMAGE
     aug = A.Compose([augmentation_cls(p=1, **params)])
 


### PR DESCRIPTION
Fixes https://github.com/albumentations-team/albumentations/issues/1830

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove the `to_float` and `from_float` functions and their associated tests, refactor the `FromFloat` class for improved clarity, update the `albucore` dependency, and ensure consistent test results by setting a seed.

Enhancements:
- Refactor the `FromFloat` class to improve clarity and update its docstring with detailed usage instructions and examples.
- Update the `FromFloat` class to use the `from_float` function internally for consistent value scaling.

Build:
- Update the `albucore` dependency version to `>=0.0.15` in `setup.py`.

Tests:
- Remove multiple tests related to `to_float` and `from_float` functions, indicating a shift in testing strategy or functionality.
- Add a seed setting in `test_return_nonzero` to ensure consistent test results.

Chores:
- Remove unused imports and functions from `functional.py`, specifically `to_float` and `from_float`.

<!-- Generated by sourcery-ai[bot]: end summary -->