### PR TITLE
Remove scikit image

### DIFF
--- a/albumentations/augmentations/text/transforms.py
+++ b/albumentations/augmentations/text/transforms.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Annotated, Any, Literal
 
 import numpy as np
-from PIL import ImageFont
 from pydantic import AfterValidator
 
 import albumentations.augmentations.text.functional as ftext
@@ -151,6 +150,12 @@ class TextImage(ImageOnlyTransform):
         text: str,
         bbox_index: int,
     ) -> dict[str, Any]:
+        try:
+            from PIL import ImageFont
+        except ImportError as err:
+            raise ImportError(
+                "ImageFont from PIL is required to use TextImage transform. Install it with `pip install Pillow`.",
+            ) from err
         check_bboxes(np.array([bbox]))
         denormalized_bbox = denormalize_bboxes(np.array([bbox]), image.shape[:2])[0]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ pytest>=8.3.3
 pytest_cov>=5.0.0
 pytest_mock>=3.14.0
 requests>=2.31.0
+scikit-image
 tomli>=2.0.1
 torch>=2.3.1
 torchvision>=0.18.1

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ from pkg_resources import DistributionNotFound, get_distribution
 from setuptools import setup, find_packages
 
 INSTALL_REQUIRES = [
-    "numpy>=1.24.4", "scipy>=1.10.0", "scikit-image>=0.21.0",
+    "numpy>=1.24.4",
+    "scipy>=1.10.0",
     "PyYAML",
     "typing-extensions>=4.9.0; python_version<'3.10'",
     "pydantic>=2.7.0",


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/1895

## Summary by Sourcery

Remove the dependency on scikit-image by refactoring the superpixels function to use numpy operations instead of regionprops, and update the setup.py to reflect this change.

Enhancements:
- Refactor the superpixels function to remove the dependency on scikit-image by replacing regionprops with numpy operations.

Build:
- Remove scikit-image from the list of installation requirements in setup.py.