### PR TITLE
Fix to tensor v2 docsting

### DIFF
--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -20,12 +20,11 @@ class ToTensorV2(BasicTransform):
     Attributes:
         transpose_mask (bool): If True, transposes 3D input mask dimensions from `[height, width, num_channels]` to
             `[num_channels, height, width]`.
-        always_apply (bool): Deprecated. Default: None.
         p (float): Probability of applying the transform. Default: 1.0.
 
     Note:
-        - For 2D images (HW), the output will be HW1 format
-        - For 3D images (HWC), the output will be CHW format
+        - For 2D images (HW), the output will be 1xHxW format
+        - For 3D images (HWC), the output will be CxHxW format
     """
 
     _targets = (Targets.IMAGE, Targets.MASK)
@@ -44,11 +43,11 @@ class ToTensorV2(BasicTransform):
         }
 
     def apply(self, img: np.ndarray, **params: Any) -> torch.Tensor:
-        if len(img.shape) not in [2, 3]:
+        if img.ndim not in {MONO_CHANNEL_DIMENSIONS, NUM_MULTI_CHANNEL_DIMENSIONS}:
             msg = "Albumentations only supports images in HW or HWC format"
             raise ValueError(msg)
 
-        if len(img.shape) == MONO_CHANNEL_DIMENSIONS:
+        if img.ndim == MONO_CHANNEL_DIMENSIONS:
             img = np.expand_dims(img, 2)
 
         return torch.from_numpy(img.transpose(2, 0, 1))

--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -12,8 +12,10 @@ __all__ = ["ToTensorV2"]
 
 
 class ToTensorV2(BasicTransform):
-    """Converts images/masks to PyTorch Tensors, inheriting from BasicTransform. Supports images in numpy `HWC` format
-    and converts them to PyTorch `CHW` format. If the image is in `HW` format, it will be converted to PyTorch `HW`.
+    """Converts images/masks to PyTorch Tensors, inheriting from BasicTransform.
+    For images:
+        - If input is in `HWC` format, converts to PyTorch `CHW` format
+        - If input is in `HW` format, converts to PyTorch `HWC` format (adds channel dimension)
 
     Attributes:
         transpose_mask (bool): If True, transposes 3D input mask dimensions from `[height, width, num_channels]` to
@@ -21,6 +23,9 @@ class ToTensorV2(BasicTransform):
         always_apply (bool): Deprecated. Default: None.
         p (float): Probability of applying the transform. Default: 1.0.
 
+    Note:
+        - For 2D images (HW), the output will be HW1 format
+        - For 3D images (HWC), the output will be CHW format
     """
 
     _targets = (Targets.IMAGE, Targets.MASK)

--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -15,16 +15,12 @@ class ToTensorV2(BasicTransform):
     """Converts images/masks to PyTorch Tensors, inheriting from BasicTransform.
     For images:
         - If input is in `HWC` format, converts to PyTorch `CHW` format
-        - If input is in `HW` format, converts to PyTorch `HWC` format (adds channel dimension)
+        - If input is in `HW` format, converts to PyTorch `1HW` format (adds channel dimension)
 
     Attributes:
         transpose_mask (bool): If True, transposes 3D input mask dimensions from `[height, width, num_channels]` to
             `[num_channels, height, width]`.
         p (float): Probability of applying the transform. Default: 1.0.
-
-    Note:
-        - For 2D images (HW), the output will be 1xHxW format
-        - For 3D images (HWC), the output will be CxHxW format
     """
 
     _targets = (Targets.IMAGE, Targets.MASK)


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2029

## Summary by Sourcery

Fix the condition for checking image dimensions in the apply method and update the ToTensorV2 class docstring for clarity.

Bug Fixes:
- Correct the condition for checking image dimensions in the apply method to use img.ndim instead of len(img.shape).

Documentation:
- Revise the docstring for the ToTensorV2 class to clarify the conversion process for images in different formats.