### PR TITLE
Fix in crop

### DIFF
--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -223,7 +223,11 @@ class BaseCropAndPad(BaseCrop):
         image_shape = params["shape"][:2]
 
         if pad_params is not None:
-            # First apply padding to keypoints
+            # Calculate padded dimensions
+            padded_height = image_shape[0] + pad_params["pad_top"] + pad_params["pad_bottom"]
+            padded_width = image_shape[1] + pad_params["pad_left"] + pad_params["pad_right"]
+
+            # First apply padding to keypoints using original image shape
             keypoints = fgeometric.pad_keypoints(
                 keypoints,
                 pad_params["pad_top"],
@@ -233,6 +237,9 @@ class BaseCropAndPad(BaseCrop):
                 self.pad_mode,
                 image_shape=image_shape,
             )
+
+            # Update image shape for subsequent crop operation
+            params = {**params, "shape": (padded_height, padded_width)}
 
         return super().apply_to_keypoints(keypoints, crop_coords, **params)
 

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -1943,7 +1943,7 @@ def pad_keypoints(
     border_mode: int,
     image_shape: tuple[int, int],
 ) -> np.ndarray:
-    if border_mode not in {cv2.BORDER_REFLECT_101, cv2.BORDER_REFLECT101}:
+    if border_mode not in REFLECT_BORDER_MODES:
         shift_vector = np.array([pad_left, pad_top])  # Only shift x and y
         return shift_keypoints(keypoints, shift_vector)
 

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -151,7 +151,7 @@ POSITIONS: list[PositionType] = ["center", "top_left", "top_right", "bottom_left
     ]
 )
 @pytest.mark.parametrize("pad_position", POSITIONS)
-@pytest.mark.parametrize("pad_mode", [cv2.BORDER_CONSTANT, cv2.BORDER_REFLECT_101])
+@pytest.mark.parametrize("pad_mode", [cv2.BORDER_CONSTANT, cv2.BORDER_REFLECT_101, cv2.BORDER_REFLECT])
 def test_pad_position_equivalence(
     image: np.ndarray,
     crop_cls: type[A.DualTransform],


### PR DESCRIPTION
## Summary by Sourcery

Fix keypoint padding logic by updating image shape after padding, refactor border mode check, and enhance test coverage for additional border mode.

Bug Fixes:
- Fix padding calculation for keypoints by updating image shape after padding is applied.

Enhancements:
- Refactor border mode check in pad_keypoints function to use a predefined set of reflect border modes.

Tests:
- Add test coverage for additional border mode cv2.BORDER_REFLECT in pad position equivalence tests.