### PR TITLE
Fix iso noise

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -3174,7 +3174,7 @@ class Downscale(ImageOnlyTransform):
             Lower values result in more aggressive downscaling.
             Default: (0.25, 0.25)
 
-        interpolation_pair (Interpolationdict): A dictionary specifying the interpolation methods to use for
+        interpolation_pair (InterpolationDict): A dictionary specifying the interpolation methods to use for
             downscaling and upscaling. Should contain two keys:
             - 'downscale': Interpolation method for downscaling
             - 'upscale': Interpolation method for upscaling


### PR DESCRIPTION
Fixes https://github.com/albumentations-team/albumentations/issues/1985

## Summary by Sourcery

Fix the iso_noise function to correctly simulate camera sensor noise by adjusting the application of Poisson and color noise, and ensure the output is clamped within the valid range. Remove default parameter values to enhance flexibility.

Bug Fixes:
- Fix the iso_noise function to correctly apply Poisson noise and color noise to simulate camera sensor noise, ensuring the output is within the [0, 1] range.

Enhancements:
- Remove default values for color_shift and intensity parameters in the iso_noise function to allow more flexible usage.