### PR TITLE
Added extra test for ToTensorV2 and non contigious

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       types: [python]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.5
+    rev: v0.6.6
     hooks:
       # Run the linter.
       - id: ruff
@@ -70,7 +70,7 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "2.2.3"
+    rev: "2.2.4"
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -3497,7 +3497,7 @@ class FancyPCA(ImageOnlyTransform):
     deviation 'alpha'.
 
     Args:
-        alpha (float or tuple of float): Standard deviation of the Gaussian distribution used to generate
+        alpha (tuple[float, float] | float): Standard deviation of the Gaussian distribution used to generate
             random noise for each principal component. If a single float is provided, it will be used for
             all channels. If a tuple of two floats (min, max) is provided, the standard deviation will be
             uniformly sampled from this range for each run. Default: 0.1.

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -6,7 +6,7 @@ from torchvision.transforms import ColorJitter
 
 import albumentations as A
 from albumentations.pytorch.transforms import ToTensorV2
-from tests.conftest import UINT8_IMAGES
+from tests.conftest import RECTANGULAR_UINT8_IMAGE, UINT8_IMAGES
 from .utils import set_seed
 
 
@@ -225,3 +225,46 @@ def test_post_data_check():
     assert len(res["keypoints"]) != 0 and len(res["bboxes"]) != 0
     np.testing.assert_array_equal(res["keypoints"], [(45, 45), (25, 25)])
     np.testing.assert_array_equal(res["bboxes"], [(0, 0, 45, 45, 0)])
+
+
+def test_to_tensor_v2_on_non_contiguous_array():
+    # Create a contiguous array
+    img = np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)
+    assert img.flags["C_CONTIGUOUS"]
+
+    # Create a non-contiguous array by slicing
+    non_contiguous_img = img[::2, ::2, :]
+    assert not non_contiguous_img.flags["C_CONTIGUOUS"]
+
+    transform = A.Compose([ToTensorV2()])
+    transformed = transform(image=non_contiguous_img, masks=[non_contiguous_img] * 2)["image"]
+
+    # Check that the output is a contiguous tensor
+    assert transformed.is_contiguous()
+
+    # Additional checks to ensure the transformation worked correctly
+    assert isinstance(transformed, torch.Tensor)
+    assert transformed.shape == (3, 50, 50)  # Shape changed due to slicing
+    assert transformed.dtype == torch.uint8
+
+    # Optional: Check that the content is correct
+    np_transformed = transformed.numpy()
+    np.testing.assert_array_equal(np_transformed.transpose(1, 2, 0), non_contiguous_img)
+
+
+def test_to_tensor_v2_on_non_contiguous_array_with_horizontal_flip():
+    transform= A.Compose([
+        A.HorizontalFlip(p=1),
+        A.ToFloat(max_value=255),
+        ToTensorV2()
+    ],is_check_shapes=False)
+
+    image = RECTANGULAR_UINT8_IMAGE
+
+    masks = [image[:, :, 0]] * 2
+
+    transformed = transform(image=image, masks=masks)
+
+    assert transformed["image"].flags["C_CONTIGUOUS"]
+    assert transformed["masks"][0].flags["C_CONTIGUOUS"]
+    assert transformed["masks"][1].flags["C_CONTIGUOUS"]

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -237,18 +237,15 @@ def test_to_tensor_v2_on_non_contiguous_array():
     assert not non_contiguous_img.flags["C_CONTIGUOUS"]
 
     transform = A.Compose([ToTensorV2()])
-    transformed = transform(image=non_contiguous_img, masks=[non_contiguous_img] * 2)["image"]
-
-    # Check that the output is a contiguous tensor
-    assert transformed.is_contiguous()
+    transformed = transform(image=non_contiguous_img, masks=[non_contiguous_img] * 2)
 
     # Additional checks to ensure the transformation worked correctly
-    assert isinstance(transformed, torch.Tensor)
-    assert transformed.shape == (3, 50, 50)  # Shape changed due to slicing
-    assert transformed.dtype == torch.uint8
+    assert isinstance(transformed["image"], torch.Tensor)
+    assert transformed["image"].shape == (3, 50, 50)  # Shape changed due to slicing
+    assert transformed["image"].dtype == torch.uint8
 
     # Optional: Check that the content is correct
-    np_transformed = transformed.numpy()
+    np_transformed = transformed["image"].numpy()
     np.testing.assert_array_equal(np_transformed.transpose(1, 2, 0), non_contiguous_img)
 
 
@@ -263,8 +260,4 @@ def test_to_tensor_v2_on_non_contiguous_array_with_horizontal_flip():
 
     masks = [image[:, :, 0]] * 2
 
-    transformed = transform(image=image, masks=masks)
-
-    assert transformed["image"].flags["C_CONTIGUOUS"]
-    assert transformed["masks"][0].flags["C_CONTIGUOUS"]
-    assert transformed["masks"][1].flags["C_CONTIGUOUS"]
+    transform(image=image, masks=masks)


### PR DESCRIPTION
Extra tests for the case https://github.com/albumentations-team/albumentations/issues/1935

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce additional tests for ToTensorV2 to handle non-contiguous arrays, update pre-commit hooks to newer versions, and enhance type annotations in the FancyPCA class.

Enhancements:
- Clarify the type annotation for the 'alpha' parameter in the FancyPCA class to support both float and tuple of floats.

Build:
- Update pre-commit configuration to use newer versions of ruff and pyproject-fmt.

Tests:
- Add tests for ToTensorV2 transformation on non-contiguous arrays to ensure correct handling and output as contiguous tensors.

<!-- Generated by sourcery-ai[bot]: end summary -->