### PR TITLE
Update elastic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         files: setup.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.7.1
+    rev: v0.7.2
     hooks:
       # Run the linter.
       - id: ruff


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2046

## Summary by Sourcery

Add support for configurable noise distribution in the ElasticTransform class, allowing users to select between Gaussian and uniform distributions for displacement fields. Refactor related functions for improved clarity and update the pre-commit configuration to the latest Ruff version.

New Features:
- Introduce a new parameter 'noise_distribution' to the ElasticTransform class, allowing users to choose between 'gaussian' and 'uniform' noise distributions for generating displacement fields.

Enhancements:
- Refactor the generate_displacement_fields function to support different noise distributions and improve code readability.

Build:
- Update the pre-commit configuration to use Ruff version v0.7.2.