### PR TITLE
Fix longest max size

### DIFF
--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -468,10 +468,7 @@ def perspective(
     )
     warped = perspective_func(img)
 
-    if keep_size:
-        return resize(warped, image_shape, interpolation=interpolation)
-
-    return warped
+    return resize(warped, image_shape, interpolation=interpolation) if keep_size else warped
 
 
 @handle_empty_array

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -149,7 +149,7 @@ class LongestMaxSize(DualTransform):
         uint8, float32
 
     Note:
-        - If the longest side of the image is already less than or equal to max_size, the image will not be resized.
+        - If the longest side of the image is already equal to max_size, the image will not be resized.
         - This transform will not crop the image. The resulting image may be smaller than max_size in both dimensions.
         - For non-square images, the shorter side will be scaled proportionally to maintain the aspect ratio.
 
@@ -233,7 +233,7 @@ class SmallestMaxSize(DualTransform):
         uint8, float32
 
     Note:
-        - If the smallest side of the image is already less than or equal to max_size, the image will not be resized.
+        - If the smallest side of the image is already equal to max_size, the image will not be resized.
         - This transform will not crop the image. The resulting image may be larger than max_size in both dimensions.
         - For non-square images, the larger side will be scaled proportionally to maintain the aspect ratio.
         - Bounding boxes and keypoints are scaled accordingly.


### PR DESCRIPTION
Fixes https://github.com/albumentations-team/albumentations/issues/1989

## Summary by Sourcery

Bug Fixes:
- Correct the condition for resizing in LongestMaxSize and SmallestMaxSize transforms to ensure images are resized only when their longest or smallest side is not equal to max_size.