### PR TITLE
Add time reverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [SafeRotate](https://explore.albumentations.ai/transform/SafeRotate)                             | ✓     | ✓    | ✓      | ✓         |
 | [ShiftScaleRotate](https://explore.albumentations.ai/transform/ShiftScaleRotate)                 | ✓     | ✓    | ✓      | ✓         |
 | [SmallestMaxSize](https://explore.albumentations.ai/transform/SmallestMaxSize)                   | ✓     | ✓    | ✓      | ✓         |
+| [TimeReverse](https://explore.albumentations.ai/transform/TimeReverse)                           | ✓     | ✓    | ✓      | ✓         |
 | [Transpose](https://explore.albumentations.ai/transform/Transpose)                               | ✓     | ✓    | ✓      | ✓         |
 | [VerticalFlip](https://explore.albumentations.ai/transform/VerticalFlip)                         | ✓     | ✓    | ✓      | ✓         |
 | [XYMasking](https://explore.albumentations.ai/transform/XYMasking)                               | ✓     | ✓    | ✓      | ✓         |

--- a/albumentations/augmentations/__init__.py
+++ b/albumentations/augmentations/__init__.py
@@ -17,6 +17,7 @@ from .geometric.rotate import *
 from .geometric.transforms import *
 from .mixing.functional import *
 from .mixing.transforms import *
+from .spectrogram.transform import *
 from .text.functional import *
 from .text.transforms import *
 from .transforms import *

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -1884,8 +1884,8 @@ class D4(DualTransform):
 
     def __init__(
         self,
-        always_apply: bool | None = None,
         p: float = 1,
+        always_apply: bool | None = None,
     ):
         super().__init__(p=p, always_apply=always_apply)
 

--- a/albumentations/augmentations/spectrogram/transform.py
+++ b/albumentations/augmentations/spectrogram/transform.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from albumentations.augmentations.geometric.transforms import HorizontalFlip
+from albumentations.core.transforms_interface import BaseTransformInitSchema
+from albumentations.core.types import Targets
+
+__all__ = [
+    "TimeReverse",
+]
+
+
+class TimeReverse(HorizontalFlip):
+    """Reverse the time axis of a spectrogram image, also known as time inversion.
+
+    Time inversion of a spectrogram is analogous to the random flip of an image,
+    an augmentation technique widely used in the visual domain. This can be relevant
+    in the context of audio classification tasks when working with spectrograms.
+    The technique was successfully applied in the AudioCLIP paper, which extended
+    CLIP to handle image, text, and audio inputs.
+
+    This transform is implemented as a subclass of HorizontalFlip since reversing
+    time in a spectrogram is equivalent to flipping the image horizontally.
+
+    Args:
+        p (float): probability of applying the transform. Default: 0.5.
+
+    Targets:
+        image, mask, bboxes, keypoints
+
+    Image types:
+        uint8, float32
+
+    Number of channels:
+        Any
+
+    Note:
+        This transform is functionally identical to HorizontalFlip but provides
+        a more semantically meaningful name when working with spectrograms and
+        other time-series visualizations.
+
+    References:
+        - AudioCLIP paper: https://arxiv.org/abs/2106.13043
+        - Audiomentations: https://iver56.github.io/audiomentations/waveform_transforms/reverse/
+    """
+
+    _targets = (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS)
+
+    class InitSchema(BaseTransformInitSchema):
+        pass
+
+    def __init__(
+        self,
+        p: float = 0.5,
+        always_apply: bool | None = None,
+    ):
+        super().__init__(p=p, always_apply=always_apply)

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -379,4 +379,5 @@ AUGMENTATION_CLS_PARAMS = [
     ],
     [A.GridElasticDeform, {"num_grid_xy": (10, 10), "magnitude": 10}],
     [A.ShotNoise, {"scale_range": (0.1, 0.3)}],
+    [A.TimeReverse, {}],
 ]

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -49,51 +49,9 @@ def extract_targets_from_docstring(cls):
 
 
 DUAL_TARGETS = {
-    A.Affine: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.BBoxSafeRandomCrop: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.CenterCrop: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.RandomCrop: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.RandomCropFromBorders: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.RandomResizedCrop: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.CropNonEmptyMaskIfExists: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.CoarseDropout: (Targets.IMAGE, Targets.MASK, Targets.KEYPOINTS, Targets.BBOXES),
-    A.Crop: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.CropAndPad: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.Flip: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.VerticalFlip: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.HorizontalFlip: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.PadIfNeeded: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.RandomScale: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.XYMasking: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.NoOp: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.Resize: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.Rotate: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.RandomRotate90: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.Transpose: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.SmallestMaxSize: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.ShiftScaleRotate: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.ElasticTransform: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.GridDistortion: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.LongestMaxSize: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.PiecewiseAffine: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.RandomSizedCrop: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.RandomCropFromBorders: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.RandomGridShuffle: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.OpticalDistortion: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.SafeRotate: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.CropNonEmptyMaskIfExists: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.XYMasking: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.RandomCropNearBBox: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.Perspective: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.RandomSizedBBoxSafeCrop: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.Lambda: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.D4: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
     A.OverlayElements: (Targets.IMAGE, Targets.MASK),
-    A.GridElasticDeform: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.MaskDropout: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.Morphological: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
-    A.PixelDropout: (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS),
 }
+
 
 str2target = {
     "image": Targets.IMAGE,
@@ -160,7 +118,7 @@ def test_image_only(augmentation_cls, params):
 )
 def test_dual(augmentation_cls, params):
     aug = augmentation_cls(p=1, **params)
-    assert set(aug._targets) == set(DUAL_TARGETS.get(augmentation_cls, {Targets.IMAGE, Targets.MASK}))
+    assert set(aug._targets) == set(DUAL_TARGETS.get(augmentation_cls, {Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS}))
     assert set(aug._targets) <= get_targets_from_methods(augmentation_cls)
 
     targets_from_docstring = {str2target[target] for target in extract_targets_from_docstring(augmentation_cls)}

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -2054,6 +2054,7 @@ def test_mask_dropout_bboxes(remove_invisible, expected_keypoints):
             A.PiecewiseAffine,
             A.Perspective,
             A.RandomGridShuffle,
+            A.TimeReverse,
         },
     ),
 )


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2119

## Summary by Sourcery

Add a new 'TimeReverse' transformation for spectrogram images, which reverses the time axis similar to a horizontal flip. Update documentation to reflect this addition and include tests to verify its functionality.

New Features:
- Introduce a new transformation called 'TimeReverse' for spectrogram images, which reverses the time axis, analogous to a horizontal flip in image processing.

Enhancements:
- Update the README to include the new 'TimeReverse' transformation in the list of available spatial-level transforms.

Tests:
- Add test cases for the new 'TimeReverse' transformation to ensure its correct functionality.