### PR TITLE
replace skimage affine ellipse with numpy ops

### DIFF
--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -894,7 +894,12 @@ def bboxes_affine_ellipse(bboxes: np.ndarray, matrix: skimage.transform.Projecti
     # change matrix.params.T to matrix.T if matrix is np.ndarray and no longer skimage.transform.ProjectiveTransform
     transformed_points = points @ matrix.params.T
 
-    # normalize and get x, y
+    # set zero to very small number before homogeneous divide
+    transformed_points[:, -1:] = np.where(
+        transformed_points[:, -1:] == 0,
+        np.finfo(float).eps,
+        transformed_points[:, -1:],
+    )
     transformed_points = (transformed_points / transformed_points[:, -1:])[:, :2]
 
     transformed_points = transformed_points.reshape(len(bboxes), -1, 2)

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -887,7 +887,16 @@ def bboxes_affine_ellipse(bboxes: np.ndarray, matrix: skimage.transform.Projecti
     points = np.stack([x, y], axis=-1).reshape(-1, 2)
 
     # Transform all points at once
-    transformed_points = skimage.transform.matrix_transform(points, matrix.params)
+    # Replacing skimage.transform.matrix_transform with numpy ops:
+    # points reshape from N, 2 to N, 3 with extra dim filled with 1
+    points = np.concatenate([points, np.ones((points.shape[0], 1))], axis=1)
+
+    # change matrix.params.T to matrix.T if matrix is np.ndarray and no longer skimage.transform.ProjectiveTransform
+    transformed_points = points @ matrix.params.T
+
+    # normalize and get x, y
+    transformed_points = (transformed_points / transformed_points[:, -1:])[:, :2]
+
     transformed_points = transformed_points.reshape(len(bboxes), -1, 2)
 
     # Compute new bounding boxes

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -900,6 +900,8 @@ def bboxes_affine_ellipse(bboxes: np.ndarray, matrix: skimage.transform.Projecti
         np.finfo(float).eps,
         transformed_points[:, -1:],
     )
+
+    # homogeneous divide and then get x, y
     transformed_points = (transformed_points / transformed_points[:, -1:])[:, :2]
 
     transformed_points = transformed_points.reshape(len(bboxes), -1, 2)


### PR DESCRIPTION
issue: https://github.com/albumentations-team/albumentations/issues/1895#issue-2473713635

dropping the need for skimage API within Affine bbox transformation (resize_method="ellipse") with simple numpy ops. There is no impact on time.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Replace skimage affine transformation with numpy operations in the bboxes_affine_ellipse function to eliminate dependency on skimage without impacting performance.

Enhancements:
- Replace the use of skimage's matrix_transform with equivalent numpy operations for affine transformations in the bboxes_affine_ellipse function.

<!-- Generated by sourcery-ai[bot]: end summary -->