### PR TITLE
Fix version

### DIFF
--- a/albumentations/__init__.py
+++ b/albumentations/__init__.py
@@ -1,7 +1,7 @@
 from importlib.metadata import metadata
 
 try:
-    _metadata = metadata("albucore")
+    _metadata = metadata("albumentations")
     __version__ = _metadata["Version"]
     __author__ = _metadata["Author"]
     __maintainer__ = _metadata["Maintainer"]

--- a/albumentations/check_version.py
+++ b/albumentations/check_version.py
@@ -5,6 +5,8 @@ from warnings import warn
 
 from albumentations import __version__ as current_version
 
+__version__: str = current_version  # type: ignore[has-type]
+
 SUCCESS_HTML_CODE = 200
 
 opener = None
@@ -18,7 +20,8 @@ def get_opener() -> OpenerDirector:
 
 
 def fetch_version_info() -> str:
-    opener = urllib.request.build_opener(urllib.request.HTTPHandler(), urllib.request.HTTPSHandler())
+    # Use get_opener() instead of creating a new opener
+    opener = get_opener()
     url = "https://pypi.org/pypi/albumentations/json"
     try:
         with opener.open(url, timeout=2) as response:

--- a/albumentations/check_version.py
+++ b/albumentations/check_version.py
@@ -5,7 +5,7 @@ from warnings import warn
 
 from albumentations import __version__ as current_version
 
-__version__: str = current_version  # type: ignore[has-type]
+__version__: str = current_version
 
 SUCCESS_HTML_CODE = 200
 
@@ -20,7 +20,6 @@ def get_opener() -> OpenerDirector:
 
 
 def fetch_version_info() -> str:
-    # Use get_opener() instead of creating a new opener
     opener = get_opener()
     url = "https://pypi.org/pypi/albumentations/json"
     try:

--- a/tests/functional/test_affine.py
+++ b/tests/functional/test_affine.py
@@ -266,10 +266,6 @@ def calculate_iou(img1, img2):
     union = np.logical_or(img1, img2)
     return np.sum(intersection) / np.sum(union)
 
-def visualize_difference(original, restored, shape, angle, scale):
-    diff = np.abs(original.astype(int) - restored.astype(int))
-    cv2.imwrite(f"diff_{shape}_angle{angle}_scale{scale}.png", diff)
-
 
 @pytest.mark.parametrize(
     "image_shape",
@@ -340,9 +336,6 @@ def test_inverse_angle_scale(image_shape, angle, shape, scale):
 
     mean_diff = np.mean(diff)
     num_diff_pixels = np.sum(diff > 0)
-
-    # Visualize the difference
-    visualize_difference(image, restored_img, shape, angle, scale)
 
     # Assert that the differences are within acceptable limits
     assert iou > 0.97, f"IoU ({iou}) is too low"

--- a/tests/test_check_version.py
+++ b/tests/test_check_version.py
@@ -86,3 +86,48 @@ def test_check_for_updates_exception():
         check_for_updates()
         mock_warn.assert_called_once()
         assert "Failed to check for updates" in mock_warn.call_args[0][0]
+
+@pytest.mark.parametrize("response_data, expected_version", [
+    ('{"info": {"version": "1.0.0"}}', "1.0.0"),
+    ('{"info": {}}', ""),
+    ('{}', ""),
+    ('', ""),
+    ('invalid json', ""),
+])
+def test_parse_version(response_data: str, expected_version: str):
+    assert parse_version(response_data) == expected_version
+
+def test_fetch_version_info_success():
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b'{"info": {"version": "1.0.0"}}'
+    mock_response.info.return_value.get_content_charset.return_value = "utf-8"
+    # Set up the context manager behavior
+    mock_response.__enter__.return_value = mock_response
+    mock_response.__exit__.return_value = None
+
+    mock_opener = MagicMock()
+    mock_opener.open.return_value = mock_response
+
+    with patch("albumentations.check_version.get_opener", return_value=mock_opener):
+        data = fetch_version_info()
+        assert data == '{"info": {"version": "1.0.0"}}'
+
+def test_fetch_version_info_failure():
+    with patch("urllib.request.OpenerDirector.open", side_effect=Exception("Network error")):
+        data = fetch_version_info()
+        assert data == ""
+
+def test_check_for_updates_no_update():
+    with patch("albumentations.check_version.fetch_version_info", return_value='{"info": {"version": "1.0.0"}}'):
+        with patch("albumentations.check_version.__version__", "1.0.0"):
+            with patch("warnings.warn") as mock_warn:
+                check_for_updates()
+                mock_warn.assert_not_called()
+
+def test_check_for_updates_with_update():
+    with patch("albumentations.check_version.fetch_version_info", return_value='{"info": {"version": "2.0.0"}}'):
+        with patch("albumentations.check_version.current_version", "1.0.0"):
+            with patch("albumentations.check_version.warn") as mock_warn:  # Patch the imported warn
+                check_for_updates()
+                mock_warn.assert_called_once()

--- a/tests/test_check_version.py
+++ b/tests/test_check_version.py
@@ -28,8 +28,8 @@ def test_fetch_version_info(status_code, expected_result):
     mock_response.status = status_code
     mock_response.read.return_value = expected_result.encode("utf-8")
     mock_response.__enter__.return_value = mock_response
+    mock_response.__exit__.return_value = None
 
-    # Mock the info() method and its get_content_charset() method
     mock_info = MagicMock()
     mock_info.get_content_charset.return_value = "utf-8"
     mock_response.info.return_value = mock_info
@@ -37,13 +37,9 @@ def test_fetch_version_info(status_code, expected_result):
     mock_opener = MagicMock()
     mock_opener.open.return_value = mock_response
 
-    with patch("urllib.request.build_opener", return_value=mock_opener):
+    with patch("albumentations.check_version.get_opener", return_value=mock_opener):
         result = fetch_version_info()
         assert result == expected_result
-
-    # Verify that open was called with the correct URL and timeout
-    mock_opener.open.assert_called_once_with("https://pypi.org/pypi/albumentations/json", timeout=2)
-
 
 @pytest.mark.parametrize(
     "input_data,expected_version",


### PR DESCRIPTION
Fix for https://github.com/albumentations-team/albumentations/issues/2020

## Summary by Sourcery

Fix the version fetching mechanism by using a custom get_opener function and enhance the test suite with additional test cases for version parsing and response handling. Remove unnecessary visualization code from tests to streamline the test suite.

Bug Fixes:
- Fix the version fetching mechanism by replacing the direct use of urllib's build_opener with a custom get_opener function.

Enhancements:
- Remove the visualize_difference function from the test suite to clean up the test code.

Tests:
- Add new test cases for parsing version information and handling different response scenarios in version checking.