### PR TITLE
use the same interpolation for image and mask for Rotate

### DIFF
--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -151,7 +151,7 @@ class Rotate(DualTransform):
         y_max: int,
         **params: Any,
     ) -> np.ndarray:
-        img_out = fgeometric.rotate(mask, angle, cv2.INTER_NEAREST, self.border_mode, self.mask_value)
+        img_out = fgeometric.rotate(mask, angle, self.interpolation, self.border_mode, self.mask_value)
         if self.crop_border:
             return fcrops.crop(img_out, x_min, y_min, x_max, y_max)
         return img_out


### PR DESCRIPTION
Change to use the same interpolation for image and mask in Rotate augmentation. Originally Rotate always forces cv2.INTER_NEAREST for masks which causes unexpected artifacts, especially for heatmap masks

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the Rotate augmentation to use the same interpolation method for both images and masks, addressing issues with artifacts caused by the previous forced use of cv2.INTER_NEAREST for masks.

Bug Fixes:
- Ensure consistent interpolation for images and masks in the Rotate augmentation to prevent artifacts, especially in heatmap masks.

<!-- Generated by sourcery-ai[bot]: end summary -->