### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,105 +157,105 @@ Check the [online demo of the library](https://albumentations-demo.herokuapp.com
 
 Pixel-level transforms will change just an input image and will leave any additional targets such as masks, bounding boxes, and keypoints unchanged. The list of pixel-level transforms:
 
-- [AdvancedBlur](https://albumentations.ai/docs/api_reference/augmentations/blur/transforms/#albumentations.augmentations.blur.transforms.AdvancedBlur)
-- [Blur](https://albumentations.ai/docs/api_reference/augmentations/blur/transforms/#albumentations.augmentations.blur.transforms.Blur)
-- [CLAHE](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.CLAHE)
-- [ChannelDropout](https://albumentations.ai/docs/api_reference/augmentations/dropout/channel_dropout/#albumentations.augmentations.dropout.channel_dropout.ChannelDropout)
-- [ChannelShuffle](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.ChannelShuffle)
-- [ChromaticAberration](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.ChromaticAberration)
-- [ColorJitter](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.ColorJitter)
-- [Defocus](https://albumentations.ai/docs/api_reference/augmentations/blur/transforms/#albumentations.augmentations.blur.transforms.Defocus)
-- [Downscale](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.Downscale)
-- [Emboss](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.Emboss)
-- [Equalize](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.Equalize)
-- [FDA](https://albumentations.ai/docs/api_reference/augmentations/domain_adaptation/#albumentations.augmentations.domain_adaptation.FDA)
-- [FancyPCA](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.FancyPCA)
-- [FromFloat](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.FromFloat)
-- [GaussNoise](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.GaussNoise)
-- [GaussianBlur](https://albumentations.ai/docs/api_reference/augmentations/blur/transforms/#albumentations.augmentations.blur.transforms.GaussianBlur)
-- [GlassBlur](https://albumentations.ai/docs/api_reference/augmentations/blur/transforms/#albumentations.augmentations.blur.transforms.GlassBlur)
-- [HistogramMatching](https://albumentations.ai/docs/api_reference/augmentations/domain_adaptation/#albumentations.augmentations.domain_adaptation.HistogramMatching)
-- [HueSaturationValue](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.HueSaturationValue)
-- [ISONoise](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.ISONoise)
-- [ImageCompression](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.ImageCompression)
-- [InvertImg](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.InvertImg)
-- [MedianBlur](https://albumentations.ai/docs/api_reference/augmentations/blur/transforms/#albumentations.augmentations.blur.transforms.MedianBlur)
-- [MotionBlur](https://albumentations.ai/docs/api_reference/augmentations/blur/transforms/#albumentations.augmentations.blur.transforms.MotionBlur)
-- [MultiplicativeNoise](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.MultiplicativeNoise)
-- [Normalize](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.Normalize)
-- [PixelDistributionAdaptation](https://albumentations.ai/docs/api_reference/augmentations/domain_adaptation/#albumentations.augmentations.domain_adaptation.PixelDistributionAdaptation)
-- [PlanckianJitter](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.PlanckianJitter)
-- [Posterize](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.Posterize)
-- [RGBShift](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.RGBShift)
-- [RandomBrightnessContrast](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.RandomBrightnessContrast)
-- [RandomFog](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.RandomFog)
-- [RandomGamma](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.RandomGamma)
-- [RandomGravel](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.RandomGravel)
-- [RandomRain](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.RandomRain)
-- [RandomShadow](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.RandomShadow)
-- [RandomSnow](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.RandomSnow)
-- [RandomSunFlare](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.RandomSunFlare)
-- [RandomToneCurve](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.RandomToneCurve)
-- [RingingOvershoot](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.RingingOvershoot)
-- [Sharpen](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.Sharpen)
-- [Solarize](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.Solarize)
-- [Spatter](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.Spatter)
-- [Superpixels](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.Superpixels)
-- [TemplateTransform](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.TemplateTransform)
-- [TextImage](https://albumentations.ai/docs/api_reference/augmentations/text/transforms/#albumentations.augmentations.text.transforms.TextImage)
-- [ToFloat](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.ToFloat)
-- [ToGray](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.ToGray)
-- [ToRGB](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.ToRGB)
-- [ToSepia](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.ToSepia)
-- [UnsharpMask](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.UnsharpMask)
-- [ZoomBlur](https://albumentations.ai/docs/api_reference/augmentations/blur/transforms/#albumentations.augmentations.blur.transforms.ZoomBlur)
+- [AdvancedBlur](https://explore.albumentations.ai/transform/AdvancedBlur)
+- [Blur](https://explore.albumentations.ai/transform/Blur)
+- [CLAHE](https://explore.albumentations.ai/transform/CLAHE)
+- [ChannelDropout](https://explore.albumentations.ai/transform/ChannelDropout)
+- [ChannelShuffle](https://explore.albumentations.ai/transform/ChannelShuffle)
+- [ChromaticAberration](https://explore.albumentations.ai/transform/ChromaticAberration)
+- [ColorJitter](https://explore.albumentations.ai/transform/ColorJitter)
+- [Defocus](https://explore.albumentations.ai/transform/Defocus)
+- [Downscale](https://explore.albumentations.ai/transform/Downscale)
+- [Emboss](https://explore.albumentations.ai/transform/Emboss)
+- [Equalize](https://explore.albumentations.ai/transform/Equalize)
+- [FDA](https://explore.albumentations.ai/transform/FDA)
+- [FancyPCA](https://explore.albumentations.ai/transform/FancyPCA)
+- [FromFloat](https://explore.albumentations.ai/transform/FromFloat)
+- [GaussNoise](https://explore.albumentations.ai/transform/GaussNoise)
+- [GaussianBlur](https://explore.albumentations.ai/transform/GaussianBlur)
+- [GlassBlur](https://explore.albumentations.ai/transform/GlassBlur)
+- [HistogramMatching](https://explore.albumentations.ai/transform/HistogramMatching)
+- [HueSaturationValue](https://explore.albumentations.ai/transform/HueSaturationValue)
+- [ISONoise](https://explore.albumentations.ai/transform/ISONoise)
+- [ImageCompression](https://explore.albumentations.ai/transform/ImageCompression)
+- [InvertImg](https://explore.albumentations.ai/transform/InvertImg)
+- [MedianBlur](https://explore.albumentations.ai/transform/MedianBlur)
+- [MotionBlur](https://explore.albumentations.ai/transform/MotionBlur)
+- [MultiplicativeNoise](https://explore.albumentations.ai/transform/MultiplicativeNoise)
+- [Normalize](https://explore.albumentations.ai/transform/Normalize)
+- [PixelDistributionAdaptation](https://explore.albumentations.ai/transform/PixelDistributionAdaptation)
+- [PlanckianJitter](https://explore.albumentations.ai/transform/PlanckianJitter)
+- [Posterize](https://explore.albumentations.ai/transform/Posterize)
+- [RGBShift](https://explore.albumentations.ai/transform/RGBShift)
+- [RandomBrightnessContrast](https://explore.albumentations.ai/transform/RandomBrightnessContrast)
+- [RandomFog](https://explore.albumentations.ai/transform/RandomFog)
+- [RandomGamma](https://explore.albumentations.ai/transform/RandomGamma)
+- [RandomGravel](https://explore.albumentations.ai/transform/RandomGravel)
+- [RandomRain](https://explore.albumentations.ai/transform/RandomRain)
+- [RandomShadow](https://explore.albumentations.ai/transform/RandomShadow)
+- [RandomSnow](https://explore.albumentations.ai/transform/RandomSnow)
+- [RandomSunFlare](https://explore.albumentations.ai/transform/RandomSunFlare)
+- [RandomToneCurve](https://explore.albumentations.ai/transform/RandomToneCurve)
+- [RingingOvershoot](https://explore.albumentations.ai/transform/RingingOvershoot)
+- [Sharpen](https://explore.albumentations.ai/transform/Sharpen)
+- [Solarize](https://explore.albumentations.ai/transform/Solarize)
+- [Spatter](https://explore.albumentations.ai/transform/Spatter)
+- [Superpixels](https://explore.albumentations.ai/transform/Superpixels)
+- [TemplateTransform](https://explore.albumentations.ai/transform/TemplateTransform)
+- [TextImage](https://explore.albumentations.ai/transform/TextImage)
+- [ToFloat](https://explore.albumentations.ai/transform/ToFloat)
+- [ToGray](https://explore.albumentations.ai/transform/ToGray)
+- [ToRGB](https://explore.albumentations.ai/transform/ToRGB)
+- [ToSepia](https://explore.albumentations.ai/transform/ToSepia)
+- [UnsharpMask](https://explore.albumentations.ai/transform/UnsharpMask)
+- [ZoomBlur](https://explore.albumentations.ai/transform/ZoomBlur)
 
 ### Spatial-level transforms
 
 Spatial-level transforms will simultaneously change both an input image as well as additional targets such as masks, bounding boxes, and keypoints. The following table shows which additional targets are supported by each transform.
 
-| Transform                                                                                                                                                                       | Image | Mask | BBoxes | Keypoints |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---: | :--: | :----: | :-------: |
-| [Affine](https://albumentations.ai/docs/api_reference/augmentations/geometric/transforms/#albumentations.augmentations.geometric.transforms.Affine)                             | ✓     | ✓    | ✓      | ✓         |
-| [BBoxSafeRandomCrop](https://albumentations.ai/docs/api_reference/augmentations/crops/transforms/#albumentations.augmentations.crops.transforms.BBoxSafeRandomCrop)             | ✓     | ✓    | ✓      | ✓         |
-| [CenterCrop](https://albumentations.ai/docs/api_reference/augmentations/crops/transforms/#albumentations.augmentations.crops.transforms.CenterCrop)                             | ✓     | ✓    | ✓      | ✓         |
-| [CoarseDropout](https://albumentations.ai/docs/api_reference/augmentations/dropout/coarse_dropout/#albumentations.augmentations.dropout.coarse_dropout.CoarseDropout)           | ✓     | ✓    | ✓      | ✓         |
-| [Crop](https://albumentations.ai/docs/api_reference/augmentations/crops/transforms/#albumentations.augmentations.crops.transforms.Crop)                                         | ✓     | ✓    | ✓      | ✓         |
-| [CropAndPad](https://albumentations.ai/docs/api_reference/augmentations/crops/transforms/#albumentations.augmentations.crops.transforms.CropAndPad)                             | ✓     | ✓    | ✓      | ✓         |
-| [CropNonEmptyMaskIfExists](https://albumentations.ai/docs/api_reference/augmentations/crops/transforms/#albumentations.augmentations.crops.transforms.CropNonEmptyMaskIfExists) | ✓     | ✓    | ✓      | ✓         |
-| [D4](https://albumentations.ai/docs/api_reference/augmentations/geometric/transforms/#albumentations.augmentations.geometric.transforms.D4)                                     | ✓     | ✓    | ✓      | ✓         |
-| [ElasticTransform](https://albumentations.ai/docs/api_reference/augmentations/geometric/transforms/#albumentations.augmentations.geometric.transforms.ElasticTransform)         | ✓     | ✓    | ✓      | ✓         |
-| [GridDistortion](https://albumentations.ai/docs/api_reference/augmentations/geometric/transforms/#albumentations.augmentations.geometric.transforms.GridDistortion)             | ✓     | ✓    | ✓      | ✓         |
-| [GridDropout](https://albumentations.ai/docs/api_reference/augmentations/dropout/grid_dropout/#albumentations.augmentations.dropout.grid_dropout.GridDropout)                   | ✓     | ✓    | ✓      | ✓         |
-| [GridElasticDeform](https://albumentations.ai/docs/api_reference/augmentations/geometric/transforms/#albumentations.augmentations.geometric.transforms.GridElasticDeform)       | ✓     | ✓    | ✓      | ✓         |
-| [HorizontalFlip](https://albumentations.ai/docs/api_reference/augmentations/geometric/transforms/#albumentations.augmentations.geometric.transforms.HorizontalFlip)             | ✓     | ✓    | ✓      | ✓         |
-| [Lambda](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.Lambda)                                                 | ✓     | ✓    | ✓      | ✓         |
-| [LongestMaxSize](https://albumentations.ai/docs/api_reference/augmentations/geometric/resize/#albumentations.augmentations.geometric.resize.LongestMaxSize)                     | ✓     | ✓    | ✓      | ✓         |
-| [MaskDropout](https://albumentations.ai/docs/api_reference/augmentations/dropout/mask_dropout/#albumentations.augmentations.dropout.mask_dropout.MaskDropout)                   | ✓     | ✓    | ✓      | ✓         |
-| [Morphological](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.Morphological)                                   | ✓     | ✓    | ✓      | ✓         |
-| [NoOp](https://albumentations.ai/docs/api_reference/core/transforms_interface/#albumentations.core.transforms_interface.NoOp)                                                   | ✓     | ✓    | ✓      | ✓         |
-| [OpticalDistortion](https://albumentations.ai/docs/api_reference/augmentations/geometric/transforms/#albumentations.augmentations.geometric.transforms.OpticalDistortion)       | ✓     | ✓    | ✓      | ✓         |
-| [OverlayElements](https://albumentations.ai/docs/api_reference/augmentations/mixing/transforms/#albumentations.augmentations.mixing.transforms.OverlayElements)                 | ✓     | ✓    |        |           |
-| [PadIfNeeded](https://albumentations.ai/docs/api_reference/augmentations/geometric/transforms/#albumentations.augmentations.geometric.transforms.PadIfNeeded)                   | ✓     | ✓    | ✓      | ✓         |
-| [Perspective](https://albumentations.ai/docs/api_reference/augmentations/geometric/transforms/#albumentations.augmentations.geometric.transforms.Perspective)                   | ✓     | ✓    | ✓      | ✓         |
-| [PiecewiseAffine](https://albumentations.ai/docs/api_reference/augmentations/geometric/transforms/#albumentations.augmentations.geometric.transforms.PiecewiseAffine)           | ✓     | ✓    | ✓      | ✓         |
-| [PixelDropout](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.PixelDropout)                                     | ✓     | ✓    | ✓      | ✓         |
-| [RandomCrop](https://albumentations.ai/docs/api_reference/augmentations/crops/transforms/#albumentations.augmentations.crops.transforms.RandomCrop)                             | ✓     | ✓    | ✓      | ✓         |
-| [RandomCropFromBorders](https://albumentations.ai/docs/api_reference/augmentations/crops/transforms/#albumentations.augmentations.crops.transforms.RandomCropFromBorders)       | ✓     | ✓    | ✓      | ✓         |
-| [RandomGridShuffle](https://albumentations.ai/docs/api_reference/augmentations/transforms/#albumentations.augmentations.transforms.RandomGridShuffle)                           | ✓     | ✓    |        | ✓         |
-| [RandomResizedCrop](https://albumentations.ai/docs/api_reference/augmentations/crops/transforms/#albumentations.augmentations.crops.transforms.RandomResizedCrop)               | ✓     | ✓    | ✓      | ✓         |
-| [RandomRotate90](https://albumentations.ai/docs/api_reference/augmentations/geometric/rotate/#albumentations.augmentations.geometric.rotate.RandomRotate90)                     | ✓     | ✓    | ✓      | ✓         |
-| [RandomScale](https://albumentations.ai/docs/api_reference/augmentations/geometric/resize/#albumentations.augmentations.geometric.resize.RandomScale)                           | ✓     | ✓    | ✓      | ✓         |
-| [RandomSizedBBoxSafeCrop](https://albumentations.ai/docs/api_reference/augmentations/crops/transforms/#albumentations.augmentations.crops.transforms.RandomSizedBBoxSafeCrop)   | ✓     | ✓    | ✓      | ✓         |
-| [RandomSizedCrop](https://albumentations.ai/docs/api_reference/augmentations/crops/transforms/#albumentations.augmentations.crops.transforms.RandomSizedCrop)                   | ✓     | ✓    | ✓      | ✓         |
-| [Resize](https://albumentations.ai/docs/api_reference/augmentations/geometric/resize/#albumentations.augmentations.geometric.resize.Resize)                                     | ✓     | ✓    | ✓      | ✓         |
-| [Rotate](https://albumentations.ai/docs/api_reference/augmentations/geometric/rotate/#albumentations.augmentations.geometric.rotate.Rotate)                                     | ✓     | ✓    | ✓      | ✓         |
-| [SafeRotate](https://albumentations.ai/docs/api_reference/augmentations/geometric/rotate/#albumentations.augmentations.geometric.rotate.SafeRotate)                             | ✓     | ✓    | ✓      | ✓         |
-| [ShiftScaleRotate](https://albumentations.ai/docs/api_reference/augmentations/geometric/transforms/#albumentations.augmentations.geometric.transforms.ShiftScaleRotate)         | ✓     | ✓    | ✓      | ✓         |
-| [SmallestMaxSize](https://albumentations.ai/docs/api_reference/augmentations/geometric/resize/#albumentations.augmentations.geometric.resize.SmallestMaxSize)                   | ✓     | ✓    | ✓      | ✓         |
-| [Transpose](https://albumentations.ai/docs/api_reference/augmentations/geometric/transforms/#albumentations.augmentations.geometric.transforms.Transpose)                       | ✓     | ✓    | ✓      | ✓         |
-| [VerticalFlip](https://albumentations.ai/docs/api_reference/augmentations/geometric/transforms/#albumentations.augmentations.geometric.transforms.VerticalFlip)                 | ✓     | ✓    | ✓      | ✓         |
-| [XYMasking](https://albumentations.ai/docs/api_reference/augmentations/dropout/xy_masking/#albumentations.augmentations.dropout.xy_masking.XYMasking)                           | ✓     | ✓    | ✓      | ✓         |
+| Transform                                                                                        | Image | Mask | BBoxes | Keypoints |
+| ------------------------------------------------------------------------------------------------ | :---: | :--: | :----: | :-------: |
+| [Affine](https://explore.albumentations.ai/transform/Affine)                                     | ✓     | ✓    | ✓      | ✓         |
+| [BBoxSafeRandomCrop](https://explore.albumentations.ai/transform/BBoxSafeRandomCrop)             | ✓     | ✓    | ✓      | ✓         |
+| [CenterCrop](https://explore.albumentations.ai/transform/CenterCrop)                             | ✓     | ✓    | ✓      | ✓         |
+| [CoarseDropout](https://explore.albumentations.ai/transform/CoarseDropout)                       | ✓     | ✓    | ✓      | ✓         |
+| [Crop](https://explore.albumentations.ai/transform/Crop)                                         | ✓     | ✓    | ✓      | ✓         |
+| [CropAndPad](https://explore.albumentations.ai/transform/CropAndPad)                             | ✓     | ✓    | ✓      | ✓         |
+| [CropNonEmptyMaskIfExists](https://explore.albumentations.ai/transform/CropNonEmptyMaskIfExists) | ✓     | ✓    | ✓      | ✓         |
+| [D4](https://explore.albumentations.ai/transform/D4)                                             | ✓     | ✓    | ✓      | ✓         |
+| [ElasticTransform](https://explore.albumentations.ai/transform/ElasticTransform)                 | ✓     | ✓    | ✓      | ✓         |
+| [GridDistortion](https://explore.albumentations.ai/transform/GridDistortion)                     | ✓     | ✓    | ✓      | ✓         |
+| [GridDropout](https://explore.albumentations.ai/transform/GridDropout)                           | ✓     | ✓    | ✓      | ✓         |
+| [GridElasticDeform](https://explore.albumentations.ai/transform/GridElasticDeform)               | ✓     | ✓    | ✓      | ✓         |
+| [HorizontalFlip](https://explore.albumentations.ai/transform/HorizontalFlip)                     | ✓     | ✓    | ✓      | ✓         |
+| [Lambda](https://explore.albumentations.ai/transform/Lambda)                                     | ✓     | ✓    | ✓      | ✓         |
+| [LongestMaxSize](https://explore.albumentations.ai/transform/LongestMaxSize)                     | ✓     | ✓    | ✓      | ✓         |
+| [MaskDropout](https://explore.albumentations.ai/transform/MaskDropout)                           | ✓     | ✓    | ✓      | ✓         |
+| [Morphological](https://explore.albumentations.ai/transform/Morphological)                       | ✓     | ✓    | ✓      | ✓         |
+| [NoOp](https://explore.albumentations.ai/transform/NoOp)                                         | ✓     | ✓    | ✓      | ✓         |
+| [OpticalDistortion](https://explore.albumentations.ai/transform/OpticalDistortion)               | ✓     | ✓    | ✓      | ✓         |
+| [OverlayElements](https://explore.albumentations.ai/transform/OverlayElements)                   | ✓     | ✓    |        |           |
+| [PadIfNeeded](https://explore.albumentations.ai/transform/PadIfNeeded)                           | ✓     | ✓    | ✓      | ✓         |
+| [Perspective](https://explore.albumentations.ai/transform/Perspective)                           | ✓     | ✓    | ✓      | ✓         |
+| [PiecewiseAffine](https://explore.albumentations.ai/transform/PiecewiseAffine)                   | ✓     | ✓    | ✓      | ✓         |
+| [PixelDropout](https://explore.albumentations.ai/transform/PixelDropout)                         | ✓     | ✓    | ✓      | ✓         |
+| [RandomCrop](https://explore.albumentations.ai/transform/RandomCrop)                             | ✓     | ✓    | ✓      | ✓         |
+| [RandomCropFromBorders](https://explore.albumentations.ai/transform/RandomCropFromBorders)       | ✓     | ✓    | ✓      | ✓         |
+| [RandomGridShuffle](https://explore.albumentations.ai/transform/RandomGridShuffle)               | ✓     | ✓    |        | ✓         |
+| [RandomResizedCrop](https://explore.albumentations.ai/transform/RandomResizedCrop)               | ✓     | ✓    | ✓      | ✓         |
+| [RandomRotate90](https://explore.albumentations.ai/transform/RandomRotate90)                     | ✓     | ✓    | ✓      | ✓         |
+| [RandomScale](https://explore.albumentations.ai/transform/RandomScale)                           | ✓     | ✓    | ✓      | ✓         |
+| [RandomSizedBBoxSafeCrop](https://explore.albumentations.ai/transform/RandomSizedBBoxSafeCrop)   | ✓     | ✓    | ✓      | ✓         |
+| [RandomSizedCrop](https://explore.albumentations.ai/transform/RandomSizedCrop)                   | ✓     | ✓    | ✓      | ✓         |
+| [Resize](https://explore.albumentations.ai/transform/Resize)                                     | ✓     | ✓    | ✓      | ✓         |
+| [Rotate](https://explore.albumentations.ai/transform/Rotate)                                     | ✓     | ✓    | ✓      | ✓         |
+| [SafeRotate](https://explore.albumentations.ai/transform/SafeRotate)                             | ✓     | ✓    | ✓      | ✓         |
+| [ShiftScaleRotate](https://explore.albumentations.ai/transform/ShiftScaleRotate)                 | ✓     | ✓    | ✓      | ✓         |
+| [SmallestMaxSize](https://explore.albumentations.ai/transform/SmallestMaxSize)                   | ✓     | ✓    | ✓      | ✓         |
+| [Transpose](https://explore.albumentations.ai/transform/Transpose)                               | ✓     | ✓    | ✓      | ✓         |
+| [VerticalFlip](https://explore.albumentations.ai/transform/VerticalFlip)                         | ✓     | ✓    | ✓      | ✓         |
+| [XYMasking](https://explore.albumentations.ai/transform/XYMasking)                               | ✓     | ✓    | ✓      | ✓         |
 
 ## A few more examples of **augmentations**
 

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -3301,11 +3301,10 @@ class Lambda(NoOp):
         mask: Mask transformation function.
         keypoint: Keypoint transformation function.
         bbox: BBox transformation function.
-        global_label: Global label transformation function.
         p: probability of applying the transform. Default: 1.0.
 
     Targets:
-        image, mask, bboxes, keypoints, global_label
+        image, mask, bboxes, keypoints
 
     Image types:
         uint8, float32
@@ -3321,7 +3320,6 @@ class Lambda(NoOp):
         mask: Callable[..., Any] | None = None,
         keypoints: Callable[..., Any] | None = None,
         bboxes: Callable[..., Any] | None = None,
-        global_label: Callable[..., Any] | None = None,
         name: str | None = None,
         always_apply: bool | None = None,
         p: float = 1.0,
@@ -3337,7 +3335,6 @@ class Lambda(NoOp):
             "mask": mask,
             "keypoints": keypoints,
             "bboxes": bboxes,
-            "global_label": global_label,
         }.items():
             if custom_apply_fn is not None:
                 if isinstance(custom_apply_fn, LambdaType) and custom_apply_fn.__name__ == "<lambda>":
@@ -3385,10 +3382,6 @@ class Lambda(NoOp):
             return result.tolist()
 
         return result
-
-    def apply_to_global_label(self, label: np.ndarray, **params: Any) -> np.ndarray:
-        fn = self.custom_apply_fns["global_label"]
-        return fn(label, **params)
 
     @classmethod
     def is_serializable(cls) -> bool:

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -44,7 +44,7 @@ REPR_INDENT_STEP = 2
 TransformType = Union[BasicTransform, "BaseCompose"]
 TransformsSeqType = List[TransformType]
 
-AVAILABLE_KEYS = ("image", "mask", "masks", "bboxes", "keypoints", "global_label")
+AVAILABLE_KEYS = ("image", "mask", "masks", "bboxes", "keypoints")
 MASK_KEYS = (
     "mask",
     "masks",

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -407,10 +407,6 @@ class DualTransform(BasicTransform):
         msg = f"Method apply_to_keypoints is not implemented in class {self.__class__.__name__}"
         raise NotImplementedError(msg)
 
-    def apply_to_global_label(self, label: np.ndarray, *args: Any, **params: Any) -> np.ndarray:
-        msg = f"Method apply_to_global_label is not implemented in class {self.__class__.__name__}"
-        raise NotImplementedError(msg)
-
     def apply_to_bboxes(self, bboxes: np.ndarray, *args: Any, **params: Any) -> np.ndarray:
         raise NotImplementedError(f"BBoxes not implemented for {self.__class__.__name__}")
 
@@ -430,9 +426,6 @@ class DualTransform(BasicTransform):
             return self.apply_to_mask(masks, **params)
         return [self.apply_to_mask(mask, **params) for mask in masks]
 
-    def apply_to_global_labels(self, labels: Sequence[np.ndarray], **params: Any) -> list[np.ndarray]:
-        return [self.apply_to_global_label(label, **params) for label in labels]
-
 
 class ImageOnlyTransform(BasicTransform):
     """Transform applied to image only."""
@@ -448,10 +441,10 @@ class NoOp(DualTransform):
     """Identity transform (does nothing).
 
     Targets:
-        image, mask, bboxes, keypoints, global_label
+        image, mask, bboxes, keypoints
     """
 
-    _targets = (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS, Targets.GLOBAL_LABEL)
+    _targets = (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS)
 
     def apply_to_keypoints(self, keypoints: np.ndarray, **params: Any) -> np.ndarray:
         return keypoints
@@ -464,9 +457,6 @@ class NoOp(DualTransform):
 
     def apply_to_mask(self, mask: np.ndarray, **params: Any) -> np.ndarray:
         return mask
-
-    def apply_to_global_label(self, label: np.ndarray, **params: Any) -> np.ndarray:
-        return label
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return ()

--- a/albumentations/core/types.py
+++ b/albumentations/core/types.py
@@ -39,7 +39,6 @@ D4Type = Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]
 class ReferenceImage(TypedDict):
     image: np.ndarray
     mask: NotRequired[np.ndarray]
-    global_label: NotRequired[np.ndarray]
     bbox: NotRequired[tuple[float, ...] | np.ndarray]
     keypoints: NotRequired[tuple[float, ...] | np.ndarray]
 
@@ -49,7 +48,6 @@ class Targets(Enum):
     MASK = "Mask"
     BBOXES = "BBoxes"
     KEYPOINTS = "Keypoints"
-    GLOBAL_LABEL = "Global Label"
 
 
 NUM_MULTI_CHANNEL_DIMENSIONS = 3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,6 @@ from tests.utils import set_seed
 set_seed(42)
 
 @pytest.fixture
-def global_label():
-    return np.array([1, 0, 0])
-
-@pytest.fixture
 def mask():
     return np.random.randint(low=0, high=2, size=(100, 100), dtype=np.uint8)
 

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -23,13 +23,6 @@ def get_targets_from_methods(cls):
     if has_keypoints_method:
         targets.add(Targets.KEYPOINTS)
 
-    has_global_label_method = any(
-        hasattr(cls, attr) and getattr(cls, attr) is not getattr(A.DualTransform, attr, None)
-        for attr in ["apply_to_global_label", "apply_to_global_labels"]
-    )
-    if has_global_label_method:
-        targets.add(Targets.GLOBAL_LABEL)
-
     return targets
 
 
@@ -70,7 +63,7 @@ DUAL_TARGETS = {
     A.PadIfNeeded: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
     A.RandomScale: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
     A.XYMasking: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.NoOp: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS, Targets.GLOBAL_LABEL),
+    A.NoOp: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
     A.Resize: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
     A.Rotate: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
     A.RandomRotate90: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
@@ -91,7 +84,7 @@ DUAL_TARGETS = {
     A.RandomCropNearBBox: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
     A.Perspective: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
     A.RandomSizedBBoxSafeCrop: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.Lambda: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS, Targets.GLOBAL_LABEL),
+    A.Lambda: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
     A.D4: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
     A.OverlayElements: (Targets.IMAGE, Targets.MASK),
     A.GridElasticDeform: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
@@ -101,7 +94,7 @@ DUAL_TARGETS = {
 }
 
 str2target = {
-    'image': Targets.IMAGE, 'mask': Targets.MASK, 'bboxes': Targets.BBOXES, 'keypoints': Targets.KEYPOINTS, 'global_label': Targets.GLOBAL_LABEL
+    'image': Targets.IMAGE, 'mask': Targets.MASK, 'bboxes': Targets.BBOXES, 'keypoints': Targets.KEYPOINTS,
 }
 
 @pytest.mark.parametrize(

--- a/tools/make_transforms_docs.py
+++ b/tools/make_transforms_docs.py
@@ -20,7 +20,7 @@ def make_augmentation_docs_link(cls) -> str:
     module_parts = cls.__module__.split(".")
     module_page = "/".join(module_parts[1:])
     return (
-        f"[{cls.__name__}](https://albumentations.ai/docs/api_reference/{module_page}/#{cls.__module__}.{cls.__name__})"
+        f"[{cls.__name__}](https://explore.albumentations.ai/transform/{cls.__name__})"
     )
 
 
@@ -115,7 +115,6 @@ def check_docs(filepath, image_only_transforms_links, dual_transforms_table) -> 
     outdated_docs = set()
     image_only_lines_not_in_text = []
     dual_lines_not_in_text = []
-    mixing_lines_not_in_text = []
 
     for line in image_only_transforms_links.split("\n"):
         if line not in text:
@@ -159,7 +158,7 @@ def main() -> None:
     image_only_transforms_links = make_transforms_targets_links(image_only_transforms)
 
     dual_transforms_table = make_transforms_targets_table(
-        dual_transforms, header=["Transform"] + [target.value for target in Targets if target != Targets.GLOBAL_LABEL]
+        dual_transforms, header=["Transform"] + [target.value for target in Targets]
     )
 
     if command == "make":


### PR DESCRIPTION
## Summary by Sourcery

Update documentation links in README.md to point to the new explore.albumentations.ai domain and remove the 'global_label' target from the codebase, including its references in core transforms, tests, and documentation scripts.

Enhancements:
- Update README.md to use new URLs for transform documentation, pointing to explore.albumentations.ai instead of albumentations.ai.

Chores:
- Remove support for 'global_label' target across various files, including core transforms, tests, and documentation generation scripts.