### PR TITLE
Ensure that transformed masks are contiguous arrays

### DIFF
--- a/albumentations/core/utils.py
+++ b/albumentations/core/utils.py
@@ -310,6 +310,14 @@ def ensure_int_output(
     return (int(min_val), int(max_val)) if isinstance(param, int) else (float(min_val), float(max_val))
 
 
+def ensure_contiguous_output(arg: np.ndarray | Sequence[np.ndarray]) -> np.ndarray | list[np.ndarray]:
+    if isinstance(arg, np.ndarray):
+        arg = np.require(arg, requirements=["C_CONTIGUOUS"])
+    elif isinstance(arg, Sequence):
+        arg = list(map(ensure_contiguous_output, arg))
+    return arg
+
+
 @overload
 def to_tuple(param: ScaleIntType, low: ScaleType | None = None, bias: ScalarType | None = None) -> tuple[int, int]: ...
 

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -277,6 +277,9 @@ def test_to_tensor_v2_on_non_contiguous_array_with_random_rotate90():
 
     img = np.random.randint(0, 256, (640, 480, 3)).astype(np.uint8)
     masks = [np.random.randint(0, 2, (640, 480)).astype(np.uint8) for _ in range(4)]
-    transformed = transforms(image=img, masks=masks)
-    assert transformed["image"].numpy().shape == (3, 640, 480)
-    assert transformed["masks"][0].shape == (640, 480)
+    for _ in range(10):
+        transformed = transforms(image=img, masks=masks)
+        assert isinstance(transformed["image"], torch.Tensor)
+        assert isinstance(transformed["masks"][0], torch.Tensor)
+        assert transformed["image"].numpy().shape in ((3, 640, 480), (3, 480, 640))
+        assert transformed["masks"][0].shape in ((640, 480), (480, 640))


### PR DESCRIPTION
Fixes #1972

- Recursively check sequence arguments passed to `apply_with_params` to be C_CONTIGUOUS numpy arrays.
- Adjust unit test `test_to_tensor_v2_on_non_contiguous_array_with_random_rotate90` to run the transformation multiple times to avoid only checking rotations around 0°.

## Summary by Sourcery

Ensure that transformed masks are contiguous arrays by introducing a utility function to enforce C_CONTIGUOUS requirements and updating the `apply_with_params` method. Adjust the related unit test to improve coverage and validation.

Bug Fixes:
- Ensure that sequence arguments passed to `apply_with_params` are C_CONTIGUOUS numpy arrays to fix issues with non-contiguous arrays.

Enhancements:
- Introduce a utility function `ensure_contiguous_output` to recursively ensure that numpy arrays are C_CONTIGUOUS.

Tests:
- Modify the unit test `test_to_tensor_v2_on_non_contiguous_array_with_random_rotate90` to run transformations multiple times and verify the output shapes and types.