### PR TITLE
Fix maintainers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.12.1
+    rev: v1.13.0
     hooks:
       - id: mypy
         files: ^albumentations/

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,12 @@
+# Project Maintainers
+
+## Current Maintainer
+
+Vladimir Iglovikov
+
+## Emeritus Team Members
+
+- Alexander Buslaev
+- Alex Parinov
+- Eugene Khvedchenya
+- Mikhail Druzhinin

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Here is an example of how you can apply some [pixel-level](#pixel-level-transfor
   - [Sponsors](#sponsors)
   - [Table of contents](#table-of-contents)
   - [Authors](#authors)
+    - [Current Maintainer](#current-maintainer)
+    - [Emeritus Core Team Members](#emeritus-core-team-members)
   - [Installation](#installation)
   - [Documentation](#documentation)
   - [A simple example](#a-simple-example)
@@ -64,19 +66,23 @@ Here is an example of how you can apply some [pixel-level](#pixel-level-transfor
 
 ## Authors
 
+### Current Maintainer
+
 [**Vladimir I. Iglovikov**](https://www.linkedin.com/in/iglovikov/) | [Kaggle Grandmaster](https://www.kaggle.com/iglovikov)
+
+### Emeritus Core Team Members
 
 [**Mikhail Druzhinin**](https://www.linkedin.com/in/mikhail-druzhinin-548229100/) | [Kaggle Expert](https://www.kaggle.com/dipetm)
 
 [**Alex Parinov**](https://www.linkedin.com/in/alex-parinov/) | [Kaggle Master](https://www.kaggle.com/creafz)
 
-[**Alexander Buslaev** — Computer Vision Engineer at Mapbox](https://www.linkedin.com/in/al-buslaev/) | [Kaggle Master](https://www.kaggle.com/albuslaev)
+[**Alexander Buslaev**](https://www.linkedin.com/in/al-buslaev/) | [Kaggle Master](https://www.kaggle.com/albuslaev)
 
-[**Evegene Khvedchenya** — Computer Vision Research Engineer at Piñata Farms](https://www.linkedin.com/in/cvtalks/) | [Kaggle Grandmaster](https://www.kaggle.com/bloodaxe)
+[**Eugene Khvedchenya**](https://www.linkedin.com/in/cvtalks/) | [Kaggle Grandmaster](https://www.kaggle.com/bloodaxe)
 
 ## Installation
 
-Albumentations requires Python 3.8 or higher. To install the latest version from PyPI:
+Albumentations requires Python 3.9 or higher. To install the latest version from PyPI:
 
 ```bash
 pip install -U albumentations

--- a/albumentations/__init__.py
+++ b/albumentations/__init__.py
@@ -1,3 +1,6 @@
+__author__ = "Vladimir Iglovikov"
+__maintainer__ = "Vladimir Iglovikov"
+
 import os
 
 from albumentations.check_version import check_for_updates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,10 @@ keywords = [
   "tensorflow",
 ]
 license = { file = "LICENSE" }
-authors = [
-  { name = "Vladimir I. Iglovikov" },
-  { name = "Mikhail Druzhinin" },
-  { name = "Alex Parinov" },
-  { name = "Alexander Buslaev" },
-  { name = "Eugene Khvedchenya" },
-]
+
+maintainers = [ { name = "Vladimir Iglovikov" } ]
+
+authors = [ { name = "Vladimir Iglovikov" } ]
 requires-python = ">=3.9"
 
 classifiers = [
@@ -51,6 +48,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Scientific/Engineering :: Image Processing",
   "Topic :: Software Development :: Libraries",
@@ -185,6 +183,14 @@ no_implicit_reexport = true
 
 # for strict mypy: (this is the tricky one :-))
 disallow_untyped_defs = true
+
+[tool.albumentations.maintainers]
+emeritus = [
+  "Alexander Buslaev",
+  "Alex Parinov",
+  "Eugene Khvedchenya",
+  "Mikhail Druzhinin",
+]
 
 [tool.pydantic-mypy]
 init_forbid_extra = true


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2006

## Summary by Sourcery

Update the maintainers' information in the documentation and adjust the Python version requirement. Add a new MAINTAINERS.md file to list current and emeritus team members.

Documentation:
- Add a 'Current Maintainer' and 'Emeritus Core Team Members' section to the README.md to clarify the roles of contributors.

Chores:
- Update the Python version requirement from 3.8 to 3.9 in the installation instructions.