### PR TITLE
Fix box filtering

### DIFF
--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -20,6 +20,7 @@ from albumentations.core.pydantic import (
     ZeroOneRangeType,
     check_0plus,
     check_01,
+    nondecreasing,
 )
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
 from albumentations.core.types import (
@@ -672,8 +673,8 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
     _targets = (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS)
 
     class InitSchema(BaseTransformInitSchema):
-        scale: Annotated[tuple[float, float], AfterValidator(check_01)]
-        ratio: Annotated[tuple[float, float], AfterValidator(check_0plus)]
+        scale: Annotated[tuple[float, float], AfterValidator(check_01), AfterValidator(nondecreasing)]
+        ratio: Annotated[tuple[float, float], AfterValidator(check_0plus), AfterValidator(nondecreasing)]
         width: int | None = Field(
             None,
             deprecated="Initializing with 'height' and 'width' is deprecated. Use size instead.",

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -1522,3 +1522,19 @@ def test_bboxes_from_masks_output_type():
     result = bboxes_from_masks(masks)
     assert isinstance(result, np.ndarray)
     assert result.dtype == np.int32
+
+
+def test_random_resized_crop():
+    transform = A.Compose(
+    [
+        A.RandomResizedCrop((100, 100), scale=(0.01, 0.1), ratio=(1, 1)),
+    ],
+    bbox_params=A.BboxParams(
+        format="coco",
+        label_fields=["label"],  # clip=True  # , min_area=25
+    ),
+    )
+    boxes = [[10,10,20,20], [5,5,10,10], [450, 450, 5,5], [250,250,5,5]]
+    labels = [1,2,3,4]
+    res = transform(image=np.zeros((500,500,3), dtype='uint8'), bboxes=boxes, label=labels)
+    assert len(res['bboxes']) == len(res['label'])

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -1531,7 +1531,7 @@ def test_random_resized_crop():
     ],
     bbox_params=A.BboxParams(
         format="coco",
-        label_fields=["label"],  # clip=True  # , min_area=25
+        label_fields=["label"],
     ),
     )
     boxes = [[10,10,20,20], [5,5,10,10], [450, 450, 5,5], [250,250,5,5]]


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/1999

## Summary by Sourcery

Fix box filtering logic and enhance the RandomResizedCrop transformation with additional validators. Add a test to verify the correct handling of bounding boxes and labels in the RandomResizedCrop transformation.

Bug Fixes:
- Fix box filtering logic to correctly process data fields and handle empty keypoints arrays.

Enhancements:
- Enhance the RandomResizedCrop transformation by adding validators to ensure non-decreasing scale and ratio parameters.

Tests:
- Add a test for the RandomResizedCrop transformation to ensure correct handling of bounding boxes and labels.