### PR TITLE
Update lut

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -150,9 +150,7 @@ def solarize(img: np.ndarray, threshold: int) -> np.ndarray:
         prev_shape = img.shape
         img = sz_lut(img, np.array(lut, dtype=dtype), inplace=False)
 
-        if len(prev_shape) != len(img.shape):
-            return np.expand_dims(img, -1)
-        return img
+        return np.expand_dims(img, -1) if len(prev_shape) != len(img.shape) else img
 
     cond = img >= threshold
     img[cond] = max_val - img[cond]

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -25,6 +25,7 @@ from albucore import (
     multiply_add,
     normalize_per_image,
     preserve_channel_dim,
+    sz_lut,
     to_float,
     uint8_io,
 )
@@ -89,54 +90,14 @@ __all__ = [
 ]
 
 
-def _shift_hsv_uint8(
-    img: np.ndarray,
-    hue_shift: np.ndarray,
-    sat_shift: np.ndarray,
-    val_shift: np.ndarray,
-) -> np.ndarray:
-    dtype = img.dtype
-    img = cv2.cvtColor(img, cv2.COLOR_RGB2HSV)
-    hue, sat, val = cv2.split(img)
-
-    if hue_shift != 0:
-        lut_hue = np.arange(0, 256, dtype=np.int16)
-        lut_hue = np.mod(lut_hue + hue_shift, 180).astype(dtype)
-        hue = cv2.LUT(hue, lut_hue)
-
-    sat = add(sat, sat_shift)
-    val = add(val, val_shift)
-
-    img = cv2.merge((hue, sat, val)).astype(dtype)
-    return cv2.cvtColor(img, cv2.COLOR_HSV2RGB)
-
-
-def _shift_hsv_non_uint8(
-    img: np.ndarray,
-    hue_shift: np.ndarray,
-    sat_shift: np.ndarray,
-    val_shift: np.ndarray,
-) -> np.ndarray:
-    img = cv2.cvtColor(img, cv2.COLOR_RGB2HSV)
-    hue, sat, val = cv2.split(img)
-
-    if hue_shift != 0:
-        hue = cv2.add(hue, hue_shift)
-        hue = np.mod(hue, 360)  # OpenCV fails with negative values
-
-    sat = add(sat, sat_shift)
-    val = add(val, val_shift)
-
-    img = cv2.merge((hue, sat, val))
-    return cv2.cvtColor(img, cv2.COLOR_HSV2RGB)
-
-
+@uint8_io
 @preserve_channel_dim
-def shift_hsv(img: np.ndarray, hue_shift: np.ndarray, sat_shift: np.ndarray, val_shift: np.ndarray) -> np.ndarray:
+def shift_hsv(img: np.ndarray, hue_shift: float, sat_shift: float, val_shift: float) -> np.ndarray:
     if hue_shift == 0 and sat_shift == 0 and val_shift == 0:
         return img
 
     is_gray = is_grayscale_image(img)
+
     if is_gray:
         if hue_shift != 0 or sat_shift != 0:
             hue_shift = 0
@@ -148,16 +109,28 @@ def shift_hsv(img: np.ndarray, hue_shift: np.ndarray, sat_shift: np.ndarray, val
             )
         img = cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
 
-    if img.dtype == np.uint8:
-        img = _shift_hsv_uint8(img, hue_shift, sat_shift, val_shift)
-    else:
-        img = _shift_hsv_non_uint8(img, hue_shift, sat_shift, val_shift)
+    img = cv2.cvtColor(img, cv2.COLOR_RGB2HSV)
+    hue, sat, val = cv2.split(img)
+
+    if hue_shift != 0:
+        lut_hue = np.arange(0, 256, dtype=np.int16)
+        lut_hue = np.mod(lut_hue + hue_shift, 180).astype(np.uint8)
+        hue = sz_lut(hue, lut_hue, inplace=False)
+
+    if sat_shift != 0:
+        sat = add(sat, sat_shift, inplace=False)
+
+    if val_shift != 0:
+        val = add(val, val_shift, inplace=False)
+
+    img = cv2.merge((hue, sat, val))
+    img = cv2.cvtColor(img, cv2.COLOR_HSV2RGB)
 
     return cv2.cvtColor(img, cv2.COLOR_RGB2GRAY) if is_gray else img
 
 
 @clipped
-def solarize(img: np.ndarray, threshold: int = 128) -> np.ndarray:
+def solarize(img: np.ndarray, threshold: int) -> np.ndarray:
     """Invert all pixel values above a threshold.
 
     Args:
@@ -168,6 +141,7 @@ def solarize(img: np.ndarray, threshold: int = 128) -> np.ndarray:
         Solarized image.
 
     """
+    img = img.copy()
     dtype = img.dtype
     max_val = MAX_VALUES_BY_DTYPE[dtype]
 
@@ -175,16 +149,15 @@ def solarize(img: np.ndarray, threshold: int = 128) -> np.ndarray:
         lut = [(i if i < threshold else max_val - i) for i in range(int(max_val) + 1)]
 
         prev_shape = img.shape
-        img = cv2.LUT(img, np.array(lut, dtype=dtype))
+        img = sz_lut(img, np.array(lut, dtype=dtype), inplace=True)
 
         if len(prev_shape) != len(img.shape):
-            img = np.expand_dims(img, -1)
+            return np.expand_dims(img, -1)
         return img
 
-    result_img = img.copy()
     cond = img >= threshold
-    result_img[cond] = max_val - result_img[cond]
-    return result_img
+    img[cond] = max_val - img[cond]
+    return img
 
 
 @uint8_io
@@ -213,7 +186,7 @@ def posterize(img: np.ndarray, bits: Literal[0, 1, 2, 3, 4, 5, 6, 7, 8]) -> np.n
         mask = ~np.uint8(2 ** (8 - bits_array) - 1)
         lut &= mask
 
-        return cv2.LUT(img, lut)
+        return sz_lut(img, lut, inplace=False)
 
     result_img = np.empty_like(img)
     for i, channel_bits in enumerate(bits_array):
@@ -226,7 +199,7 @@ def posterize(img: np.ndarray, bits: Literal[0, 1, 2, 3, 4, 5, 6, 7, 8]) -> np.n
             mask = ~np.uint8(2 ** (8 - channel_bits) - 1)
             lut &= mask
 
-            result_img[..., i] = cv2.LUT(img[..., i], lut)
+            result_img[..., i] = sz_lut(img[..., i], lut, inplace=True)
 
     return result_img
 
@@ -248,7 +221,7 @@ def _equalize_pil(img: np.ndarray, mask: np.ndarray | None = None) -> np.ndarray
         lut[i] = min(n // step, 255)
         n += histogram[i]
 
-    return cv2.LUT(img, np.array(lut))
+    return sz_lut(img, np.array(lut), inplace=True)
 
 
 def _equalize_cv(img: np.ndarray, mask: np.ndarray | None = None) -> np.ndarray:
@@ -276,7 +249,7 @@ def _equalize_cv(img: np.ndarray, mask: np.ndarray | None = None) -> np.ndarray:
         _sum += histogram[idx]
         lut[idx] = clip(round(_sum * scale), np.uint8)
 
-    return cv2.LUT(img, lut)
+    return sz_lut(img, lut, inplace=True)
 
 
 def _check_preconditions(img: np.ndarray, mask: np.ndarray | None, by_channels: bool) -> None:
@@ -393,10 +366,12 @@ def move_tone_curve(
 
     if np.isscalar(low_y) and np.isscalar(high_y):
         lut = clip(np.rint(evaluate_bez(t, low_y, high_y)), np.uint8)
-        return cv2.LUT(img, lut)
+        return sz_lut(img, lut, inplace=False)
     if isinstance(low_y, np.ndarray) and isinstance(high_y, np.ndarray):
         luts = clip(np.rint(evaluate_bez(t[:, np.newaxis], low_y, high_y).T), np.uint8)
-        return cv2.merge([cv2.LUT(img[:, :, i], luts[i]) for i in range(num_channels)])
+        return cv2.merge(
+            [sz_lut(img[:, :, i], np.ascontiguousarray(luts[i]), inplace=False) for i in range(num_channels)],
+        )
 
     raise TypeError(
         f"low_y and high_y must both be of type float or np.ndarray. Got {type(low_y)} and {type(high_y)}",
@@ -614,12 +589,12 @@ def add_snow_texture(img: np.ndarray, snow_point: float, brightness_coeff: float
     snow_layer = (np.dstack([snow_texture] * 3) * max_value * snow_point).astype(np.float32)
 
     # Blend snow with original image
-    img_with_snow = cv2.addWeighted(img_hsv, 1, snow_layer, 1, 0)
+    img_with_snow = add_weighted(img_hsv, 1, snow_layer, 1, 0)
 
     # Add a slight blue tint to simulate cool snow color
     blue_tint = np.full_like(img_with_snow, (0.6, 0.75, 1))  # Slight blue in HSV
 
-    img_with_snow = cv2.addWeighted(img_with_snow, 0.85, blue_tint, 0.15 * snow_point, 0)
+    img_with_snow = add_weighted(img_with_snow, 0.85, blue_tint, 0.15 * snow_point, 0)
 
     # Convert back to RGB
     img_with_snow = cv2.cvtColor(img_with_snow.astype(np.uint8), cv2.COLOR_HSV2RGB)
@@ -814,6 +789,7 @@ def add_sun_flare_overlay(
     num_times = src_radius // 10
     alpha = np.linspace(0.0, 1, num=num_times)
     rad = np.linspace(1, src_radius, num=num_times)
+
     for i in range(num_times):
         cv2.circle(overlay, point, int(rad[i]), src_color, -1)
         alp = alpha[num_times - i - 1] * alpha[num_times - i - 1] * alpha[num_times - i - 1]
@@ -1003,7 +979,8 @@ def channel_shuffle(img: np.ndarray, channels_shuffled: np.ndarray) -> np.ndarra
 def gamma_transform(img: np.ndarray, gamma: float) -> np.ndarray:
     if img.dtype == np.uint8:
         table = (np.arange(0, 256.0 / 255, 1.0 / 255) ** gamma) * 255
-        return cv2.LUT(img, table.astype(np.uint8))
+        return sz_lut(img, table.astype(np.uint8), inplace=False)
+
     return np.power(img, gamma)
 
 
@@ -1019,7 +996,7 @@ def brightness_contrast_adjust(
     else:
         value = beta * np.mean(img)
 
-    return multiply_add(img, alpha, value)
+    return multiply_add(img, alpha, value, inplace=False)
 
 
 @float32_io
@@ -1427,7 +1404,7 @@ def adjust_brightness_torchvision(img: np.ndarray, factor: np.ndarray) -> np:
     if factor == 1:
         return img
 
-    return multiply(img, factor)
+    return multiply(img, factor, inplace=False)
 
 
 @preserve_channel_dim
@@ -1442,25 +1419,19 @@ def adjust_contrast_torchvision(img: np.ndarray, factor: float) -> np.ndarray:
             mean = int(mean + 0.5)
         return np.full_like(img, mean, dtype=img.dtype)
 
-    return multiply_add(img, factor, mean * (1 - factor))
+    return multiply_add(img, factor, mean * (1 - factor), inplace=False)
 
 
 @clipped
 @preserve_channel_dim
 def adjust_saturation_torchvision(img: np.ndarray, factor: float, gamma: float = 0) -> np.ndarray:
-    if factor == 1:
-        return img
-
-    if is_grayscale_image(img):
+    if factor == 1 or is_grayscale_image(img):
         return img
 
     gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
     gray = cv2.cvtColor(gray, cv2.COLOR_GRAY2RGB)
 
-    if factor == 0:
-        return gray
-
-    return cv2.addWeighted(img, factor, gray, 1 - factor, gamma=gamma)
+    return gray if factor == 0 else cv2.addWeighted(img, factor, gray, 1 - factor, gamma=gamma)
 
 
 def _adjust_hue_torchvision_uint8(img: np.ndarray, factor: float) -> np.ndarray:
@@ -1468,7 +1439,7 @@ def _adjust_hue_torchvision_uint8(img: np.ndarray, factor: float) -> np.ndarray:
 
     lut = np.arange(0, 256, dtype=np.int16)
     lut = np.mod(lut + 180 * factor, 180).astype(np.uint8)
-    img[..., 0] = cv2.LUT(img[..., 0], lut)
+    img[..., 0] = sz_lut(img[..., 0], lut, inplace=False)
 
     return cv2.cvtColor(img, cv2.COLOR_HSV2RGB)
 

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -141,7 +141,6 @@ def solarize(img: np.ndarray, threshold: int) -> np.ndarray:
         Solarized image.
 
     """
-    img = img.copy()
     dtype = img.dtype
     max_val = MAX_VALUES_BY_DTYPE[dtype]
 
@@ -149,7 +148,7 @@ def solarize(img: np.ndarray, threshold: int) -> np.ndarray:
         lut = [(i if i < threshold else max_val - i) for i in range(int(max_val) + 1)]
 
         prev_shape = img.shape
-        img = sz_lut(img, np.array(lut, dtype=dtype), inplace=True)
+        img = sz_lut(img, np.array(lut, dtype=dtype), inplace=False)
 
         if len(prev_shape) != len(img.shape):
             return np.expand_dims(img, -1)
@@ -589,12 +588,12 @@ def add_snow_texture(img: np.ndarray, snow_point: float, brightness_coeff: float
     snow_layer = (np.dstack([snow_texture] * 3) * max_value * snow_point).astype(np.float32)
 
     # Blend snow with original image
-    img_with_snow = add_weighted(img_hsv, 1, snow_layer, 1, 0)
+    img_with_snow = cv2.add(img_hsv, snow_layer)
 
     # Add a slight blue tint to simulate cool snow color
     blue_tint = np.full_like(img_with_snow, (0.6, 0.75, 1))  # Slight blue in HSV
 
-    img_with_snow = add_weighted(img_with_snow, 0.85, blue_tint, 0.15 * snow_point, 0)
+    img_with_snow = cv2.addWeighted(img_with_snow, 0.85, blue_tint, 0.15 * snow_point, 0)
 
     # Convert back to RGB
     img_with_snow = cv2.cvtColor(img_with_snow.astype(np.uint8), cv2.COLOR_HSV2RGB)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -2251,7 +2251,7 @@ class RGBShift(ImageOnlyTransform):
 
     def apply(self, img: np.ndarray, shift: np.ndarray, **params: Any) -> np.ndarray:
         non_rgb_error(img)
-        return albucore.add_vector(img, shift)
+        return albucore.add_vector(img, shift, inplace=False)
 
     def get_params(self) -> dict[str, Any]:
         return {

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ INSTALL_REQUIRES = [
     "PyYAML",
     "typing-extensions>=4.9.0; python_version<'3.10'",
     "pydantic>=2.7.0",
-    "albucore==0.0.17",
+    "albucore==0.0.18",
     "eval-type-backport"
 ]
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -887,7 +887,7 @@ def test_random_tone_curve(image):
     result_float_value = F.move_tone_curve(image, low_y, high_y)
     result_array_value = F.move_tone_curve(image, np.array([low_y] * num_channels), np.array([high_y] * num_channels))
 
-    assert np.array_equal(result_float_value, result_array_value)
+    np.testing.assert_allclose(result_float_value, result_array_value)
 
     assert result_float_value.dtype == image.dtype
     assert result_float_value.shape == image.shape

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, Optional, Tuple, Type
 import cv2
 import numpy as np
 import pytest
-from albucore.functions import to_float
-from albucore.utils import clip
+from albucore.functions import to_float, clip, from_float
+
 from torchvision import transforms as torch_transforms
 
 import albumentations as A
@@ -651,58 +651,6 @@ def test_color_jitter_float_uint8_equal(brightness, contrast, saturation, hue):
         assert _max <= 10, f"Max: {_max}"
     else:
         assert _max <= 2, f"Max: {_max}"
-
-
-@pytest.mark.parametrize(["hue", "sat", "val"], [[13, 17, 23], [14, 18, 24], [131, 143, 151], [132, 144, 152]])
-def test_hue_saturation_value_float_uint8_equal(hue, sat, val):
-    img = SQUARE_UINT8_IMAGE
-
-    for i in range(2):
-        sign = 1 if i == 0 else -1
-        for i in range(4):
-            if i == 0:
-                _hue = hue * sign
-                _sat = 0
-                _val = 0
-            elif i == 1:
-                _hue = 0
-                _sat = sat * sign
-                _val = 0
-            elif i == 2:
-                _hue = 0
-                _sat = 0
-                _val = val * sign
-            else:
-                _hue = hue * sign
-                _sat = sat * sign
-                _val = val * sign
-
-            t1 = A.Compose(
-                [
-                    A.HueSaturationValue(
-                        hue_shift_limit=[_hue, _hue],
-                        sat_shift_limit=[_sat, _sat],
-                        val_shift_limit=[_val, _val],
-                        p=1,
-                    ),
-                ],
-            )
-            t2 = A.Compose(
-                [
-                    A.HueSaturationValue(
-                        hue_shift_limit=[_hue / 180 * 360, _hue / 180 * 360],
-                        sat_shift_limit=[_sat / 255, _sat / 255],
-                        val_shift_limit=[_val / 255, _val / 255],
-                        p=1,
-                    ),
-                ],
-            )
-
-            res1 = t1(image=img)["image"]
-            res2 = (t2(image=img.astype(np.float32) / 255.0)["image"] * 255).astype(np.uint8)
-
-            _max = np.abs(res1.astype(np.int32) - res2).max()
-            assert _max <= 10, f"Max value: {_max}"
 
 
 def test_perspective_keep_size():


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/1997

## Summary by Sourcery

Refactor image processing functions to use sz_lut instead of cv2.LUT for improved performance and consistency. Simplify the shift_hsv function by removing separate handling for different data types. Update the add_snow_texture function to use cv2.add for blending. Adjust the albucore dependency version in setup.py. Remove a redundant test case and update another for better precision.

Enhancements:
- Refactor the shift_hsv function to simplify the logic and remove separate handling for uint8 and non-uint8 images.
- Replace cv2.LUT with sz_lut for various image processing functions to improve performance and maintain consistency.
- Modify the add_snow_texture function to use cv2.add instead of cv2.addWeighted for blending snow with the original image.
- Update the adjust_brightness_torchvision and adjust_contrast_torchvision functions to use inplace=False for multiply and multiply_add operations.

Build:
- Update albucore dependency version from 0.0.17 to 0.0.18 in setup.py.

Tests:
- Remove the test_hue_saturation_value_float_uint8_equal test case from test_transforms.py.
- Update the test_random_tone_curve test in test_functional.py to use np.testing.assert_allclose for better precision in comparisons.