### PR TITLE
Add dump params

### DIFF
--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -931,30 +931,6 @@ def test_crop_boxes_replay_compose() -> None:
     np.testing.assert_almost_equal(transformed["bboxes"], transformed2["bboxes"])
 
 
-def test_crop_boxes_return_params() -> None:
-    image = np.ones((512, 384, 3))
-    bboxes = [(78, 42, 142, 80), (32, 12, 42, 72), (200, 100, 300, 200)]
-    labels = [0, 1, 2]
-    transform = Compose(
-        [RandomCrop(256, 256, p=1.0)],
-        bbox_params=BboxParams(
-            format="pascal_voc",
-            min_area=16,
-            label_fields=["labels"],
-        ),
-        return_params=True,
-    )
-
-    input_data = dict(image=image, bboxes=bboxes, labels=labels)
-    transformed = transform(**input_data)
-    transformed2 = transform.run_with_params(
-        params=transformed["applied_params"],
-        **input_data,
-    )
-
-    np.testing.assert_almost_equal(transformed["bboxes"], transformed2["bboxes"])
-
-
 def test_bounding_box_partially_outside_no_clip() -> None:
     """Test error is raised when bounding box exceeds image boundaries without clipping."""
     # Define a transformation with NoOp

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1477,9 +1477,6 @@ def test_params_content(image, transform_class, transform_params):
     transform_name, params = result["applied_transforms"][0]
 
     assert transform_name == transform_class.__name__
-    if transform_params:  # Some transforms like HorizontalFlip don't have params
-        for param in params:
-            assert isinstance(params[param], (int, float, bool, tuple, np.int64))
 
 def test_no_param_tracking():
     """Test that params are not tracked when save_applied_params=False"""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1429,3 +1429,27 @@ def test_mask_interpolation_someof(interpolation, compose):
     transformed = transform(image=image, mask=mask)
 
     assert transformed["mask"].flags["C_CONTIGUOUS"]
+
+
+@pytest.mark.parametrize(
+    ["transform", "expected_param_keys"],
+    [
+        (A.HorizontalFlip(p=1), {"cols", "rows", "shape"}),
+        (A.VerticalFlip(p=1), {"cols", "rows", "shape"}),
+        (
+            A.RandomBrightnessContrast(p=1),
+            {"cols", "rows", "shape", "alpha", "beta"}
+        ),
+        (
+            A.Rotate(p=1),
+            {'shape', 'cols', 'rows', 'x_min', 'x_max', 'y_min', 'y_max', 'matrix', 'bbox_matrix', 'interpolation'}
+        ),
+    ],
+)
+def test_transform_returns_params(transform, expected_param_keys):
+    image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+    transform(image=image)
+    params = transform.get_applied_params()
+    print("P = ", params)
+    assert isinstance(params, dict)
+    assert set(params.keys()) == expected_param_keys

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -141,8 +141,6 @@ def test_bbox_params_edges(
 
 POSITIONS: list[PositionType] = ["center", "top_left", "top_right", "bottom_left", "bottom_right"]
 
-
-
 @pytest.mark.parametrize(
     ["crop_cls", "crop_params"],
     [

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -144,22 +144,6 @@ def test_with_replaycompose() -> None:
     assert res2["mask"].dtype == torch.uint8
 
 
-def test_with_return_params() -> None:
-    aug = A.Compose([ToTensorV2()], return_params=True)
-    kwargs = {
-        "image": np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8),
-        "mask": np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8),
-    }
-    res = aug(**kwargs)
-    res2 = aug.run_with_params(params=res["applied_params"], **kwargs)
-    assert np.array_equal(res["image"], res2["image"])
-    assert np.array_equal(res["mask"], res2["mask"])
-    assert res["image"].dtype == torch.uint8
-    assert res["mask"].dtype == torch.uint8
-    assert res2["image"].dtype == torch.uint8
-    assert res2["mask"].dtype == torch.uint8
-
-
 @pytest.mark.parametrize(
     ["brightness", "contrast", "saturation", "hue"],
     [


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/1786

## Summary by Sourcery

Add a new feature to track and save the parameters of applied transforms in the Compose class by introducing the 'save_applied_params' parameter. Refactor the transform selection logic with a new base class 'TransformSelector' and its subclasses to improve code organization and functionality. Update tests to cover the new feature and remove obsolete tests related to the deprecated 'return_params' feature.

New Features:
- Introduce a new parameter 'save_applied_params' to track and save the parameters of applied transforms in the Compose class.

Enhancements:
- Refactor the transform selection logic by introducing a new base class 'TransformSelector' and its subclasses 'OneOf', 'SomeOf', 'RandomOrder', and 'OneOrOther' to streamline the selection and application of transforms.

Tests:
- Add tests to verify the functionality of the new 'save_applied_params' feature, ensuring that transform parameters are correctly tracked and saved when enabled.
- Remove tests related to the deprecated 'return_params' feature, which has been replaced by 'save_applied_params'.