### PR TITLE
Fix plankian jitter

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -5127,7 +5127,7 @@ class PlanckianJitter(ImageOnlyTransform):
     2. Natural effects: This transform produces color shifts that correspond to natural lighting
        variations, making it ideal for outdoor scene simulation or color constancy problems.
     3. Single parameter: Color changes are controlled by a single, physically meaningful parameter
-       (color temperature), unlike ColorJitter's multiple abstract parncoameters.
+       (color temperature), unlike ColorJitter's multiple abstract parameters.
     4. Correlated changes: Color shifts are correlated across channels in a way that mimics natural
        light, whereas ColorJitter can make independent channel adjustments.
 


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/1968

## Summary by Sourcery

Fix the Planckian jitter function to handle out-of-range temperatures by clamping them to valid values, enhance interpolation logic, and add comprehensive tests for edge cases and consistency.

Bug Fixes:
- Fix the Planckian jitter function to correctly handle temperature values outside the defined range by clamping them to the nearest valid temperature.

Enhancements:
- Improve the Planckian jitter function by ensuring linear interpolation between the closest valid temperatures, and handling edge cases where the temperature is at or near the minimum or maximum values.

Tests:
- Add new test cases for Planckian jitter to cover edge cases, interpolation, consistency, and invalid mode handling.