### PR TITLE
Simplify blur parameters

### DIFF
--- a/albumentations/augmentations/blur/functional.py
+++ b/albumentations/augmentations/blur/functional.py
@@ -144,7 +144,7 @@ def _ensure_odd_values(result: tuple[int, int], field_name: str | None = None) -
 
 def process_blur_limit(value: ScaleIntType, info: ValidationInfo, min_value: int = 0) -> tuple[int, int]:
     """Process blur limit to ensure valid kernel sizes."""
-    result = (min_value, value) if not isinstance(value, Sequence) else value
+    result = value if isinstance(value, Sequence) else (min_value, value)
 
     result = _ensure_min_value(result, min_value, info.field_name)
     result = _ensure_odd_values(result, info.field_name)

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Sequence
 from typing import Any, Literal, cast
 
 import cv2
@@ -29,58 +28,13 @@ HALF = 0.5
 TWO = 2
 
 
-def process_blur_limit(value: ScaleIntType, info: ValidationInfo, min_value: int = 0) -> tuple[int, int]:
-    """Process blur limit to ensure valid kernel sizes."""
-    # Convert to tuple if single value
-    result = (min_value, value) if not isinstance(value, Sequence) else value
-    original = result
-
-    # Ensure minimum value
-    if result[0] < min_value or result[1] < min_value:
-        result = (max(min_value, result[0]), max(min_value, result[1]))
-        warnings.warn(
-            f"{info.field_name}: Invalid kernel size range {original}. "
-            f"Values less than {min_value} are not allowed. "
-            f"Range automatically adjusted to {result}.",
-            UserWarning,
-            stacklevel=2,
-        )
-
-    # Ensure odd values by rounding up to next odd number, but only for non-zero values
-    new_result = (
-        result[0] if result[0] == 0 or result[0] % 2 == 1 else result[0] + 1,
-        result[1] if result[1] == 0 or result[1] % 2 == 1 else result[1] + 1,
-    )
-    if new_result != result:
-        warnings.warn(
-            f"{info.field_name}: Non-zero kernel sizes must be odd. "
-            f"Range {result} automatically adjusted to {new_result}.",
-            UserWarning,
-            stacklevel=2,
-        )
-        result = new_result
-
-    # Ensure min <= max
-    if result[0] > result[1]:
-        final_result = (result[1], result[1])
-        warnings.warn(
-            f"{info.field_name}: Invalid range {result} (min > max). "
-            f"Range automatically adjusted to {final_result}.",
-            UserWarning,
-            stacklevel=2,
-        )
-        return final_result
-
-    return result
-
-
 class BlurInitSchema(BaseTransformInitSchema):
     blur_limit: ScaleIntType
 
     @field_validator("blur_limit")
     @classmethod
     def process_blur(cls, value: ScaleIntType, info: ValidationInfo) -> tuple[int, int]:
-        return process_blur_limit(value, info, min_value=3)
+        return fblur.process_blur_limit(value, info, min_value=3)
 
 
 class Blur(ImageOnlyTransform):
@@ -387,7 +341,7 @@ class GaussianBlur(ImageOnlyTransform):
         @field_validator("blur_limit")
         @classmethod
         def process_blur(cls, value: ScaleIntType, info: ValidationInfo) -> tuple[int, int]:
-            return process_blur_limit(value, info, min_value=0)
+            return fblur.process_blur_limit(value, info, min_value=0)
 
         @model_validator(mode="after")
         def validate_limits(self) -> Self:

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -31,8 +31,8 @@ from typing_extensions import Literal, Self, TypedDict
 
 import albumentations.augmentations.dropout.functional as fdropout
 import albumentations.augmentations.geometric.functional as fgeometric
-from albumentations.augmentations.blur.functional import blur
-from albumentations.augmentations.blur.transforms import BlurInitSchema, process_blur_limit
+from albumentations.augmentations.blur import functional as fblur
+from albumentations.augmentations.blur.transforms import BlurInitSchema
 from albumentations.augmentations.utils import check_range, non_rgb_error
 from albumentations.core.bbox_utils import BboxProcessor, denormalize_bboxes, normalize_bboxes
 from albumentations.core.keypoints_utils import KeypointsProcessor
@@ -4215,7 +4215,7 @@ class UnsharpMask(ImageOnlyTransform):
         @field_validator("blur_limit")
         @classmethod
         def process_blur(cls, value: ScaleIntType, info: ValidationInfo) -> tuple[int, int]:
-            return process_blur_limit(value, info, min_value=3)
+            return fblur.process_blur_limit(value, info, min_value=3)
 
     def __init__(
         self,
@@ -4566,12 +4566,12 @@ class Spatter(ImageOnlyTransform):
             dist = 255 - cv2.Canny(liquid_layer, 50, 150)
             dist = cv2.distanceTransform(dist, cv2.DIST_L2, 5)
             _, dist = cv2.threshold(dist, 20, 20, cv2.THRESH_TRUNC)
-            dist = clip(blur(dist, 3), np.uint8, inplace=True)
+            dist = clip(fblur.blur(dist, 3), np.uint8, inplace=True)
             dist = fmain.equalize(dist)
 
             ker = np.array([[-2, -1, 0], [-1, 1, 1], [0, 1, 2]])
             dist = fmain.convolve(dist, ker)
-            dist = blur(dist, 3).astype(np.float32)
+            dist = fblur.blur(dist, 3).astype(np.float32)
 
             m = liquid_layer * dist
             m *= 1 / np.max(m, axis=(0, 1))

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -5,8 +5,8 @@ import numpy as np
 import pytest
 
 import albumentations as A
-from albumentations.augmentations.blur.functional import gaussian_blur
-from albumentations.augmentations.blur.transforms import process_blur_limit
+from albumentations.augmentations.blur import functional as fblur
+
 from albumentations.core.transforms_interface import BasicTransform
 from tests.conftest import UINT8_IMAGES
 
@@ -112,7 +112,7 @@ def test_gaus_blur_limits(
     aug = A.Compose([A.GaussianBlur(blur_limit=blur_limit, sigma_limit=sigma, p=1)])
 
     res = aug(image=img)["image"]
-    assert np.allclose(res, gaussian_blur(img, result_blur, result_sigma))
+    np.testing.assert_allclose(res, fblur.gaussian_blur(img, result_blur, result_sigma))
 
 
 class MockValidationInfo:
@@ -197,7 +197,7 @@ def test_process_blur_limit(
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        result = process_blur_limit(value, info, min_value)
+        result = fblur.process_blur_limit(value, info, min_value)
 
         assert result == expected
         assert len(w) == len(warning_messages)
@@ -208,11 +208,11 @@ def test_process_blur_limit_sequence_check() -> None:
     info = MockValidationInfo("test_field")
 
     # Test with integer input
-    result = process_blur_limit(5, info, min_value=0)
+    result = fblur.process_blur_limit(5, info, min_value=0)
     assert isinstance(result, tuple)
     assert result == (0, 5)
 
     # Test with float input
-    result = process_blur_limit(5.0, info, min_value=0)
+    result = fblur.process_blur_limit(5.0, info, min_value=0)
     assert isinstance(result, tuple)
     assert result == (0, 5)

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -1,9 +1,12 @@
 
+from typing import Any
+import warnings
 import numpy as np
 import pytest
 
 import albumentations as A
 from albumentations.augmentations.blur.functional import gaussian_blur
+from albumentations.augmentations.blur.transforms import process_blur_limit
 from albumentations.core.transforms_interface import BasicTransform
 from tests.conftest import UINT8_IMAGES
 
@@ -75,8 +78,6 @@ def test_advanced_blur_float_uint8_diff_less_than_two(val_uint8: list[int]) -> N
 @pytest.mark.parametrize(
     "params",
     [
-        {"blur_limit": (2, 5)},
-        {"blur_limit": (3, 6)},
         {"sigma_x_limit": (0.0, 1.0), "sigma_y_limit": (0.0, 1.0)},
         {"beta_limit": (0.1, 0.9)},
         {"beta_limit": (1.1, 8.0)},
@@ -112,3 +113,106 @@ def test_gaus_blur_limits(
 
     res = aug(image=img)["image"]
     assert np.allclose(res, gaussian_blur(img, result_blur, result_sigma))
+
+
+class MockValidationInfo:
+    def __init__(self, field_name: str):
+        self.field_name = field_name
+
+
+@pytest.mark.parametrize(
+    ["value", "min_value", "expected", "warning_messages"],
+    [
+        # Basic valid cases - no warnings
+        ((3, 5), 3, (3, 5), []),
+        ((0, 3), 0, (0, 3), []),
+        (5, 3, (3, 5), []),
+
+        # Adjust values below min_value
+        (
+            (1, 2),
+            3,
+            (3, 3),
+            ["test_field: Invalid kernel size range (1, 2). Values less than 3 are not allowed. Range automatically adjusted to (3, 3)."]
+        ),
+        # Adjust values below min_value (with automatic odd adjustment)
+        (
+            (-1, 4),
+            0,
+            (0, 5),
+            [
+                "test_field: Non-zero kernel sizes must be odd. Range (0, 4) automatically adjusted to (0, 5)",
+                "test_field: Invalid kernel size range (-1, 4). Values less than 0 are not allowed. Range automatically adjusted to (0, 4)."
+            ]
+        ),
+
+        # Adjust non-odd values
+        (
+            (3, 4),
+            3,
+            (3, 5),
+            ["test_field: Non-zero kernel sizes must be odd. Range (3, 4) automatically adjusted to (3, 5)."]
+        ),
+        (
+            (4, 8),
+            0,
+            (5, 9),
+            ["test_field: Non-zero kernel sizes must be odd. Range (4, 8) automatically adjusted to (5, 9)."]
+        ),
+
+        # Special case: keep zero values
+        (
+            (0, 4),
+            0,
+            (0, 5),
+            ["test_field: Non-zero kernel sizes must be odd. Range (0, 4) automatically adjusted to (0, 5)."]
+        ),
+
+        # Fix min > max
+        (
+            (7, 5),
+            3,
+            (5, 5),
+            ["test_field: Invalid range (7, 5) (min > max). Range automatically adjusted to (5, 5)."]
+        ),
+        # Multiple adjustments
+        (
+            (2, 4),
+            3,
+            (3, 5),
+            [
+                "test_field: Invalid kernel size range (2, 4). Values less than 3 are not allowed. Range automatically adjusted to (3, 4).",
+                "test_field: Non-zero kernel sizes must be odd. Range (3, 4) automatically adjusted to (3, 5).",
+            ]
+        ),
+    ]
+)
+def test_process_blur_limit(
+    value: Any,
+    min_value: int,
+    expected: tuple[int, int],
+    warning_messages: list[str]
+) -> None:
+    info = MockValidationInfo("test_field")
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = process_blur_limit(value, info, min_value)
+
+        assert result == expected
+        assert len(w) == len(warning_messages)
+
+
+def test_process_blur_limit_sequence_check() -> None:
+    """Test that non-sequence values are properly converted to tuples."""
+    info = MockValidationInfo("test_field")
+
+    # Test with integer input
+    result = process_blur_limit(5, info, min_value=0)
+    assert isinstance(result, tuple)
+    assert result == (0, 5)
+
+    # Test with float input
+    result = process_blur_limit(5.0, info, min_value=0)
+    assert isinstance(result, tuple)
+    assert result == (0, 5)


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2066

## Summary by Sourcery

Simplify and correct the handling of blur limit parameters by ensuring valid kernel sizes and adding comprehensive tests for various input scenarios.

Bug Fixes:
- Fix the handling of blur limit parameters to ensure valid kernel sizes, including adjustments for minimum values, odd values, and ensuring min is less than or equal to max.

Tests:
- Add tests for the process_blur_limit function to validate handling of various input scenarios, including adjustments for minimum values, odd values, and sequence conversion.