### PR TITLE
Update piecewise affine

### DIFF
--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -1597,7 +1597,7 @@ def test_random_resized_crop():
     ],
 )
 def test_distortion_bboxes(bboxes, map_x, map_y, image_shape, expected):
-    result = fgeometric.distortion_bboxes(bboxes, map_x, map_y, image_shape)
+    result = fgeometric.remap_bboxes(bboxes, map_x, map_y, image_shape)
     np.testing.assert_array_almost_equal(result, expected)
 
 
@@ -1615,7 +1615,7 @@ def test_distortion_bboxes_complex_distortion():
     map_x = x + (x - c_x) / factor
     map_y = y + (y - c_y) / factor
 
-    result = fgeometric.distortion_bboxes(bboxes, map_x, map_y, image_shape)
+    result = fgeometric.remap_bboxes(bboxes, map_x, map_y, image_shape)
 
     # Check that the result is different from input but still valid
     assert not np.array_equal(result, bboxes)


### PR DESCRIPTION
## Summary by Sourcery

Replace the piecewise affine transformation with a remap-based approach and update related functions and tests.

Enhancements:
- Replace the piecewise affine transformation with a new remap-based approach for image, keypoints, and bounding boxes.

Tests:
- Add tests for the new create_piecewise_affine_maps function to ensure correct map shapes, bounds, and reproducibility.