### PR TITLE
Fix random shadow intensity

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -980,8 +980,9 @@ def add_shadow(img: np.ndarray, vertices_list: list[np.ndarray], intensities: np
         # Apply shadow to the channels directly
         # It could be tempting to convert to HLS and apply the shadow to the L channel, but it creates artifacts
         shadowed_indices = mask[:, :, 0] == max_value
+        darkness = 1 - shadow_intensity
         img_shadowed[shadowed_indices] = clip(
-            img_shadowed[shadowed_indices] * shadow_intensity,
+            img_shadowed[shadowed_indices] * darkness,
             np.uint8,
             inplace=True,
         )

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1413,8 +1413,8 @@ class RandomShadow(ImageOnlyTransform):
         num_shadows_limit (tuple[int, int]): Lower and upper limits for the possible number of shadows.
             Default: (1, 2).
         shadow_dimension (int): Number of edges in the shadow polygons. Default: 5.
-        shadow_intensity_range (tuple[float, float]): Range for the shadow intensity.
-            Should be two float values between 0 and 1. Default: (0.5, 0.5).
+        shadow_intensity_range (tuple[float, float]): Range for the shadow intensity. Larger value
+            means darker shadow. Should be two float values between 0 and 1. Default: (0.5, 0.5).
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2070

## Summary by Sourcery

Bug Fixes:
- Correct the calculation of shadow intensity in the RandomShadow transformation by adjusting the formula to use darkness instead of shadow intensity directly.