### PR TITLE
Fix small box filtering

### DIFF
--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -475,10 +475,7 @@ def filter_bboxes(
     filtered_bboxes = clipped_bboxes[mask]
 
     # If no bboxes pass the filter, return an empty array with the same number of columns as input
-    if len(filtered_bboxes) == 0:
-        return np.array([], dtype=np.float32)
-
-    return filtered_bboxes
+    return filtered_bboxes if len(filtered_bboxes) > 0 else np.array([], dtype=np.float32)
 
 
 def union_of_bboxes(bboxes: np.ndarray, erosion_rate: float) -> np.ndarray | None:

--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -21,7 +21,6 @@ __all__ = [
 ]
 
 BBOX_WITH_LABEL_SHAPE = 5
-EPSILON = 1e-5
 
 
 class BboxParams(Params):
@@ -443,6 +442,8 @@ def filter_bboxes(
     Returns:
         numpy array of filtered bounding boxes.
     """
+    epsilon = 1e-7
+
     if len(bboxes) == 0:
         return np.array([], dtype=np.float32)
 
@@ -463,11 +464,11 @@ def filter_bboxes(
 
     # Create a mask for bboxes that meet all criteria
     mask = (
-        (denormalized_box_areas >= EPSILON)
-        & (clipped_box_areas >= min_area - EPSILON)
-        & (clipped_box_areas / denormalized_box_areas >= min_visibility - EPSILON)
-        & (clipped_widths >= min_width - EPSILON)
-        & (clipped_heights >= min_height - EPSILON)
+        (denormalized_box_areas >= epsilon)
+        & (clipped_box_areas >= min_area - epsilon)
+        & (clipped_box_areas / denormalized_box_areas >= min_visibility - epsilon)
+        & (clipped_widths >= min_width - epsilon)
+        & (clipped_heights >= min_height - epsilon)
     )
 
     # Apply the mask to get the filtered bboxes
@@ -484,7 +485,7 @@ def union_of_bboxes(bboxes: np.ndarray, erosion_rate: float) -> np.ndarray | Non
     """Calculate union of bounding boxes. Boxes could be in albumentations or Pascal Voc format.
 
     Args:
-        bboxes (list[tuple]): List of bounding boxes
+        bboxes (np.ndarray): List of bounding boxes
         erosion_rate (float): How much each bounding box can be shrunk, useful for erosive cropping.
             Set this in range [0, 1]. 0 will not be erosive at all, 1.0 can make any bbox lose its volume.
 
@@ -501,6 +502,8 @@ def union_of_bboxes(bboxes: np.ndarray, erosion_rate: float) -> np.ndarray | Non
     if bboxes.shape[0] == 1:
         return bboxes[0][:4]
 
+    epsilon = 1e-6
+
     x_min, y_min = np.min(bboxes[:, :2], axis=0)
     x_max, y_max = np.max(bboxes[:, 2:4], axis=0)
 
@@ -515,7 +518,7 @@ def union_of_bboxes(bboxes: np.ndarray, erosion_rate: float) -> np.ndarray | Non
     x_max -= erosion_x
     y_max -= erosion_y
 
-    if abs(x_max - x_min) < EPSILON or abs(y_max - y_min) < EPSILON:
+    if abs(x_max - x_min) < epsilon or abs(y_max - y_min) < epsilon:
         return None
 
     return np.array([x_min, y_min, x_max, y_max], dtype=np.float32)

--- a/albumentations/core/utils.py
+++ b/albumentations/core/utils.py
@@ -123,7 +123,6 @@ class DataProcessor(ABC):
                 self.is_sequence_input[data_name] = False
 
         data = self.add_label_fields_to_data(data)
-
         for data_name in set(self.data_fields) & set(data.keys()):
             data[data_name] = self.check_and_convert(data[data_name], image_shape, direction="to")
 
@@ -190,6 +189,8 @@ class DataProcessor(ABC):
 
                 data_array = np.hstack((data_array, encoded_labels))
 
+                del data[label_field]
+
             data[data_name] = data_array
         return data
 
@@ -200,6 +201,8 @@ class DataProcessor(ABC):
         for data_name in set(self.data_fields) & set(data.keys()):
             data_array = data[data_name]
             if not data_array.size:
+                for label_field in self.params.label_fields:
+                    data[label_field] = []
                 continue
 
             num_label_fields = len(self.params.label_fields)

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -1205,11 +1205,42 @@ def test_bbox_d4(bbox, group_member, expected):
     np.testing.assert_array_almost_equal(result, expected)
 
 
-def test_less_1_pixel_bbox():
+@pytest.mark.parametrize("bbox_format, bbox, expected", [
+    ("coco", [[1.0, 1.0, 0.75, 0.75]], [[1.0, 1.0, 0.75, 0.75]]),
+    ("coco", [[1.0, 1.0, 1E-3, 1E-3]], [[1.0, 1.0, 1E-3, 1E-3]]),
+    ("yolo", [[0.25, 0.25, 0.1875, 0.1875]], [[0.25, 0.25, 0.1875, 0.1875]]),
+    ("yolo", [[0.25, 0.25, 1E-3, 1E-3]], [[0.25, 0.25, 1E-3, 1E-3]]),
+    ("yolo", [[0.1, 0.2, 1E-3, 1E-3]], [[0.1, 0.2, 1E-3, 1E-3]]),
+    ("pascal_voc", [[1, 1, 2, 2]], [[1, 1, 2, 2]]),
+    ("pascal_voc", [[1, 1, 1.004, 1.004]], [[1, 1, 1.004, 1.004]]),
+])
+def test_small_bbox(bbox_format, bbox, expected):
     transform = A.Compose(
-    [A.NoOp()],
-        bbox_params=A.BboxParams(format="coco", label_fields=["category_id"]),
+        [A.NoOp()],
+        bbox_params=A.BboxParams(format=bbox_format, label_fields=["category_id"]),
     )
-    transformed = transform(image=np.zeros((4, 4, 3), dtype=np.uint8), bboxes=[[1.0, 1.0, 0.75, 0.75]], category_id=[1])
+    transformed = transform(
+        image=np.zeros((4, 4, 3), dtype=np.uint8),
+        bboxes=bbox,
+        category_id=[1] * len(bbox)
+    )
 
-    np.testing.assert_array_almost_equal(transformed["bboxes"], [[1.0, 1.0, 0.75, 0.75]])
+    np.testing.assert_array_almost_equal(transformed["bboxes"], expected)
+
+@pytest.mark.parametrize("bbox_format, bbox", [
+    ("coco", np.array((0.1, 0.2, 1E-3, 1E-3))),
+    ("yolo", np.array((0.1, 0.2, 1E-3, 1E-3))),
+    ("pascal_voc", np.array((1, 1, 1.001, 1.001))),
+])
+def test_very_small_bbox(bbox_format, bbox):
+    transform = A.Compose(
+        [A.NoOp()],
+        bbox_params=A.BboxParams(format=bbox_format, label_fields=["category_id"]),
+    )
+    transformed = transform(
+        image=np.zeros((100, 100, 3), dtype=np.uint8),
+        bboxes=[bbox],
+        category_id=[1]
+    )
+
+    np.testing.assert_array_almost_equal(transformed["bboxes"], [bbox])

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -1243,20 +1243,24 @@ def test_small_bbox(bbox_format, bbox, expected):
 
     np.testing.assert_array_almost_equal(transformed["bboxes"], expected)
 
-@pytest.mark.parametrize("bbox_format, bbox", [
-    ("coco", np.array((0.1, 0.2, 1E-3, 1E-3))),
-    ("yolo", np.array((0.1, 0.2, 1E-3, 1E-3))),
-    ("pascal_voc", np.array((1, 1, 1.001, 1.001))),
+@pytest.mark.parametrize("bbox_format, bboxes, expected", [
+    ("coco", np.array([[0.1, 0.2, 1E-3, 1E-3]]), np.array([[0.1, 0.2, 1E-3, 1E-3]])),
+    ("yolo", np.array([[0.1, 0.2, 1E-3, 1E-3]]), np.array([[0.1, 0.2, 1E-3, 1E-3]])),
+    ("pascal_voc", np.array([[1, 1, 1.001, 1.001]]), np.array([[1, 1, 1.001, 1.001]])),
 ])
-def test_very_small_bbox(bbox_format, bbox):
+def test_very_small_bbox(bbox_format, bboxes, expected):
     transform = A.Compose(
         [A.NoOp()],
         bbox_params=A.BboxParams(format=bbox_format, label_fields=["category_id"]),
     )
+
+    categories = [1]
+
     transformed = transform(
         image=np.zeros((100, 100, 3), dtype=np.uint8),
-        bboxes=[bbox],
-        category_id=[1]
+        bboxes=bboxes,
+        category_id=categories
     )
 
-    np.testing.assert_array_almost_equal(transformed["bboxes"], [bbox])
+    np.testing.assert_array_almost_equal(transformed["bboxes"], expected)
+    np.testing.assert_array_almost_equal(transformed["category_id"], categories)

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -565,6 +565,22 @@ def test_filter_bboxes_clipping():
     np.testing.assert_allclose(result, expected, rtol=1e-5)
 
 
+
+def test_filter_bboxes_noop():
+    in_data = dict(
+    image=np.ones((100, 100, 3)),
+    bboxes=np.array([[0.1, 0.2, 1E-3, 1E-3]]),
+    classes=np.array([1]),
+    )
+    bbox_conf = A.core.bbox_utils.BboxParams(format="yolo", label_fields=["classes"], min_area=1.)
+    transf = A.Compose([A.NoOp(p=1.)], bbox_params=bbox_conf, is_check_shapes=False)
+
+    out_data = transf(**in_data)
+
+    assert out_data["bboxes"].shape[0] == 0
+    assert len(out_data["classes"]) == 0
+
+
 @pytest.mark.parametrize("bboxes, erosion_rate, expected", [
     (np.array([[0.1, 0.1, 0.5, 0.5], [0.2, 0.2, 0.6, 0.6]]), 0, np.array([0.1, 0.1, 0.6, 0.6])),
     (np.array([[0.1, 0.1, 0.5, 0.5], [0.2, 0.2, 0.6, 0.6]]), 0.5, np.array([0.225, 0.225, 0.475, 0.475])),


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/1941

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the small box filtering issue by adjusting the epsilon value in the bounding box filtering logic and add new test cases to ensure correct behavior across different bounding box formats.

Bug Fixes:
- Fix small box filtering by adjusting the epsilon value used in bounding box filtering logic to ensure that very small boxes are correctly filtered out.

Tests:
- Add new test cases to verify the correct filtering of very small bounding boxes across different formats, ensuring that boxes below a certain size are removed.

<!-- Generated by sourcery-ai[bot]: end summary -->