### PR TITLE
Add time masking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
     - name: Install PyTorch
       run: |
         if [ "${{ matrix.operating-system }}" = "macos-latest" ]; then
-          uv pip install --system torch==2.4.1 torchvision==0.19.1
+          uv pip install --system torch==2.5.1 torchvision==0.20.1
         else
-          uv pip install --system torch==2.4.1+cpu torchvision==0.19.1+cpu --extra-index-url https://download.pytorch.org/whl/cpu
+          uv pip install --system torch==2.5.1+cpu torchvision==0.20.1+cpu --extra-index-url https://download.pytorch.org/whl/cpu
         fi
       shell: bash
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [SafeRotate](https://explore.albumentations.ai/transform/SafeRotate)                             | ✓     | ✓    | ✓      | ✓         |
 | [ShiftScaleRotate](https://explore.albumentations.ai/transform/ShiftScaleRotate)                 | ✓     | ✓    | ✓      | ✓         |
 | [SmallestMaxSize](https://explore.albumentations.ai/transform/SmallestMaxSize)                   | ✓     | ✓    | ✓      | ✓         |
+| [TimeMasking](https://explore.albumentations.ai/transform/TimeMasking)                           | ✓     | ✓    | ✓      | ✓         |
 | [TimeReverse](https://explore.albumentations.ai/transform/TimeReverse)                           | ✓     | ✓    | ✓      | ✓         |
 | [Transpose](https://explore.albumentations.ai/transform/Transpose)                               | ✓     | ✓    | ✓      | ✓         |
 | [VerticalFlip](https://explore.albumentations.ai/transform/VerticalFlip)                         | ✓     | ✓    | ✓      | ✓         |

--- a/albumentations/augmentations/dropout/transforms.py
+++ b/albumentations/augmentations/dropout/transforms.py
@@ -54,6 +54,8 @@ class BaseDropout(DualTransform):
         self.mask_fill_value = mask_fill_value
 
     def apply(self, img: np.ndarray, holes: np.ndarray, seed: int, **params: Any) -> np.ndarray:
+        if holes.size == 0:
+            return img
         if self.fill_value in {"inpaint_telea", "inpaint_ns"}:
             num_channels = get_num_channels(img)
             if num_channels not in {1, 3}:
@@ -61,7 +63,7 @@ class BaseDropout(DualTransform):
         return cutout(img, holes, self.fill_value, np.random.default_rng(seed))
 
     def apply_to_mask(self, mask: np.ndarray, holes: np.ndarray, seed: int, **params: Any) -> np.ndarray:
-        if self.mask_fill_value is None:
+        if self.mask_fill_value is None or holes.size == 0:
             return mask
         return cutout(mask, holes, self.mask_fill_value, np.random.default_rng(seed))
 
@@ -71,6 +73,8 @@ class BaseDropout(DualTransform):
         holes: np.ndarray,
         **params: Any,
     ) -> np.ndarray:
+        if holes.size == 0:
+            return bboxes
         processor = cast(BboxProcessor, self.get_processor("bboxes"))
         if processor is None:
             return bboxes
@@ -96,6 +100,8 @@ class BaseDropout(DualTransform):
         holes: np.ndarray,
         **params: Any,
     ) -> np.ndarray:
+        if holes.size == 0:
+            return keypoints
         processor = cast(KeypointsProcessor, self.get_processor("keypoints"))
 
         if processor is None or not processor.params.remove_invisible:

--- a/albumentations/augmentations/dropout/xy_masking.py
+++ b/albumentations/augmentations/dropout/xy_masking.py
@@ -123,6 +123,7 @@ class XYMasking(BaseDropout):
         masks_y = self.generate_masks(self.num_masks_y, image_shape, self.mask_y_length, axis="y")
 
         holes = np.array(masks_x + masks_y)
+
         return {"holes": holes, "seed": self.random_generator.integers(0, 2**32 - 1)}
 
     def generate_mask_size(self, mask_length: tuple[int, int]) -> int:

--- a/albumentations/augmentations/spectrogram/transform.py
+++ b/albumentations/augmentations/spectrogram/transform.py
@@ -120,7 +120,7 @@ class TimeMasking(XYMasking):
 
     def __init__(
         self,
-        time_mask_param: int = 0,
+        time_mask_param: int = 40,
         p: float = 0.5,
         always_apply: bool | None = None,
     ):

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -552,8 +552,8 @@ class RandomSnow(ImageOnlyTransform):
 
         return result
 
-    def get_transform_init_args_names(self) -> tuple[str, str]:
-        return "snow_point_range", "brightness_coeff"
+    def get_transform_init_args_names(self) -> tuple[str, ...]:
+        return "snow_point_range", "brightness_coeff", "method"
 
 
 class RandomGravel(ImageOnlyTransform):

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -380,4 +380,5 @@ AUGMENTATION_CLS_PARAMS = [
     [A.GridElasticDeform, {"num_grid_xy": (10, 10), "magnitude": 10}],
     [A.ShotNoise, {"scale_range": (0.1, 0.3)}],
     [A.TimeReverse, {}],
+    [A.TimeMasking, {"time_mask_param": 10}],
 ]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1331,6 +1331,7 @@ def test_masks_as_target(augmentation_cls, params, masks):
             A.FromFloat,
             A.MaskDropout,
             A.XYMasking,
+            A.TimeMasking,
         },
     ),
 )
@@ -1343,7 +1344,7 @@ def test_mask_interpolation(augmentation_cls, params, interpolation):
     image = SQUARE_UINT8_IMAGE
     mask = image.copy()
 
-    aug = A.Compose([augmentation_cls(p=1, interpolation=interpolation, mask_interpolation=interpolation, **params)])
+    aug = A.Compose([augmentation_cls(p=1, interpolation=interpolation, mask_interpolation=interpolation, seed=42,**params)])
 
     transformed = aug(image=image, mask=mask)
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1249,6 +1249,7 @@ def test_coarse_dropout_invalid_input(params):
                 "reference_images": [SQUARE_UINT8_IMAGE + 1],
                 "read_fn": lambda x: x,
             },
+            A.TimeMasking: {"time_mask_param": 10},
         },
         except_augmentations={
             A.RandomCropNearBBox,
@@ -1313,6 +1314,7 @@ def test_change_image(augmentation_cls, params):
             A.FancyPCA: {"alpha": 1},
             A.GridElasticDeform: {"num_grid_xy": (10, 10), "magnitude": 10},
             A.RGBShift: {"r_shift_limit": (10, 10), "g_shift_limit": (10, 10), "b_shift_limit": (10, 10)},
+            A.TimeMasking: {"time_mask_param": 10},
         },
         except_augmentations={
             A.Crop,


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2074

## Summary by Sourcery

Add the TimeMasking transform to the library, allowing for time domain masking of spectrograms. Fix issues related to empty 'holes' arrays in transformations. Enhance user guidance with warnings about transform usage and update documentation to reflect new features.

New Features:
- Introduce the TimeMasking transform to apply masking to spectrograms in the time domain, enhancing model robustness against temporal variations.

Bug Fixes:
- Fix the issue where transformations would fail if the 'holes' array was empty by adding checks to return the original data in such cases.

Enhancements:
- Add warnings to inform users about the alias nature of TimeReverse and the specialized nature of TimeMasking, suggesting alternatives for more flexibility.

Documentation:
- Update README to include documentation for the new TimeMasking transform.

Tests:
- Add test cases for the new TimeMasking transform to ensure its correct functionality.