### PR TITLE
Do not filter bboxes less than 1 pixel

### DIFF
--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -466,8 +466,8 @@ def filter_bboxes(
         (denormalized_box_areas >= EPSILON)
         & (clipped_box_areas >= min_area - EPSILON)
         & (clipped_box_areas / denormalized_box_areas >= min_visibility - EPSILON)
-        & (clipped_widths >= max(min_width, 0))
-        & (clipped_heights >= max(min_height, 0))
+        & (clipped_widths >= min_width - EPSILON)
+        & (clipped_heights >= min_height - EPSILON)
     )
 
     # Apply the mask to get the filtered bboxes

--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 BBOX_WITH_LABEL_SHAPE = 5
-EPSILON = 1e-3
+EPSILON = 1e-5
 
 
 class BboxParams(Params):
@@ -463,11 +463,11 @@ def filter_bboxes(
 
     # Create a mask for bboxes that meet all criteria
     mask = (
-        (denormalized_box_areas >= (1 - EPSILON))
+        (denormalized_box_areas >= EPSILON)
         & (clipped_box_areas >= min_area - EPSILON)
         & (clipped_box_areas / denormalized_box_areas >= min_visibility - EPSILON)
-        & (clipped_widths >= max(min_width, 1 - EPSILON))
-        & (clipped_heights >= max(min_height, 1 - EPSILON))
+        & (clipped_widths >= max(min_width, 0))
+        & (clipped_heights >= max(min_height, 0))
     )
 
     # Apply the mask to get the filtered bboxes

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,10 @@
 deepdiff>=8.0.1
 eval-type-backport
-mypy>=1.11.2
 pre_commit>=3.5.0
 pytest>=8.3.3
 pytest_cov>=5.0.0
 pytest_mock>=3.14.0
 requests>=2.31.0
-ruff>=0.6.5
 tomli>=2.0.1
 torch>=2.3.1
 torchvision>=0.18.1

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -1203,3 +1203,13 @@ def test_bbox_d4(bbox, group_member, expected):
     bboxes = np.array([bbox])
     result = fgeometric.bboxes_d4(bboxes, group_member)[0]
     np.testing.assert_array_almost_equal(result, expected)
+
+
+def test_less_1_pixel_bbox():
+    transform = A.Compose(
+    [A.NoOp()],
+        bbox_params=A.BboxParams(format="coco", label_fields=["category_id"]),
+    )
+    transformed = transform(image=np.zeros((4, 4, 3), dtype=np.uint8), bboxes=[[1.0, 1.0, 0.75, 0.75]], category_id=[1])
+
+    np.testing.assert_array_almost_equal(transformed["bboxes"], [[1.0, 1.0, 0.75, 0.75]])


### PR DESCRIPTION
FIxes: https://github.com/albumentations-team/albumentations/issues/1928

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue where bounding boxes less than 1 pixel were incorrectly filtered out by adjusting the EPSILON value and related conditions, and add a test to ensure this behavior.

Bug Fixes:
- Adjust the filtering logic for bounding boxes to allow bboxes with dimensions less than 1 pixel by changing the EPSILON value and related conditions.

Tests:
- Add a test case to verify that bounding boxes with dimensions less than 1 pixel are not filtered out.

<!-- Generated by sourcery-ai[bot]: end summary -->