### PR TITLE
Update albucore

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -11,6 +11,7 @@ from albucore import (
     MAX_VALUES_BY_DTYPE,
     add,
     add_array,
+    add_constant,
     add_weighted,
     clip,
     clipped,
@@ -116,10 +117,10 @@ def shift_hsv(img: np.ndarray, hue_shift: float, sat_shift: float, val_shift: fl
         hue = sz_lut(hue, lut_hue, inplace=False)
 
     if sat_shift != 0:
-        sat = add(sat, sat_shift, inplace=False)
+        sat = add_constant(sat, sat_shift)
 
     if val_shift != 0:
-        val = add(val, val_shift, inplace=False)
+        val = add_constant(val, val_shift)
 
     img = cv2.merge((hue, sat, val))
     img = cv2.cvtColor(img, cv2.COLOR_HSV2RGB)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ INSTALL_REQUIRES = [
     "PyYAML",
     "typing-extensions>=4.9.0; python_version<'3.10'",
     "pydantic>=2.7.0",
-    "albucore==0.0.19",
+    "albucore==0.0.20",
     "eval-type-backport",
 ]
 


### PR DESCRIPTION
## Summary by Sourcery

Enhance the 'shift_hsv' function by using 'add_constant' for hue and saturation adjustments and update the 'albucore' dependency to version 0.0.20.

Enhancements:
- Replace the use of the 'add' function with 'add_constant' for hue and saturation adjustments in the 'shift_hsv' function.

Build:
- Update the 'albucore' dependency version from 0.0.19 to 0.0.20 in the setup configuration.