### PR TITLE
Force mask interpolation

### DIFF
--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -753,7 +753,7 @@ class Defocus(ImageOnlyTransform):
         always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p, always_apply)
+        super().__init__(p=p, always_apply=always_apply)
         self.radius = cast(tuple[int, int], radius)
         self.alias_blur = cast(tuple[float, float], alias_blur)
 
@@ -803,7 +803,7 @@ class ZoomBlur(ImageOnlyTransform):
         always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p, always_apply)
+        super().__init__(p=p, always_apply=always_apply)
         self.max_factor = cast(tuple[float, float], max_factor)
         self.step_factor = cast(tuple[float, float], step_factor)
 

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -503,6 +503,9 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
         interpolation (OpenCV flag): Flag that is used to specify the interpolation algorithm. Should be one of:
             cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
             Default: cv2.INTER_LINEAR.
+        mask_interpolation (OpenCV flag): Flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         p (float): Probability of applying the transform. Default: 1.0
 
     Targets:
@@ -649,6 +652,9 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
         interpolation (OpenCV flag): Flag that is used to specify the interpolation algorithm. Should be one of:
             cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
             Default: cv2.INTER_LINEAR
+        mask_interpolation (OpenCV flag): Flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST
         p (float): Probability of applying the transform. Default: 1.0
 
     Targets:
@@ -1020,6 +1026,9 @@ class RandomSizedBBoxSafeCrop(BBoxSafeRandomCrop):
         interpolation (OpenCV flag): Flag that is used to specify the interpolation algorithm. Should be one of:
             cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.AREA, cv2.INTER_LANCZOS4.
             Default: cv2.INTER_LINEAR.
+        mask_interpolation (OpenCV flag): Flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         p (float): Probability of applying the transform. Default: 1.0.
 
     Targets:
@@ -1174,6 +1183,11 @@ class CropAndPad(DualTransform):
         interpolation (int):
             OpenCV interpolation flag used for resizing if keep_size is True.
             Default: cv2.INTER_LINEAR.
+
+        mask_interpolation (int):
+            OpenCV interpolation flag used for resizing if keep_size is True.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
 
         p (float):
             Probability of applying the transform. Default: 1.0.

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -1214,6 +1214,7 @@ class CropAndPad(DualTransform):
         keep_size: bool
         sample_independently: bool
         interpolation: InterpolationType
+        mask_interpolation: InterpolationType
 
         @model_validator(mode="after")
         def check_px_percent(self) -> Self:
@@ -1235,6 +1236,7 @@ class CropAndPad(DualTransform):
         keep_size: bool = True,
         sample_independently: bool = True,
         interpolation: int = cv2.INTER_LINEAR,
+        mask_interpolation: int = cv2.INTER_NEAREST,
         always_apply: bool | None = None,
         p: float = 1.0,
     ):
@@ -1251,6 +1253,7 @@ class CropAndPad(DualTransform):
         self.sample_independently = sample_independently
 
         self.interpolation = interpolation
+        self.mask_interpolation = mask_interpolation
 
     def apply(
         self,
@@ -1258,7 +1261,6 @@ class CropAndPad(DualTransform):
         crop_params: Sequence[int],
         pad_params: Sequence[int],
         pad_value: ColorType,
-        interpolation: int,
         **params: Any,
     ) -> np.ndarray:
         return fcrops.crop_and_pad(
@@ -1267,7 +1269,7 @@ class CropAndPad(DualTransform):
             pad_params,
             pad_value,
             params["shape"][:2],
-            interpolation,
+            self.interpolation,
             self.pad_mode,
             self.keep_size,
         )
@@ -1278,7 +1280,6 @@ class CropAndPad(DualTransform):
         crop_params: Sequence[int],
         pad_params: Sequence[int],
         pad_value_mask: float,
-        interpolation: int,
         **params: Any,
     ) -> np.ndarray:
         return fcrops.crop_and_pad(
@@ -1287,7 +1288,7 @@ class CropAndPad(DualTransform):
             pad_params,
             pad_value_mask,
             params["shape"][:2],
-            interpolation,
+            self.mask_interpolation,
             self.pad_mode,
             self.keep_size,
         )
@@ -1463,6 +1464,7 @@ class CropAndPad(DualTransform):
             "keep_size",
             "sample_independently",
             "interpolation",
+            "mask_interpolation",
         )
 
 

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -29,6 +29,9 @@ class RandomScale(DualTransform):
         interpolation (OpenCV flag): flag that is used to specify the interpolation algorithm. Should be one of:
             cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
             Default: cv2.INTER_LINEAR.
+        mask_interpolation (OpenCV flag): flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         p (float): probability of applying the transform. Default: 0.5.
 
     Targets:
@@ -148,6 +151,9 @@ class LongestMaxSize(DualTransform):
         max_size (int, Sequence[int]): Maximum size of the image after the transformation. When using a list or tuple,
             the max size will be randomly selected from the values provided.
         interpolation (OpenCV flag): interpolation method. Default: cv2.INTER_LINEAR.
+        mask_interpolation (OpenCV flag): flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         p (float): probability of applying the transform. Default: 1.
 
     Targets:
@@ -241,6 +247,9 @@ class SmallestMaxSize(DualTransform):
         interpolation (OpenCV flag): Flag that is used to specify the interpolation algorithm. Should be one of:
             cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
             Default: cv2.INTER_LINEAR.
+        mask_interpolation (OpenCV flag): flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         p (float): Probability of applying the transform. Default: 1.
 
     Targets:
@@ -341,6 +350,9 @@ class Resize(DualTransform):
         interpolation (OpenCV flag): flag that is used to specify the interpolation algorithm. Should be one of:
             cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
             Default: cv2.INTER_LINEAR.
+        mask_interpolation (OpenCV flag): flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         p (float): probability of applying the transform. Default: 1.
 
     Targets:

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -65,6 +65,7 @@ class RandomScale(DualTransform):
     class InitSchema(BaseTransformInitSchema):
         scale_limit: ScaleFloatType
         interpolation: InterpolationType
+        mask_interpolation: InterpolationType
 
         @field_validator("scale_limit")
         @classmethod
@@ -75,12 +76,14 @@ class RandomScale(DualTransform):
         self,
         scale_limit: ScaleFloatType = (-0.1, 0.1),
         interpolation: int = cv2.INTER_LINEAR,
+        mask_interpolation: int = cv2.INTER_NEAREST,
         always_apply: bool | None = None,
         p: float = 0.5,
     ):
         super().__init__(p=p, always_apply=always_apply)
         self.scale_limit = cast(tuple[float, float], scale_limit)
         self.interpolation = interpolation
+        self.mask_interpolation = mask_interpolation
 
     def get_params(self) -> dict[str, float]:
         return {"scale": random.uniform(*self.scale_limit)}
@@ -100,7 +103,7 @@ class RandomScale(DualTransform):
         interpolation: int,
         **params: Any,
     ) -> np.ndarray:
-        return fgeometric.scale(mask, scale, cv2.INTER_NEAREST)
+        return fgeometric.scale(mask, scale, self.mask_interpolation)
 
     def apply_to_bboxes(self, bboxes: np.ndarray, **params: Any) -> np.ndarray:
         # Bounding box coordinates are scale invariant
@@ -115,12 +118,17 @@ class RandomScale(DualTransform):
         return fgeometric.keypoints_scale(keypoints, scale, scale)
 
     def get_transform_init_args(self) -> dict[str, Any]:
-        return {"interpolation": self.interpolation, "scale_limit": to_tuple(self.scale_limit, bias=-1.0)}
+        return {
+            "interpolation": self.interpolation,
+            "mask_interpolation": self.mask_interpolation,
+            "scale_limit": to_tuple(self.scale_limit, bias=-1.0),
+        }
 
 
 class MaxSizeInitSchema(BaseTransformInitSchema):
     max_size: int | list[int]
     interpolation: InterpolationType
+    mask_interpolation: InterpolationType | None = None
 
     @field_validator("max_size")
     @classmethod
@@ -177,21 +185,30 @@ class LongestMaxSize(DualTransform):
         self,
         max_size: int | Sequence[int] = 1024,
         interpolation: int = cv2.INTER_LINEAR,
+        mask_interpolation: int = cv2.INTER_NEAREST,
         always_apply: bool | None = None,
         p: float = 1,
     ):
         super().__init__(p, always_apply)
         self.interpolation = interpolation
+        self.mask_interpolation = mask_interpolation
         self.max_size = max_size
 
     def apply(
         self,
         img: np.ndarray,
         max_size: int,
-        interpolation: int,
         **params: Any,
     ) -> np.ndarray:
-        return fgeometric.longest_max_size(img, max_size=max_size, interpolation=interpolation)
+        return fgeometric.longest_max_size(img, max_size=max_size, interpolation=self.interpolation)
+
+    def apply_to_mask(
+        self,
+        mask: np.ndarray,
+        max_size: int,
+        **params: Any,
+    ) -> np.ndarray:
+        return fgeometric.longest_max_size(mask, max_size=max_size, interpolation=self.mask_interpolation)
 
     def apply_to_bboxes(self, bboxes: np.ndarray, **params: Any) -> np.ndarray:
         # Bounding box coordinates are scale invariant
@@ -212,7 +229,7 @@ class LongestMaxSize(DualTransform):
         return {"max_size": self.max_size if isinstance(self.max_size, int) else random.choice(self.max_size)}
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
-        return "max_size", "interpolation"
+        return "max_size", "interpolation", "mask_interpolation"
 
 
 class SmallestMaxSize(DualTransform):
@@ -268,21 +285,30 @@ class SmallestMaxSize(DualTransform):
         self,
         max_size: int | Sequence[int] = 1024,
         interpolation: int = cv2.INTER_LINEAR,
+        mask_interpolation: int = cv2.INTER_NEAREST,
         always_apply: bool | None = None,
         p: float = 1,
     ):
-        super().__init__(p, always_apply)
+        super().__init__(p=p, always_apply=always_apply)
         self.interpolation = interpolation
+        self.mask_interpolation = mask_interpolation
         self.max_size = max_size
 
     def apply(
         self,
         img: np.ndarray,
         max_size: int,
-        interpolation: int,
         **params: Any,
     ) -> np.ndarray:
-        return fgeometric.smallest_max_size(img, max_size=max_size, interpolation=interpolation)
+        return fgeometric.smallest_max_size(img, max_size=max_size, interpolation=self.interpolation)
+
+    def apply_to_mask(
+        self,
+        mask: np.ndarray,
+        max_size: int,
+        **params: Any,
+    ) -> np.ndarray:
+        return fgeometric.smallest_max_size(mask, max_size=max_size, interpolation=self.mask_interpolation)
 
     def apply_to_bboxes(self, bboxes: np.ndarray, **params: Any) -> np.ndarray:
         # Bounding box coordinates are scale invariant
@@ -303,7 +329,7 @@ class SmallestMaxSize(DualTransform):
         return {"max_size": self.max_size if isinstance(self.max_size, int) else random.choice(self.max_size)}
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
-        return "max_size", "interpolation"
+        return "max_size", "interpolation", "mask_interpolation"
 
 
 class Resize(DualTransform):
@@ -331,12 +357,14 @@ class Resize(DualTransform):
         height: int = Field(ge=1)
         width: int = Field(ge=1)
         interpolation: InterpolationType
+        mask_interpolation: InterpolationType
 
     def __init__(
         self,
         height: int,
         width: int,
         interpolation: int = cv2.INTER_LINEAR,
+        mask_interpolation: int = cv2.INTER_NEAREST,
         always_apply: bool | None = None,
         p: float = 1,
     ):
@@ -344,12 +372,13 @@ class Resize(DualTransform):
         self.height = height
         self.width = width
         self.interpolation = interpolation
+        self.mask_interpolation = mask_interpolation
 
     def apply(self, img: np.ndarray, **params: Any) -> np.ndarray:
         return fgeometric.resize(img, (self.height, self.width), interpolation=self.interpolation)
 
-    def apply_to_mask(self, mask: np.ndarray, *args: Any, **params: Any) -> np.ndarray:
-        return fgeometric.resize(mask, (self.height, self.width), interpolation=cv2.INTER_NEAREST)
+    def apply_to_mask(self, mask: np.ndarray, **params: Any) -> np.ndarray:
+        return fgeometric.resize(mask, (self.height, self.width), interpolation=self.mask_interpolation)
 
     def apply_to_bboxes(self, bboxes: np.ndarray, **params: Any) -> np.ndarray:
         # Bounding box coordinates are scale invariant
@@ -362,4 +391,4 @@ class Resize(DualTransform):
         return fgeometric.keypoints_scale(keypoints, scale_x, scale_y)
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
-        return "height", "width", "interpolation"
+        return "height", "width", "interpolation", "mask_interpolation"

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -90,6 +90,9 @@ class Rotate(DualTransform):
             Default: 'largest_box'
         crop_border (bool): Whether to crop border after rotation. If True, the output image size might differ
             from the input. Default: False
+        mask_interpolation (OpenCV flag): flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
@@ -296,6 +299,9 @@ class SafeRotate(Affine):
             for masks.
         rotate_method (str): Method to rotate bounding boxes. Should be 'largest_box' or 'ellipse'.
             Default: 'largest_box'
+        mask_interpolation (OpenCV flag): flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -63,6 +63,8 @@ class RotateInitSchema(BaseTransformInitSchema):
     limit: SymmetricRangeType
 
     interpolation: InterpolationType
+    mask_interpolation: InterpolationType
+
     border_mode: BorderModeType
 
     value: ColorType | None
@@ -142,12 +144,14 @@ class Rotate(DualTransform):
         mask_value: ColorType | None = None,
         rotate_method: Literal["largest_box", "ellipse"] = "largest_box",
         crop_border: bool = False,
+        mask_interpolation: int = cv2.INTER_NEAREST,
         always_apply: bool | None = None,
         p: float = 0.5,
     ):
         super().__init__(p=p, always_apply=always_apply)
         self.limit = cast(tuple[float, float], limit)
         self.interpolation = interpolation
+        self.mask_interpolation = mask_interpolation
         self.border_mode = border_mode
         self.value = value
         self.mask_value = mask_value
@@ -179,7 +183,7 @@ class Rotate(DualTransform):
         y_max: int,
         **params: Any,
     ) -> np.ndarray:
-        img_out = fgeometric.rotate(mask, angle, cv2.INTER_NEAREST, self.border_mode, self.mask_value)
+        img_out = fgeometric.rotate(mask, angle, self.mask_interpolation, self.border_mode, self.mask_value)
         if self.crop_border:
             return fcrops.crop(img_out, x_min, y_min, x_max, y_max)
         return img_out
@@ -259,7 +263,16 @@ class Rotate(DualTransform):
         return out_params
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
-        return "limit", "interpolation", "border_mode", "value", "mask_value", "rotate_method", "crop_border"
+        return (
+            "limit",
+            "interpolation",
+            "border_mode",
+            "value",
+            "mask_value",
+            "rotate_method",
+            "crop_border",
+            "mask_interpolation",
+        )
 
 
 class SafeRotate(Affine):
@@ -339,6 +352,7 @@ class SafeRotate(Affine):
         value: ColorType | None = None,
         mask_value: ColorType | None = None,
         rotate_method: Literal["largest_box", "ellipse"] = "largest_box",
+        mask_interpolation: int = cv2.INTER_NEAREST,
         always_apply: bool | None = None,
         p: float = 0.5,
     ):
@@ -352,6 +366,7 @@ class SafeRotate(Affine):
             cval_mask=mask_value,
             rotate_method=rotate_method,
             fit_output=True,
+            mask_interpolation=mask_interpolation,
             p=p,
             always_apply=always_apply,
         )
@@ -361,9 +376,18 @@ class SafeRotate(Affine):
         self.value = value
         self.mask_value = mask_value
         self.rotate_method = rotate_method
+        self.mask_interpolation = mask_interpolation
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
-        return "limit", "interpolation", "border_mode", "value", "mask_value", "rotate_method"
+        return (
+            "limit",
+            "interpolation",
+            "border_mode",
+            "value",
+            "mask_value",
+            "rotate_method",
+            "mask_interpolation",
+        )
 
     def _create_safe_rotate_matrix(
         self,

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -73,6 +73,9 @@ class BaseDistortion(DualTransform):
             cv2.BORDER_CONSTANT. Default: None
         mask_value (ColorType | None): Padding value for mask if
             border_mode is cv2.BORDER_CONSTANT. Default: None
+        mask_interpolation (int): Flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         p (float): Probability of applying the transform. Default: 0.5
 
     Targets:
@@ -182,6 +185,9 @@ class ElasticTransform(BaseDistortion):
             less accurate for large sigma values. Default: False
         same_dxdy (bool): Whether to use the same random displacement field for both x and y
             directions. Can speed up the transform at the cost of less diverse distortions. Default: False
+        mask_interpolation (int): Flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         p (float): Probability of applying the transform. Default: 0.5
 
     Targets:
@@ -227,8 +233,8 @@ class ElasticTransform(BaseDistortion):
         mask_value: ScalarType | list[ScalarType] | None = None,
         always_apply: bool | None = None,
         approximate: bool = False,
-        mask_interpolation: int = cv2.INTER_NEAREST,
         same_dxdy: bool = False,
+        mask_interpolation: int = cv2.INTER_NEAREST,
         p: float = 0.5,
     ):
         super().__init__(
@@ -291,6 +297,11 @@ class Perspective(DualTransform):
             to True. If False, parts of the transformed image may be outside of the image plane.
             This setting should not be set to True when using large scale values as it could lead to very large images.
             Default: False.
+        interpolation (int): Interpolation method to be used for image transformation. Should be one
+            of the OpenCV interpolation types. Default: cv2.INTER_LINEAR
+        mask_interpolation (int): Flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
@@ -850,6 +861,9 @@ class ShiftScaleRotate(Affine):
             in the range [-, 1]. Default: None.
         rotate_method (str): rotation method used for the bounding boxes. Should be one of "largest_box" or "ellipse".
             Default: "largest_box"
+        mask_interpolation (OpenCV flag): Flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         p (float): probability of applying the transform. Default: 0.5.
 
     Targets:
@@ -873,6 +887,7 @@ class ShiftScaleRotate(Affine):
         shift_limit_x: ScaleFloatType | None = Field(default=None)
         shift_limit_y: ScaleFloatType | None = Field(default=None)
         rotate_method: Literal["largest_box", "ellipse"] = "largest_box"
+        mask_interpolation: InterpolationType
 
         @model_validator(mode="after")
         def check_shift_limit(self) -> Self:
@@ -903,6 +918,7 @@ class ShiftScaleRotate(Affine):
         shift_limit_x: ScaleFloatType | None = None,
         shift_limit_y: ScaleFloatType | None = None,
         rotate_method: Literal["largest_box", "ellipse"] = "largest_box",
+        mask_interpolation: InterpolationType = cv2.INTER_NEAREST,
         always_apply: bool | None = None,
         p: float = 0.5,
     ):
@@ -912,7 +928,7 @@ class ShiftScaleRotate(Affine):
             rotate=rotate_limit,
             shear=(0, 0),
             interpolation=interpolation,
-            mask_interpolation=cv2.INTER_NEAREST,
+            mask_interpolation=mask_interpolation,
             cval=value,
             cval_mask=mask_value,
             mode=border_mode,
@@ -946,6 +962,7 @@ class ShiftScaleRotate(Affine):
             "value": self.value,
             "mask_value": self.mask_value,
             "rotate_method": self.rotate_method,
+            "mask_interpolation": self.mask_interpolation,
         }
 
 
@@ -978,8 +995,9 @@ class PiecewiseAffine(DualTransform):
              - 3: Bi-cubic
              - 4: Bi-quartic
              - 5: Bi-quintic
-        mask_interpolation (int): The order of interpolation for masks. Similar to 'interpolation' but for masks.
-            Default: 0 (Nearest-neighbor).
+        mask_interpolation (OpenCV flag): Flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         cval (number): The constant value to use when filling in newly created pixels.
             Default: 0.
         cval_mask (number): The constant value to use when filling in newly created pixels in masks.
@@ -1673,8 +1691,9 @@ class OpticalDistortion(BaseDistortion):
             is cv2.BORDER_CONSTANT. Default: None.
         mask_value (int, float, list of int, list of float): Padding value for mask
             if border_mode is cv2.BORDER_CONSTANT. Default: None.
-        always_apply (bool): If True, the transform will be always applied.
-            Default: None.
+        mask_interpolation (OpenCV flag): Flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
@@ -1779,7 +1798,9 @@ class GridDistortion(BaseDistortion):
         normalized (bool): If True, ensures that the distortion does not move pixels
             outside the image boundaries. This can result in less extreme distortions
             but guarantees that no information is lost. Default: True.
-        always_apply (bool): If True, the transform will be always applied. Default: None.
+        mask_interpolation (OpenCV flag): Flag that is used to specify the interpolation algorithm for mask.
+            Should be one of: cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4.
+            Default: cv2.INTER_NEAREST.
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -101,7 +101,7 @@ class BaseCompose(Serializable):
     check_each_transform: tuple[DataProcessor, ...] | None = None
     main_compose: bool = True
 
-    def __init__(self, transforms: TransformsSeqType, p: float):
+    def __init__(self, transforms: TransformsSeqType, p: float, mask_interpolation: int | None = None):
         if isinstance(transforms, (BaseCompose, BasicTransform)):
             warnings.warn(
                 "transforms is single transform, but a sequence is expected! Transform will be wrapped into list.",
@@ -118,6 +118,19 @@ class BaseCompose(Serializable):
         self._available_keys: set[str] = set()
         self.processors: dict[str, BboxProcessor | KeypointsProcessor] = {}
         self._set_keys()
+        self.set_mask_interpolation(mask_interpolation)
+
+    def set_mask_interpolation(self, mask_interpolation: int | None) -> None:
+        self.mask_interpolation = mask_interpolation
+        self._set_mask_interpolation_recursive(self.transforms)
+
+    def _set_mask_interpolation_recursive(self, transforms: TransformsSeqType) -> None:
+        for transform in transforms:
+            if isinstance(transform, BasicTransform):
+                if hasattr(transform, "mask_interpolation") and self.mask_interpolation is not None:
+                    transform.mask_interpolation = self.mask_interpolation
+            elif isinstance(transform, BaseCompose):
+                transform.set_mask_interpolation(self.mask_interpolation)
 
     def __iter__(self) -> Iterator[TransformType]:
         return iter(self.transforms)
@@ -228,20 +241,43 @@ class BaseCompose(Serializable):
 
 
 class Compose(BaseCompose, HubMixin):
-    """Compose transforms and handle all transformations regarding bounding boxes
+    """Compose multiple transforms together and apply them sequentially to input data.
+
+    This class allows you to chain multiple image augmentation transforms and apply them
+    in a specified order. It also handles bounding box and keypoint transformations if
+    the appropriate parameters are provided.
 
     Args:
-        transforms (list): list of transformations to compose.
-        bbox_params (BboxParams): Parameters for bounding boxes transforms
-        keypoint_params (KeypointParams): Parameters for keypoints transforms
-        additional_targets (dict): Dict with keys - new target name, values - old target name. ex: {'image2': 'image'}
-        p (float): probability of applying all list of transforms. Default: 1.0.
-        is_check_shapes (bool): If True shapes consistency of images/mask/masks would be checked on each call. If you
-            would like to disable this check - pass False (do it only if you are sure in your data consistency).
-        strict (bool): If True, unknown keys will raise an error. If False, unknown keys will be ignored. Default: True.
-        return_params (bool): if True returns params of each applied transform
-        save_key (str): key to save applied params, default is 'applied_params'
+        transforms (List[Union[BasicTransform, BaseCompose]]): A list of transforms to apply.
+        bbox_params (Union[dict, BboxParams, None]): Parameters for bounding box transforms.
+            Can be a dict of params or a BboxParams object. Default is None.
+        keypoint_params (Union[dict, KeypointParams, None]): Parameters for keypoint transforms.
+            Can be a dict of params or a KeypointParams object. Default is None.
+        additional_targets (Dict[str, str], optional): A dictionary mapping additional target names
+            to their types. For example, {'image2': 'image'}. Default is None.
+        p (float): Probability of applying all transforms. Should be in range [0, 1]. Default is 1.0.
+        is_check_shapes (bool): If True, checks consistency of shapes for image/mask/masks on each call.
+            Disable only if you are sure about your data consistency. Default is True.
+        strict (bool): If True, raises an error on unknown input keys. If False, ignores them. Default is True.
+        return_params (bool): If True, returns parameters of applied transforms. Default is False.
+        save_key (str): Key to save applied params if return_params is True. Default is 'applied_params'.
+        mask_interpolation (int, optional): Interpolation method for mask transforms. When defined,
+            it overrides the interpolation method specified in individual transforms. Default is None.
 
+    Example:
+        >>> import albumentations as A
+        >>> transform = A.Compose([
+        ...     A.RandomCrop(width=256, height=256),
+        ...     A.HorizontalFlip(p=0.5),
+        ...     A.RandomBrightnessContrast(p=0.2),
+        ... ])
+        >>> transformed = transform(image=image)
+
+    Note:
+        - The class checks the validity of input data and shapes if is_check_args and is_check_shapes are True.
+        - When bbox_params or keypoint_params are provided, it sets up the corresponding processors.
+        - The transform can handle additional targets specified in the additional_targets dictionary.
+        - If return_params is True, it will return the parameters of applied transforms in the output.
     """
 
     def __init__(
@@ -257,7 +293,7 @@ class Compose(BaseCompose, HubMixin):
         save_key: str = "applied_params",
         mask_interpolation: int | None = None,  # Add this parameter
     ):
-        super().__init__(transforms=transforms, p=p)
+        super().__init__(transforms=transforms, p=p, mask_interpolation=mask_interpolation)
 
         if bbox_params:
             if isinstance(bbox_params, dict):
@@ -304,17 +340,6 @@ class Compose(BaseCompose, HubMixin):
             self.set_deterministic(True, save_key=save_key)
 
         self._set_processors_for_transforms(self.transforms)
-
-        self.mask_interpolation = mask_interpolation
-        self._set_mask_interpolation(self.transforms)
-
-    def _set_mask_interpolation(self, transforms: TransformsSeqType) -> None:
-        for transform in transforms:
-            if isinstance(transform, BasicTransform):
-                if hasattr(transform, "mask_interpolation") and self.mask_interpolation is not None:
-                    transform.mask_interpolation = self.mask_interpolation
-            elif isinstance(transform, BaseCompose):
-                self._set_mask_interpolation(transform.transforms)
 
     def _set_processors_for_transforms(self, transforms: TransformsSeqType) -> None:
         for transform in transforms:
@@ -518,18 +543,40 @@ class OneOf(BaseCompose):
 
 
 class SomeOf(BaseCompose):
-    """Select N transforms to apply. Selected transforms will be called with `force_apply=True`.
-    Transforms probabilities will be normalized to one 1, so in this case transforms probabilities works as weights.
+    """Apply a random subset of transforms from the given list.
+
+    This class selects a specified number of transforms from the provided list
+    and applies them to the input data. The selection can be done with or without
+    replacement, allowing for the same transform to be potentially applied multiple times.
 
     Args:
-        transforms (list): list of transformations to compose.
-        n (int): number of transforms to apply.
-        replace (bool): Whether the sampled transforms are with or without replacement. Default: True.
-        p (float): probability of applying selected transform. Default: 1.
+        transforms (List[Union[BasicTransform, BaseCompose]]): A list of transforms to choose from.
+        n (int): The number of transforms to apply. If greater than the number of
+                 transforms and replace=False, it will be set to the number of transforms.
+        replace (bool): Whether to sample transforms with replacement. Default is True.
+        p (float): Probability of applying the selected transforms. Should be in the range [0, 1].
+                   Default is 1.0.
+        mask_interpolation (int, optional): Interpolation method for mask transforms.
+                                            When defined, it overrides the interpolation method
+                                            specified in individual transforms. Default is None.
 
+    Note:
+        - If `n` is greater than the number of transforms and `replace` is False,
+          `n` will be set to the number of transforms with a warning.
+        - The probabilities of individual transforms are used as weights for sampling.
+        - When `replace` is True, the same transform can be selected multiple times.
+
+    Example:
+        >>> import albumentations as A
+        >>> transform = A.SomeOf([
+        ...     A.HorizontalFlip(p=1),
+        ...     A.VerticalFlip(p=1),
+        ...     A.RandomBrightnessContrast(p=1),
+        ... ], n=2, replace=False, p=0.5)
+        >>> # This will apply 2 out of the 3 transforms with 50% probability
     """
 
-    def __init__(self, transforms: TransformsSeqType, n: int, replace: bool = True, p: float = 1):
+    def __init__(self, transforms: TransformsSeqType, n: int = 1, replace: bool = False, p: float = 1):
         super().__init__(transforms, p)
         self.n = n
         if not replace and n > len(self.transforms):

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -255,8 +255,9 @@ class Compose(BaseCompose, HubMixin):
         strict: bool = True,
         return_params: bool = False,
         save_key: str = "applied_params",
+        mask_interpolation: int | None = None,  # Add this parameter
     ):
-        super().__init__(transforms, p)
+        super().__init__(transforms=transforms, p=p)
 
         if bbox_params:
             if isinstance(bbox_params, dict):
@@ -303,6 +304,17 @@ class Compose(BaseCompose, HubMixin):
             self.set_deterministic(True, save_key=save_key)
 
         self._set_processors_for_transforms(self.transforms)
+
+        self.mask_interpolation = mask_interpolation
+        self._set_mask_interpolation(self.transforms)
+
+    def _set_mask_interpolation(self, transforms: TransformsSeqType) -> None:
+        for transform in transforms:
+            if isinstance(transform, BasicTransform):
+                if hasattr(transform, "mask_interpolation") and self.mask_interpolation is not None:
+                    transform.mask_interpolation = self.mask_interpolation
+            elif isinstance(transform, BaseCompose):
+                self._set_mask_interpolation(transform.transforms)
 
     def _set_processors_for_transforms(self, transforms: TransformsSeqType) -> None:
         for transform in transforms:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1411,3 +1411,21 @@ def test_mask_interpolation(augmentation_cls, params, interpolation):
     assert transformed["mask"].flags["C_CONTIGUOUS"]
 
     np.testing.assert_array_equal(transformed["mask"], transformed["image"])
+
+
+
+@pytest.mark.parametrize("interpolation", [cv2.INTER_NEAREST,
+                                                cv2.INTER_LINEAR,
+                                                cv2.INTER_CUBIC,
+                                                cv2.INTER_AREA
+                                                ])
+@pytest.mark.parametrize("compose", [A.Compose, A.OneOf, A.Sequential, A.SomeOf])
+def test_mask_interpolation_someof(interpolation, compose):
+    transform = A.Compose([compose([A.Affine(p=1), A.RandomSizedCrop(min_max_height=(4, 8), size= (113, 103), p=1)], p=1)], mask_interpolation=interpolation)
+
+    image = SQUARE_UINT8_IMAGE
+    mask = image.copy()
+
+    transformed = transform(image=image, mask=mask)
+
+    assert transformed["mask"].flags["C_CONTIGUOUS"]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1370,6 +1370,7 @@ def test_masks_as_target(augmentation_cls, params, masks):
             A.RandomSizedCrop: {"min_max_height": (4, 8), "size": (113, 103)},
             A.Resize: {"height": 113, "width": 113},
             A.GridElasticDeform: {"num_grid_xy": (10, 10), "magnitude": 10},
+            A.CropAndPad: {"px": 10},
         },
         except_augmentations={
             A.RandomSizedBBoxSafeCrop,
@@ -1377,7 +1378,6 @@ def test_masks_as_target(augmentation_cls, params, masks):
             A.CropNonEmptyMaskIfExists,
             A.PixelDistributionAdaptation,
             A.PadIfNeeded,
-            A.CropAndPad,
             A.RandomCrop,
             A.Crop,
             A.CenterCrop,

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -111,6 +111,7 @@ def test_binary_mask_interpolation(augmentation_cls, params):
             A.RandomSizedCrop: {"min_max_height": (4, 8), "size": (113, 103)},
             A.Resize: {"height": 113, "width": 113},
             A.GridElasticDeform: {"num_grid_xy": (10, 10), "magnitude": 10},
+            A.CropAndPad: {"px": 10},
         },
         except_augmentations={
             A.RandomSizedBBoxSafeCrop,
@@ -118,7 +119,6 @@ def test_binary_mask_interpolation(augmentation_cls, params):
             A.CropNonEmptyMaskIfExists,
             A.PixelDistributionAdaptation,
             A.PadIfNeeded,
-            A.CropAndPad,
             A.RandomCrop,
             A.Crop,
             A.CenterCrop,

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -107,25 +107,32 @@ def test_binary_mask_interpolation(augmentation_cls, params):
     ["augmentation_cls", "params"],
     get_dual_transforms(
         custom_arguments={
-            A.Crop: {"y_min": 0, "y_max": 10, "x_min": 0, "x_max": 10},
-            A.CenterCrop: {"height": 10, "width": 10},
-            A.CropNonEmptyMaskIfExists: {"height": 10, "width": 10},
-            A.RandomCrop: {"height": 10, "width": 10},
-            A.RandomResizedCrop: {"height": 10, "width": 10},
-            A.RandomSizedCrop: {"min_max_height": (4, 8), "height": 10, "width": 10},
-            A.Resize: {"height": 10, "width": 10},
-            A.PixelDropout: {"dropout_prob": 0.5, "mask_drop_value": 10, "drop_value": 20},
+            A.RandomResizedCrop: {"size": (113, 103)},
+            A.RandomSizedCrop: {"min_max_height": (4, 8), "size": (113, 103)},
+            A.Resize: {"height": 113, "width": 113},
             A.GridElasticDeform: {"num_grid_xy": (10, 10), "magnitude": 10},
         },
         except_augmentations={
-            A.RandomCropNearBBox,
             A.RandomSizedBBoxSafeCrop,
-            A.BBoxSafeRandomCrop,
-            A.CropAndPad,
             A.PixelDropout,
-            A.XYMasking,
+            A.CropNonEmptyMaskIfExists,
+            A.PixelDistributionAdaptation,
+            A.PadIfNeeded,
+            A.CropAndPad,
+            A.RandomCrop,
+            A.Crop,
+            A.CenterCrop,
+            A.FDA,
+            A.HistogramMatching,
+            A.Lambda,
+            A.TemplateTransform,
+            A.CropNonEmptyMaskIfExists,
+            A.BBoxSafeRandomCrop,
             A.OverlayElements,
             A.TextImage,
+            A.FromFloat,
+            A.MaskDropout,
+            A.XYMasking,
         },
     ),
 )
@@ -136,7 +143,7 @@ def test_semantic_mask_interpolation(augmentation_cls, params):
     mask = np.random.randint(low=0, high=4, size=(100, 100), dtype=np.uint8) * 64
 
     data = aug(image=image, mask=mask)
-    assert np.array_equal(np.unique(data["mask"]), np.array([0, 64, 128, 192]))
+    np.testing.assert_array_equal(np.unique(data["mask"]), np.array([0, 64, 128, 192]))
 
 
 def __test_multiprocessing_support_proc(args):


### PR DESCRIPTION
Fixes: 

https://github.com/albumentations-team/albumentations/issues/1344
https://github.com/albumentations-team/albumentations/issues/850
https://github.com/albumentations-team/albumentations/issues/1145
https://github.com/albumentations-team/albumentations/issues/233

## Summary by Sourcery

Introduce a 'mask_interpolation' parameter to allow specifying interpolation methods for masks in geometric transformations, addressing several related issues. Update tests to ensure the correct application of this new parameter.

Bug Fixes:
- Fix mask interpolation issues in various geometric transformations by allowing specification of interpolation methods.

Enhancements:
- Add a new parameter 'mask_interpolation' to various transformation classes to specify the interpolation algorithm for masks.

Tests:
- Add tests to verify the correct application of mask interpolation across different transformations.