### PR TITLE
Fix docstrings for Sharpen, RandomToneCurve and RingingOvershot

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -3830,10 +3830,10 @@ class Superpixels(ImageOnlyTransform):
     """
 
     class InitSchema(BaseTransformInitSchema):
-        p_replace: ZeroOneRangeType = (0, 0.1)
-        n_segments: OnePlusIntRangeType = (100, 100)
-        max_size: int | None = Field(default=128, ge=1, description="Maximum image size for the transformation.")
-        interpolation: InterpolationType = cv2.INTER_LINEAR
+        p_replace: ZeroOneRangeType
+        n_segments: OnePlusIntRangeType
+        max_size: int | None = Field(ge=1)
+        interpolation: InterpolationType
 
     def __init__(
         self,


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the documentation for the RandomToneCurve, Sharpen, and RingingOvershoot transforms by providing more detailed descriptions, mathematical formulations, and usage examples.

Enhancements:
- Improve the docstring for the RandomToneCurve transform by adding detailed explanations of its functionality, including the mathematical formulation and examples.
- Enhance the docstring for the Sharpen transform with additional details on its operation, including mathematical formulation and examples.
- Update the docstring for the RingingOvershoot transform to include a more comprehensive explanation of its effects, mathematical formulation, and usage examples.

<!-- Generated by sourcery-ai[bot]: end summary -->