### PR TITLE
Added support for masks like numpy array (num_masks, height, width)

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -429,7 +429,7 @@ class Compose(BaseCompose, HubMixin):
         if isinstance(data, Sequence):
             if not all(isinstance(m, np.ndarray) for m in data):
                 raise TypeError(f"All elements in {data_name} must be numpy arrays")
-            if not all(m.ndim in [2, 3] for m in data):
+            if any(m.ndim not in [2, 3] for m in data):
                 raise TypeError(f"All masks in {data_name} must be 2D or 3D numpy arrays")
             return data[0].shape[:2]
 

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -347,19 +347,18 @@ class DualTransform(BasicTransform):
         apply_to_keypoints(keypoints: np.ndarray, **params: Any) -> np.ndarray:
             Apply the transform to keypoints.
 
-            keypoints: Array of shape (N, 2) where N is the number of keypoints.
+            keypoints: Array of shape (N, 2+) where N is the number of keypoints.
                 **params: Additional parameters specific to the transform.
-            Returns Transformed keypoints array of shape (N, 2).
+            Returns Transformed keypoints array of shape (N, 2+).
 
         apply_to_bboxes(bboxes: np.ndarray, **params: Any) -> np.ndarray:
             Apply the transform to bounding boxes.
 
-
-            bboxes: Array of shape (N, 4) where N is the number of bounding boxes,
+            bboxes: Array of shape (N, 4+) where N is the number of bounding boxes,
                     and each row is in the format [x_min, y_min, x_max, y_max].
             **params: Additional parameters specific to the transform.
 
-            Returns Transformed bounding boxes array of shape (N, 4).
+            Returns Transformed bounding boxes array of shape (N, 4+).
 
     Note:
         - All `apply_*` methods should maintain the input shape and format of the data.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1234,3 +1234,68 @@ def test_non_contiguous_input_with_compose(augmentation_cls, params, bboxes):
     # Check if the augmentation is not an ImageOnlyTransform and mask is in the output
     if not issubclass(augmentation_cls, ImageOnlyTransform) and "mask" in transformed:
         assert transformed["mask"].flags["C_CONTIGUOUS"], f"{augmentation_cls.__name__} did not return a C_CONTIGUOUS mask"
+
+
+@pytest.mark.parametrize(
+    ["augmentation_cls", "params"],
+    get_transforms(
+        custom_arguments={
+            A.Crop: {"y_min": 0, "y_max": 10, "x_min": 0, "x_max": 10},
+            A.CenterCrop: {"height": 10, "width": 10},
+            A.CropNonEmptyMaskIfExists: {"height": 10, "width": 10},
+            A.RandomCrop: {"height": 10, "width": 10},
+            A.RandomResizedCrop: {"size": (10, 10)},
+            A.RandomSizedCrop: {"min_max_height": (4, 8), "size" : (10, 10)},
+            A.CropAndPad: {"px": 10},
+            A.Resize: {"height": 10, "width": 10},
+            A.XYMasking: {
+                "num_masks_x": (1, 3),
+                "num_masks_y": 3,
+                "mask_x_length": (10, 20),
+                "mask_y_length": 10,
+                "fill_value": 0,
+                "mask_fill_value": 1,
+            },
+            A.PadIfNeeded: {
+                "min_height": 512,
+                "min_width": 512,
+                "border_mode": 0,
+                "value": [124, 116, 104],
+                "position": "top_left"
+            },
+            A.GridElasticDeform: {"num_grid_xy": (10, 10), "magnitude": 10},
+            A.PixelDistributionAdaptation: {
+                "reference_images": [np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)],
+                "read_fn": lambda x: x,
+                "transform_type": "standard",
+            },
+        },
+        except_augmentations={
+            A.FDA,
+            A.HistogramMatching,
+            A.Lambda,
+            A.TemplateTransform,
+            A.MixUp,
+            A.RandomSizedBBoxSafeCrop,
+            A.MaskDropout,
+            A.CropNonEmptyMaskIfExists,
+            A.BBoxSafeRandomCrop,
+            A.OverlayElements,
+            A.TextImage,
+            A.FromFloat
+        },
+    ),
+)
+@pytest.mark.parametrize("masks", [[np.random.randint(0, 1, [100, 100], dtype=np.uint8)] * 2,
+                                   [np.random.randint(0, 1, [100, 100, 3], dtype=np.uint8)] * 2,
+                                   np.random.randint(0, 1, [2, 100, 100], dtype=np.uint8)])
+def test_masks_as_target(augmentation_cls, params, masks):
+    image = SQUARE_UINT8_IMAGE
+
+    aug = A.Compose(
+        [augmentation_cls(p=1, **params)]
+    )
+
+    transformed = aug(image=image, masks=masks)
+
+    np.testing.assert_array_equal(transformed["masks"][0], transformed["masks"][1])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1286,9 +1286,9 @@ def test_non_contiguous_input_with_compose(augmentation_cls, params, bboxes):
         },
     ),
 )
-@pytest.mark.parametrize("masks", [[np.random.randint(0, 1, [100, 100], dtype=np.uint8)] * 2,
-                                   [np.random.randint(0, 1, [100, 100, 3], dtype=np.uint8)] * 2,
-                                   np.random.randint(0, 1, [2, 100, 100], dtype=np.uint8)])
+@pytest.mark.parametrize("masks", [[np.random.randint(0, 2, [100, 100], dtype=np.uint8)] * 2,
+                                   [np.random.randint(0, 2, [100, 100, 3], dtype=np.uint8)] * 2,
+                                   np.stack([np.random.randint(0, 2, [100, 100], dtype=np.uint8)] * 2)])
 def test_masks_as_target(augmentation_cls, params, masks):
     image = SQUARE_UINT8_IMAGE
 
@@ -1299,3 +1299,5 @@ def test_masks_as_target(augmentation_cls, params, masks):
     transformed = aug(image=image, masks=masks)
 
     np.testing.assert_array_equal(transformed["masks"][0], transformed["masks"][1])
+
+    assert transformed["masks"][0].dtype == masks[0].dtype


### PR DESCRIPTION
Should fix:

https://github.com/albumentations-team/albumentations/issues/1958

https://github.com/albumentations-team/albucore/issues/35

## Summary by Sourcery

Add support for transformations on masks structured as 3D numpy arrays, enhancing the flexibility of mask handling in the library. Refactor transformation methods to accommodate both single and multiple masks, and introduce tests to ensure the correctness of these transformations.

New Features:
- Add support for applying transformations to masks represented as 3D numpy arrays with shape (num_masks, height, width) or (height, width, num_masks).

Enhancements:
- Refactor the transformation methods to handle both single masks and sequences of masks, ensuring consistent application across different data formats.

Tests:
- Introduce new tests to verify the correct handling of masks as transformation targets, including various mask shapes and configurations.