### PR TITLE
Remove scikit image

### DIFF
--- a/albumentations/augmentations/dropout/mask_dropout.py
+++ b/albumentations/augmentations/dropout/mask_dropout.py
@@ -5,7 +5,6 @@ from typing import Any, Literal, cast
 
 import cv2
 import numpy as np
-from skimage.measure import label
 
 import albumentations.augmentations.dropout.functional as fdropout
 from albumentations.core.bbox_utils import BboxProcessor, denormalize_bboxes, normalize_bboxes
@@ -98,7 +97,7 @@ class MaskDropout(DualTransform):
     def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
         mask = data["mask"]
 
-        label_image, num_labels = label(mask, return_num=True)
+        label_image, num_labels = fdropout.label(mask, return_num=True)
 
         if num_labels == 0:
             dropout_mask = None

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -3944,8 +3944,6 @@ class Emboss(ImageOnlyTransform):
 class Superpixels(ImageOnlyTransform):
     """Transform images partially/completely to their superpixel representation.
 
-    This implementation uses skimage's version of the SLIC (Simple Linear Iterative Clustering) algorithm.
-
     Args:
         p_replace (tuple[float, float] | float): Defines for any segment the probability that the pixels within that
             segment are replaced by their average color (otherwise, the pixels are not changed).

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -3942,98 +3942,35 @@ class Emboss(ImageOnlyTransform):
 
 
 class Superpixels(ImageOnlyTransform):
-    """Transform images partially/completely to their superpixel representation.
+    """Apply superpixel segmentation to the input image and optionally replace superpixels with their mean color.
 
-    This implementation uses skimage's version of the SLIC (Simple Linear Iterative Clustering) algorithm.
+    This function uses a custom implementation of the SLIC (Simple Linear Iterative Clustering) algorithm
+    based on OpenCV and NumPy. It segments the image into approximately n_segments superpixels and then
+    selectively replaces some superpixels with their mean color based on the replace_samples parameter.
 
     Args:
-        p_replace (tuple[float, float] | float): Defines for any segment the probability that the pixels within that
-            segment are replaced by their average color (otherwise, the pixels are not changed).
+        image (np.ndarray): Input image. Can be 2D (grayscale) or 3D (multi-channel) array.
+        n_segments (int): Approximate number of superpixels to generate.
+        replace_samples (Sequence[bool]): Boolean mask indicating which superpixels to replace with their mean color.
+        max_size (int | None): Maximum image size. If the image is larger, it will be resized before processing.
+        interpolation (int): Interpolation method to use for resizing (OpenCV interpolation flag).
 
-
-            * A probability of ``0.0`` would mean, that the pixels in no
-                segment are replaced by their average color (image is not
-                changed at all).
-            * A probability of ``0.5`` would mean, that around half of all
-                segments are replaced by their average color.
-            * A probability of ``1.0`` would mean, that all segments are
-                replaced by their average color (resulting in a voronoi
-                image).
-
-            Behavior based on chosen data types for this parameter:
-            * If a ``float``, then that ``float`` will always be used.
-            * If ``tuple`` ``(a, b)``, then a random probability will be
-            sampled from the interval ``[a, b]`` per image.
-            Default: (0.1, 0.3)
-
-        n_segments (tuple[int, int] | int): Rough target number of how many superpixels to generate.
-            The algorithm may deviate from this number.
-            Lower value will lead to coarser superpixels.
-            Higher values are computationally more intensive and will hence lead to a slowdown.
-            If tuple ``(a, b)``, then a value from the discrete interval ``[a..b]`` will be sampled per image.
-            Default: (15, 120)
-
-        max_size (int | None): Maximum image size at which the augmentation is performed.
-            If the width or height of an image exceeds this value, it will be
-            downscaled before the augmentation so that the longest side matches `max_size`.
-            This is done to speed up the process. The final output image has the same size as the input image.
-            Note that in case `p_replace` is below ``1.0``,
-            the down-/upscaling will affect the not-replaced pixels too.
-            Use ``None`` to apply no down-/upscaling.
-            Default: 128
-
-        interpolation (OpenCV flag): Flag that is used to specify the interpolation algorithm. Should be one of:
-            cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
-            Default: cv2.INTER_LINEAR.
-
-        p (float): Probability of applying the transform. Default: 0.5.
-
-    Targets:
-        image
-
-    Image types:
-        uint8, float32
-
-    Number of channels:
-        Any
+    Returns:
+        np.ndarray: Processed image with superpixel segmentation applied and selected superpixels replaced.
 
     Note:
-        - This transform can significantly change the visual appearance of the image.
-        - The transform makes use of a superpixel algorithm, which tends to be slow.
-        If performance is a concern, consider using `max_size` to limit the image size.
-        - The effect of this transform can vary greatly depending on the `p_replace` and `n_segments` parameters.
-        - When `p_replace` is high, the image can become highly abstracted, resembling a voronoi diagram.
-        - The transform preserves the original image type (uint8 or float32).
+        - The SLIC implementation used here is a simplified version and may produce results slightly different
+          from scikit-image's implementation.
+        - The function handles both 2D (grayscale) and 3D (multi-channel) images.
+        - If max_size is specified and the image is larger, it will be resized before processing and then
+          resized back to its original dimensions after processing.
+        - The replace_samples sequence is used cyclically if its length is less than the number of superpixels.
 
-    Mathematical Formulation:
-        1. The image is segmented into approximately `n_segments` superpixels using the SLIC algorithm.
-        2. For each superpixel:
-        - With probability `p_replace`, all pixels in the superpixel are replaced with their mean color.
-        - With probability `1 - p_replace`, the superpixel is left unchanged.
-        3. If the image was resized due to `max_size`, it is resized back to its original dimensions.
-
-    Examples:
-        >>> import numpy as np
-        >>> import albumentations as A
+    Example:
         >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-
-        # Apply superpixels with default parameters
-        >>> transform = A.Superpixels(p=1.0)
-        >>> augmented_image = transform(image=image)['image']
-
-        # Apply superpixels with custom parameters
-        >>> transform = A.Superpixels(
-        ...     p_replace=(0.5, 0.7),
-        ...     n_segments=(50, 100),
-        ...     max_size=None,
-        ...     interpolation=cv2.INTER_NEAREST,
-        ...     p=1.0
-        ... )
-        >>> augmented_image = transform(image=image)['image']
-
-    References:
-        - SLIC Superpixels: https://scikit-image.org/docs/dev/api/skimage.segmentation.html#skimage.segmentation.slic
-        - "SLIC Superpixels Compared to State-of-the-art Superpixel Methods" by Radhakrishna Achanta, et al.
+        >>> n_segments = 50
+        >>> replace_samples = [True, False] * 25  # Replace every other superpixel
+        >>> result = superpixels(image, n_segments, replace_samples, max_size=None, interpolation=cv2.INTER_LINEAR)
     """
 
     class InitSchema(BaseTransformInitSchema):


### PR DESCRIPTION
## Summary by Sourcery

Remove the dependency on scikit-image by implementing custom functions for histogram matching and superpixel segmentation using OpenCV and NumPy. Update related tests to validate the new implementations.

New Features:
- Introduce a custom implementation of histogram matching using OpenCV and NumPy, replacing the previous dependency on scikit-image.

Enhancements:
- Replace the scikit-image SLIC superpixel segmentation with a custom implementation using OpenCV and NumPy.
- Add a custom label function for connected region labeling, mimicking scikit-image's label function using OpenCV.

Tests:
- Add tests for the new histogram matching function to ensure it produces results comparable to the scikit-image implementation.