### PR TITLE
Clean depencencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ INSTALL_REQUIRES = [
     "typing-extensions>=4.9.0; python_version<'3.10'",
     "pydantic>=2.7.0",
     "albucore==0.0.19",
-    "eval-type-backport",
 ]
 
 MIN_OPENCV_VERSION = "4.9.0.80"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove unused dependency 'eval-type-backport' from setup.py.