### PR TITLE
Bugfixes in textimage

### DIFF
--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -793,8 +793,8 @@ class ZoomBlur(ImageOnlyTransform):
     """
 
     class InitSchema(BaseTransformInitSchema):
-        max_factor: OnePlusFloatRangeType = (1, 1.31)
-        step_factor: NonNegativeFloatRangeType = (0.01, 0.03)
+        max_factor: OnePlusFloatRangeType
+        step_factor: NonNegativeFloatRangeType
 
     def __init__(
         self,
@@ -811,8 +811,8 @@ class ZoomBlur(ImageOnlyTransform):
         return fblur.zoom_blur(img, zoom_factors)
 
     def get_params(self) -> dict[str, Any]:
-        max_factor = random.uniform(self.max_factor[0], self.max_factor[1])
-        step_factor = random.uniform(self.step_factor[0], self.step_factor[1])
+        step_factor = random.uniform(*self.step_factor)
+        max_factor = max(1 + step_factor, random.uniform(*self.max_factor))
         return {"zoom_factors": np.arange(1.0, max_factor, step_factor)}
 
     def get_transform_init_args_names(self) -> tuple[str, str]:

--- a/albumentations/augmentations/domain_adaptation_functional.py
+++ b/albumentations/augmentations/domain_adaptation_functional.py
@@ -11,7 +11,7 @@ from albucore.utils import clip, clipped, get_num_channels, preserve_channel_dim
 from skimage.exposure import match_histograms
 from typing_extensions import Protocol
 
-import albumentations.augmentations.functional as fmain
+import albumentations.augmentations.geometric.functional as fgeometric
 from albumentations.augmentations.utils import PCA
 from albumentations.core.types import MONO_CHANNEL_DIMENSIONS, NUM_MULTI_CHANNEL_DIMENSIONS
 
@@ -212,7 +212,7 @@ def low_freq_mutate(amp_src: np.ndarray, amp_trg: np.ndarray, beta: float) -> np
 
     border = int(np.floor(min(image_shape) * beta))
 
-    center_x, center_y = fmain.center(image_shape)
+    center_x, center_y = fgeometric.center(image_shape)
 
     height, width = image_shape
 

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -9,9 +9,8 @@ import skimage.transform
 from albucore.utils import clipped, get_num_channels, maybe_process_in_chunks, preserve_channel_dim
 
 from albumentations import random_utils
-from albumentations.augmentations.functional import bbox_from_mask, center
 from albumentations.augmentations.utils import angle_2pi_range, handle_empty_array
-from albumentations.core.bbox_utils import denormalize_bboxes, normalize_bboxes
+from albumentations.core.bbox_utils import bbox_from_mask, denormalize_bboxes, normalize_bboxes
 from albumentations.core.types import (
     NUM_KEYPOINTS_COLUMNS_IN_ALBUMENTATIONS,
     NUM_MULTI_CHANNEL_DIMENSIONS,
@@ -59,6 +58,8 @@ __all__ = [
     "keypoints_vflip",
     "bboxes_hflip",
     "keypoints_hflip",
+    "center",
+    "center_bbox",
 ]
 
 PAIR = 2
@@ -2642,3 +2643,29 @@ def bboxes_grid_distortion(
 
     # Normalize the returned bboxes
     return normalize_bboxes(bboxes_returned, image_shape)
+
+
+def center(image_shape: tuple[int, int]) -> tuple[float, float]:
+    """Calculate the center coordinates if image. Used by images, masks and keypoints.
+
+    Args:
+        image_shape (tuple[int, int]): The shape of the image.
+
+    Returns:
+        tuple[float, float]: The center coordinates.
+    """
+    height, width = image_shape[:2]
+    return width / 2 - 0.5, height / 2 - 0.5
+
+
+def center_bbox(image_shape: tuple[int, int]) -> tuple[float, float]:
+    """Calculate the center coordinates for of image for bounding boxes.
+
+    Args:
+        image_shape (tuple[int, int]): The shape of the image.
+
+    Returns:
+        tuple[float, float]: The center coordinates.
+    """
+    height, width = image_shape[:2]
+    return width / 2, height / 2

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -10,7 +10,6 @@ from skimage.transform import ProjectiveTransform
 from typing_extensions import Literal
 
 from albumentations.augmentations.crops import functional as fcrops
-from albumentations.augmentations.functional import center, center_bbox
 from albumentations.augmentations.geometric.transforms import Affine
 from albumentations.core.pydantic import BorderModeType, InterpolationType, SymmetricRangeType
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
@@ -345,8 +344,8 @@ class SafeRotate(Affine):
         angle = random.uniform(self.limit[0], self.limit[1])
 
         # Calculate centers for image and bbox
-        image_center = center(image_shape)
-        bbox_center = center_bbox(image_shape)
+        image_center = fgeometric.center(image_shape)
+        bbox_center = fgeometric.center_bbox(image_shape)
 
         # Create matrices for image and bbox
         matrix, scale = self._create_safe_rotate_matrix(angle, image_center, image_shape)

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -14,7 +14,6 @@ from pydantic import AfterValidator, Field, ValidationInfo, field_validator, mod
 from typing_extensions import Annotated, Self
 
 from albumentations import random_utils
-from albumentations.augmentations.functional import center, center_bbox
 from albumentations.augmentations.utils import check_range
 from albumentations.core.bbox_utils import denormalize_bboxes, normalize_bboxes
 from albumentations.core.pydantic import (
@@ -776,8 +775,8 @@ class Affine(DualTransform):
         scale = self.get_scale(self.scale, self.keep_ratio, self.balanced_scale)
         rotate = -random.uniform(*self.rotate)
 
-        image_shift = center(image_shape)
-        bbox_shift = center_bbox(image_shape)
+        image_shift = fgeometric.center(image_shape)
+        bbox_shift = fgeometric.center_bbox(image_shape)
 
         matrix = fgeometric.create_affine_transformation_matrix(translate, shear, scale, rotate, image_shift)
         bbox_matrix = fgeometric.create_affine_transformation_matrix(translate, shear, scale, rotate, bbox_shift)

--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -519,3 +519,39 @@ def union_of_bboxes(bboxes: np.ndarray, erosion_rate: float) -> np.ndarray | Non
         return None
 
     return np.array([x_min, y_min, x_max, y_max], dtype=np.float32)
+
+
+def bbox_from_mask(mask: np.ndarray) -> tuple[int, int, int, int]:
+    """Create bounding box from binary mask (fast version)
+
+    Args:
+        mask (numpy.ndarray): binary mask.
+
+    Returns:
+        tuple: A bounding box tuple `(x_min, y_min, x_max, y_max)`.
+
+    """
+    rows = np.any(mask, axis=1)
+    if not rows.any():
+        return -1, -1, -1, -1
+    cols = np.any(mask, axis=0)
+    y_min, y_max = np.where(rows)[0][[0, -1]]
+    x_min, x_max = np.where(cols)[0][[0, -1]]
+    return x_min, y_min, x_max + 1, y_max + 1
+
+
+def mask_from_bbox(img: np.ndarray, bbox: tuple[int, int, int, int]) -> np.ndarray:
+    """Create binary mask from bounding box
+
+    Args:
+        img: input image
+        bbox: A bounding box tuple `(x_min, y_min, x_max, y_max)`
+
+    Returns:
+        mask: binary mask
+
+    """
+    mask = np.zeros(img.shape[:2], dtype=np.uint8)
+    x_min, y_min, x_max, y_max = bbox
+    mask[y_min:y_max, x_min:x_max] = 1
+    return mask

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ lint.ignore = [
   "S311",
   "TCH001",
   "TCH002",
+  "TCH003",
   "TRY003",
 ]
 

--- a/tests/functional/test_affine.py
+++ b/tests/functional/test_affine.py
@@ -3,7 +3,6 @@ import numpy as np
 import pytest
 import skimage.transform
 import cv2
-from albumentations.augmentations.functional import center_bbox
 import albumentations.augmentations.geometric.functional as fgeometric
 import albumentations as A
 
@@ -395,7 +394,7 @@ def test_create_affine_transformation_matrix_extreme_values():
     {"translate": {"x": 0, "y": 0}, "shear": {"x": 30, "y": 20}, "scale": {"x": 1.5, "y": 1.2}, "rotate": 45},
 ])
 def test_center_remains_stationary(image_shape, transform_params):
-    center = center_bbox(image_shape)
+    center = fgeometric.center_bbox(image_shape)
 
     transform = fgeometric.create_affine_transformation_matrix(**transform_params, shift=center)
 
@@ -467,7 +466,7 @@ def test_center_remains_stationary(image_shape, transform_params):
     ]
 )
 def test_calculate_affine_transform_padding(image_shape, transform_params, expected_padding):
-    bbox_shift = center_bbox(image_shape)
+    bbox_shift = fgeometric.center_bbox(image_shape)
 
     transform = fgeometric.create_affine_transformation_matrix(**transform_params, shift=(bbox_shift[0], bbox_shift[1]))
 

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -46,7 +46,7 @@ def test_image_only_augmentations_mask_persists(augmentation_cls, params):
     mask = image.copy()
     if augmentation_cls == A.TextImage:
         aug = A.Compose([augmentation_cls(p=1, **params)], bbox_params=A.BboxParams(format="pascal_voc"))
-        data= aug(image=image, mask=mask, textimage_metadata=[])
+        data= aug(image=image, mask=mask, textimage_metadata={"text": "May the transformations be ever in your favor!", "bbox": (0.1, 0.1, 0.9, 0.2)})
     else:
         aug = A.Compose([augmentation_cls(p=1, **params)])
         data = aug(image=image, mask=mask)
@@ -94,7 +94,7 @@ def test_image_only_augmentations(augmentation_cls, params):
     mask = image[:, :, 0].copy().astype(np.uint8)
     if augmentation_cls == A.TextImage:
         aug = A.Compose([augmentation_cls(p=1, **params)], bbox_params=A.BboxParams(format="pascal_voc"))
-        data= aug(image=image, mask=mask, textimage_metadata=[])
+        data= aug(image=image, mask=mask, textimage_metadata={"text": "Hello, world!", "bbox": (0.1, 0.1, 0.9, 0.2)})
     else:
         aug = augmentation_cls(p=1, **params)
         data = aug(image=image, mask=mask)
@@ -254,7 +254,7 @@ def test_augmentations_wont_change_input(augmentation_cls, params):
     if augmentation_cls == A.OverlayElements:
         aug(image=image, mask=mask, overlay_metadata=[])
     elif augmentation_cls == A.TextImage:
-        aug(image=image, mask=mask, textimage_metadata=[])
+        aug(image=image, mask=mask, textimage_metadata={"text": "May the transformations be ever in your favor!", "bbox": (0.1, 0.1, 0.9, 0.2)})
     else:
         aug(image=image, mask=mask)
 
@@ -327,7 +327,7 @@ def test_augmentations_wont_change_float_input(augmentation_cls, params):
     if augmentation_cls == A.OverlayElements:
         data["overlay_metadata"] = []
     elif augmentation_cls == A.TextImage:
-        data["textimage_metadata"] = []
+        data["textimage_metadata"] = {"text": "May the transformations be ever in your favor!", "bbox": (0.1, 0.1, 0.9, 0.2)}
 
     aug(**data)
 
@@ -395,7 +395,6 @@ def test_augmentations_wont_change_float_input(augmentation_cls, params):
             A.RandomSnow,
             A.ToRGB,
             A.ToSepia,
-            A.UnsharpMask,
             A.RandomCropFromBorders,
             A.Spatter,
             A.ChromaticAberration,
@@ -420,7 +419,7 @@ def test_augmentations_wont_change_shape_grayscale(augmentation_cls, params, sha
     if augmentation_cls == A.OverlayElements:
         data["overlay_metadata"] = []
     elif augmentation_cls == A.TextImage:
-        data["textimage_metadata"] = []
+        data["textimage_metadata"] = {"text": "May the transformations be ever in your favor!", "bbox": (0.1, 0.1, 0.9, 0.2)}
     result = aug(**data)
 
     np.testing.assert_array_equal(image.shape, result["image"].shape)
@@ -504,7 +503,7 @@ def test_augmentations_wont_change_shape_rgb(augmentation_cls, params):
     elif augmentation_cls == A.TextImage:
         data = {
             "image": image_3ch,
-            "textimage_metadata": [],
+            "textimage_metadata": {"text": "May the transformations be ever in your favor!", "bbox": (0.1, 0.1, 0.9, 0.2)},
             "mask": mask_3ch,
         }
     elif augmentation_cls == A.FromFloat:
@@ -639,7 +638,7 @@ def test_multichannel_image_augmentations(augmentation_cls, params):
     if augmentation_cls == A.OverlayElements:
         data["overlay_metadata"] = []
     elif augmentation_cls == A.TextImage:
-        data["textimage_metadata"] = []
+        data["textimage_metadata"] = {"text": "May the transformations be ever in your favor!", "bbox": (0.1, 0.1, 0.9, 0.2)}
 
     data = aug(**data)
     assert data["image"].dtype == np.uint8
@@ -727,7 +726,7 @@ def test_float_multichannel_image_augmentations(augmentation_cls, params):
     if augmentation_cls == A.OverlayElements:
         data["overlay_metadata"] = []
     elif augmentation_cls == A.TextImage:
-        data["textimage_metadata"] = []
+        data["textimage_metadata"] = {"text": "May the transformations be ever in your favor!", "bbox": (0.1, 0.1, 0.9, 0.2)}
 
     data = aug(**data)
 
@@ -812,7 +811,7 @@ def test_multichannel_image_augmentations_diff_channels(augmentation_cls, params
     if augmentation_cls == A.OverlayElements:
         data["overlay_metadata"] = []
     elif augmentation_cls == A.TextImage:
-        data["textimage_metadata"] = []
+        data["textimage_metadata"] = {"text": "May the transformations be ever in your favor!", "bbox": (0.1, 0.1, 0.9, 0.2)}
 
     data = aug(**data)
 
@@ -887,7 +886,7 @@ def test_multichannel_image_augmentations_diff_channels(augmentation_cls, params
 )
 def test_float_multichannel_image_augmentations_diff_channels(augmentation_cls, params):
     image = SQUARE_MULTI_FLOAT_IMAGE
-    aug = augmentation_cls(p=1, **params)
+    aug = A.Compose([augmentation_cls(p=1, **params)])
 
     data = {
         "image": image,
@@ -896,7 +895,7 @@ def test_float_multichannel_image_augmentations_diff_channels(augmentation_cls, 
     if augmentation_cls == A.OverlayElements:
         data["overlay_metadata"] = []
     elif augmentation_cls == A.TextImage:
-        data["textimage_metadata"] = []
+        data["textimage_metadata"] = {"text": "May the transformations be ever in your favor!", "bbox": (0.1, 0.1, 0.9, 0.2)}
 
     data = aug(**data)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -777,7 +777,6 @@ def test_contiguous_output_dual(augmentation_cls, params):
             A.FDA,
             A.HistogramMatching,
             A.Lambda,
-            A.TemplateTransform,
             A.MixUp,
             A.RandomSizedBBoxSafeCrop,
             A.CropNonEmptyMaskIfExists,
@@ -790,6 +789,9 @@ def test_contiguous_output_dual(augmentation_cls, params):
                 "reference_images": [np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)],
                 "read_fn": lambda x: x,
                 "transform_type": "standard",
+            },
+            A.TemplateTransform: {
+                "templates": np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8),
             },
         },
     ),
@@ -1201,7 +1203,7 @@ def test_non_contiguous_input_with_compose(augmentation_cls, params, bboxes):
         transformed = aug(image=image, mask=mask, bboxes=bboxes)
     elif augmentation_cls == A.TextImage:
         aug = A.Compose([augmentation_cls(p=1, **params)], bbox_params=A.BboxParams(format="pascal_voc"))
-        transformed = aug(image=image, mask=mask, bboxes=bboxes, textimage_metadata=[])
+        transformed = aug(image=image, mask=mask, bboxes=bboxes, textimage_metadata={"text": "Hello, world!", "bbox": (0.1, 0.1, 0.9, 0.2)})
     elif augmentation_cls == A.OverlayElements:
         # requires "metadata" arg
         aug = A.Compose([augmentation_cls(p=1, **params)])

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -137,7 +137,16 @@ dummy_metadata = {
     "text": "Test",
     "font": font,
     "font_color": (127, 127, 127, 127, 127)
-}])])
+}]),
+((100, 100, 5), [{
+    "bbox_coords": (20, 20, 110, 60),
+    "text": "Test",
+    "font": font,
+    "font_color": "red"
+}]),
+
+
+    ])
 def test_draw_text_on_pil_image(image_shape, metadata_list):
     image = np.random.randint(0, 255, size=image_shape, dtype=np.uint8)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -119,9 +119,9 @@ def get_transforms(
 
 
 def check_all_augs_exists(
-    augmentations: typing.List[typing.List],
+    augmentations: list[list],
     except_augmentations: Optional[Set] = None,
-) -> typing.List[typing.List]:
+) -> list[list]:
     existed_augs = {i[0] for i in augmentations}
     except_augmentations = except_augmentations or set()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import random
 import typing


### PR DESCRIPTION
Also fixes: https://github.com/albumentations-team/albumentations/issues/1926

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix a bug in fog augmentation by correcting the function call for center calculation. Enhance several image transformation classes with improved functionality, documentation, and examples. Update tests to cover new features and remove redundant tests.

Bug Fixes:
- Fix incorrect function call for calculating the center of an image in fog augmentation.

Enhancements:
- Improve the ToRGB transform by adding support for specifying the number of output channels and updating the documentation.
- Enhance the ToSepia transform with detailed documentation and examples.
- Refactor the Superpixels transform to improve performance and update documentation.
- Update the TemplateTransform to handle different types of font colors and improve blending logic.
- Refactor the UnsharpMask transform to improve edge detection and sharpening logic.

Tests:
- Add tests for the TextImage augmentation to ensure metadata handling and image transformation.
- Remove redundant test for TemplateTransform with incorrect size.

<!-- Generated by sourcery-ai[bot]: end summary -->