### PR TITLE
Add tests for contigous masks

### DIFF
--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -270,4 +270,6 @@ def test_to_tensor_v2_on_non_contiguous_array_with_random_rotate90():
 
     img = np.random.randint(0, 256, (640, 480, 3)).astype(np.uint8)
     masks = [np.random.randint(0, 2, (640, 480)).astype(np.uint8) for _ in range(4)]
-    transforms(image=img, masks=masks)
+    transformed = transforms(image=img, masks=masks)
+    assert transformed["image"].numpy().shape == (3, 640, 480)
+    assert transformed["masks"][0].shape == (640, 480)

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -261,3 +261,13 @@ def test_to_tensor_v2_on_non_contiguous_array_with_horizontal_flip():
     masks = [image[:, :, 0]] * 2
 
     transform(image=image, masks=masks)
+
+def test_to_tensor_v2_on_non_contiguous_array_with_random_rotate90():
+    transforms = A.Compose([
+    A.RandomRotate90(p=1.0),
+    ToTensorV2(),
+    ])
+
+    img = np.random.randint(0, 256, (640, 480, 3)).astype(np.uint8)
+    masks = [np.random.randint(0, 2, (640, 480)).astype(np.uint8) for _ in range(4)]
+    transforms(image=img, masks=masks)


### PR DESCRIPTION
Added tests, just in case for: 
https://github.com/albumentations-team/albumentations/issues/1972

## Summary by Sourcery

Add a test case to verify the behavior of the ToTensorV2 transformation when applied to non-contiguous arrays with a RandomRotate90 transformation.

Tests:
- Add a test for the ToTensorV2 transformation on a non-contiguous array with a RandomRotate90 transformation.