### PR TITLE
Moved hflip and vflip to albucore

### DIFF
--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Literal, Sequence, Tuple, TypedDict, cast
 import cv2
 import numpy as np
 import skimage.transform
-from albucore.utils import clipped, get_num_channels, maybe_process_in_chunks, preserve_channel_dim
+from albucore import clipped, get_num_channels, hflip, maybe_process_in_chunks, preserve_channel_dim, vflip
 
 from albumentations import random_utils
 from albumentations.augmentations.utils import angle_2pi_range, handle_empty_array
@@ -41,10 +41,7 @@ __all__ = [
     "piecewise_affine",
     "to_distance_maps",
     "from_distance_maps",
-    "hflip",
-    "hflip_cv2",
     "transpose",
-    "vflip",
     "d4",
     "bboxes_rotate",
     "keypoints_rotate",
@@ -1241,18 +1238,6 @@ def bboxes_piecewise_affine(
 
     # Normalize the new bboxes
     return normalize_bboxes(new_bboxes, image_shape)
-
-
-def vflip(img: np.ndarray) -> np.ndarray:
-    return img[::-1, ...]
-
-
-def hflip(img: np.ndarray) -> np.ndarray:
-    return img[:, ::-1, ...]
-
-
-def hflip_cv2(img: np.ndarray) -> np.ndarray:
-    return cv2.flip(img, 1)
 
 
 def d4(img: np.ndarray, group_member: D4Type) -> np.ndarray:

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -9,7 +9,7 @@ from warnings import warn
 import cv2
 import numpy as np
 import skimage.transform
-from albucore.utils import get_num_channels
+from albucore import hflip, vflip
 from pydantic import AfterValidator, Field, ValidationInfo, field_validator, model_validator
 from typing_extensions import Annotated, Self
 
@@ -1474,7 +1474,7 @@ class VerticalFlip(DualTransform):
     _targets = (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS)
 
     def apply(self, img: np.ndarray, **params: Any) -> np.ndarray:
-        return fgeometric.vflip(img)
+        return vflip(img)
 
     def apply_to_bboxes(self, bboxes: np.ndarray, **params: Any) -> np.ndarray:
         return fgeometric.bboxes_vflip(bboxes)
@@ -1503,12 +1503,7 @@ class HorizontalFlip(DualTransform):
     _targets = (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS)
 
     def apply(self, img: np.ndarray, **params: Any) -> np.ndarray:
-        if get_num_channels(img) > 1 and img.dtype == np.uint8:
-            # Opencv is faster than numpy only in case of
-            # non-gray scale 8bits images
-            return fgeometric.hflip_cv2(img)
-
-        return fgeometric.hflip(img)
+        return hflip(img)
 
     def apply_to_bboxes(self, bboxes: np.ndarray, **params: Any) -> np.ndarray:
         return fgeometric.bboxes_hflip(bboxes)

--- a/albumentations/augmentations/text/functional.py
+++ b/albumentations/augmentations/text/functional.py
@@ -5,8 +5,14 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 import cv2
 import numpy as np
-from albucore.functions import from_float, to_float
-from albucore.utils import MONO_CHANNEL_DIMENSIONS, NUM_MULTI_CHANNEL_DIMENSIONS, NUM_RGB_CHANNELS, preserve_channel_dim
+from albucore import (
+    MONO_CHANNEL_DIMENSIONS,
+    NUM_MULTI_CHANNEL_DIMENSIONS,
+    NUM_RGB_CHANNELS,
+    from_float,
+    preserve_channel_dim,
+    to_float,
+)
 
 from albumentations.core.types import PAIR
 
@@ -132,7 +138,7 @@ def render_text(image: np.ndarray, metadata_list: list[dict[str, Any]], clear_bg
     original_dtype = image.dtype
 
     if original_dtype == np.float32:
-        image = from_float(image, dtype=np.uint8)
+        image = from_float(image, target_dtype=np.uint8)
 
     # First clean background under boxes using seamless clone if clear_bg is True
     if clear_bg:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ INSTALL_REQUIRES = [
     "PyYAML",
     "typing-extensions>=4.9.0; python_version<'3.10'",
     "pydantic>=2.7.0",
-    "albucore>=0.0.15",
+    "albucore>=0.0.16",
     "eval-type-backport"
 ]
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -7,11 +7,10 @@ import skimage
 
 import albumentations.augmentations.functional as F
 import albumentations.augmentations.geometric.functional as fgeometric
-from albucore.utils import is_multispectral_image, MAX_VALUES_BY_DTYPE, get_num_channels, clip
-from albucore.functions import to_float
+from albucore import is_multispectral_image, MAX_VALUES_BY_DTYPE, get_num_channels, clip, to_float
 
 from albumentations.core.types import d4_group_elements
-from tests.conftest import IMAGES, RECTANGULAR_FLOAT_IMAGE, RECTANGULAR_IMAGES, RECTANGULAR_UINT8_IMAGE, SQUARE_UINT8_IMAGE, UINT8_IMAGES
+from tests.conftest import IMAGES, RECTANGULAR_IMAGES, RECTANGULAR_UINT8_IMAGE, SQUARE_UINT8_IMAGE, UINT8_IMAGES
 from tests.utils import convert_2d_to_target_format, set_seed
 
 
@@ -887,7 +886,7 @@ def test_iso_noise(image, color_shift, intensity):
     set_seed(42)
     result_float = F.iso_noise(float_image, color_shift=color_shift, intensity=intensity)
 
-    result_float = F.from_float(result_float, dtype=np.uint8)  # Convert the float result back to uint8
+    result_float = F.from_float(result_float, target_dtype=np.uint8)  # Convert the float result back to uint8
 
     np.testing.assert_allclose(result_uint8, result_float, rtol=1e-5, atol=1)
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Move horizontal and vertical flip functions from geometric functional module to albucore, and refactor image conversion functions to use 'target_dtype' for improved clarity.

Enhancements:
- Refactor image conversion functions to use 'target_dtype' parameter instead of 'dtype' for improved clarity and consistency.

Chores:
- Update albucore dependency version in setup.py from 0.0.15 to 0.0.16.

<!-- Generated by sourcery-ai[bot]: end summary -->