### PR TITLE
Implement ToTensorv2 for multiple images

### DIFF
--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -31,7 +31,12 @@ class ToTensorV2(BasicTransform):
 
     @property
     def targets(self) -> dict[str, Any]:
-        return {"image": self.apply, "images": self.apply_to_images, "mask": self.apply_to_mask, "masks": self.apply_to_masks}
+        return {
+            "image": self.apply,
+            "images": self.apply_to_images,
+            "mask": self.apply_to_mask,
+            "masks": self.apply_to_masks,
+        }
 
     def apply(self, img: np.ndarray, **params: Any) -> torch.Tensor:
         if len(img.shape) not in [2, 3]:

--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -31,7 +31,7 @@ class ToTensorV2(BasicTransform):
 
     @property
     def targets(self) -> dict[str, Any]:
-        return {"image": self.apply, "mask": self.apply_to_mask, "masks": self.apply_to_masks}
+        return {"image": self.apply, "images": self.apply_to_images, "mask": self.apply_to_mask, "masks": self.apply_to_masks}
 
     def apply(self, img: np.ndarray, **params: Any) -> torch.Tensor:
         if len(img.shape) not in [2, 3]:
@@ -42,6 +42,9 @@ class ToTensorV2(BasicTransform):
             img = np.expand_dims(img, 2)
 
         return torch.from_numpy(img.transpose(2, 0, 1))
+
+    def apply_to_images(self, images: list[np.ndarray], **params: Any) -> list[torch.Tensor]:
+        return [self.apply(image, **params) for image in images]
 
     def apply_to_mask(self, mask: np.ndarray, **params: Any) -> torch.Tensor:
         if self.transpose_mask and mask.ndim == NUM_MULTI_CHANNEL_DIMENSIONS:


### PR DESCRIPTION
The current behavior is the following:

```python
>>> import numpy as np
>>> import albumentations as A
>>> from albumentations.pytorch import ToTensorV2
>>> 
>>> t = A.Compose([
...     ToTensorV2(),
... ])
>>> x = [np.zeros((224, 224, 3))]
>>> x = t(images=x)['images']
>>> 
>>> print(type(x[0]))
<class 'numpy.ndarray'>
```

Is that an expected behavior? I added a handler on the `ToTensorV2` class to also transform lists of images, let me know if I'm missing something

## Summary by Sourcery

New Features:
- Add support for transforming lists of images to tensors using ToTensorV2.