### PR TITLE
Fix optical distortion

### DIFF
--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -140,7 +140,7 @@ class BaseDistortion(DualTransform):
     def apply_to_bboxes(self, bboxes: np.ndarray, map_x: np.ndarray, map_y: np.ndarray, **params: Any) -> np.ndarray:
         image_shape = params["shape"][:2]
         bboxes_denorm = denormalize_bboxes(bboxes, image_shape)
-        bboxes_returned = fgeometric.distortion_bboxes(bboxes_denorm, map_x, map_y, image_shape, self.border_mode)
+        bboxes_returned = fgeometric.distortion_bboxes(bboxes_denorm, map_x, map_y, image_shape)
         return normalize_bboxes(bboxes_returned, image_shape)
 
     def apply_to_keypoints(


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2007

## Summary by Sourcery

Fix optical distortion in bounding boxes by updating the distortion_bboxes function and add comprehensive test cases to ensure correct behavior.

Bug Fixes:
- Fix optical distortion in bounding boxes by updating the distortion_bboxes function to correctly transform corner points and reshape them back to bounding box format.

Tests:
- Add new test cases for distortion_bboxes function to verify correct handling of identity mapping, simple translation, multiple bounding boxes, boundary conditions, and complex distortion patterns.