### PR TITLE
Fix random order

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         files: setup.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.7.0
+    rev: v0.7.1
     hooks:
       # Run the linter.
       - id: ruff
@@ -77,7 +77,7 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "2.4.3"
+    rev: "v2.4.3"
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/albumentations/check_version.py
+++ b/albumentations/check_version.py
@@ -5,7 +5,7 @@ from warnings import warn
 
 from albumentations import __version__ as current_version
 
-__version__: str = current_version
+__version__: str = current_version  # type: ignore[has-type, unused-ignore]
 
 SUCCESS_HTML_CODE = 200
 


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2021

## Summary by Sourcery

Fix the random order of transformations in the RandomOrder class and enhance its documentation. Update pre-commit configuration to use newer versions of ruff and pyproject-fmt.

Bug Fixes:
- Fix the random order of transformations in the RandomOrder class to ensure correct application of transforms.

Enhancements:
- Improve the RandomOrder class by updating its docstring to provide clearer guidance on its usage and attributes.

Build:
- Update pre-commit configuration to use newer versions of ruff and pyproject-fmt.