### PR TITLE
Add random jpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [RandomFog](https://explore.albumentations.ai/transform/RandomFog)
 - [RandomGamma](https://explore.albumentations.ai/transform/RandomGamma)
 - [RandomGravel](https://explore.albumentations.ai/transform/RandomGravel)
+- [RandomJPEG](https://explore.albumentations.ai/transform/RandomJPEG)
 - [RandomRain](https://explore.albumentations.ai/transform/RandomRain)
 - [RandomShadow](https://explore.albumentations.ai/transform/RandomShadow)
 - [RandomSnow](https://explore.albumentations.ai/transform/RandomSnow)

--- a/albumentations/augmentations/__init__.py
+++ b/albumentations/augmentations/__init__.py
@@ -20,5 +20,6 @@ from .mixing.transforms import *
 from .spectrogram.transform import *
 from .text.functional import *
 from .text.transforms import *
+from .tk.transform import *
 from .transforms import *
 from .utils import *

--- a/albumentations/augmentations/tk/__init__.py
+++ b/albumentations/augmentations/tk/__init__.py
@@ -1,0 +1,1 @@
+### Aliased for torchvision and kornia transforms

--- a/albumentations/augmentations/tk/transform.py
+++ b/albumentations/augmentations/tk/transform.py
@@ -44,7 +44,7 @@ class RandomJPEG(ImageCompression):
     """
 
     class InitSchema(BaseTransformInitSchema):
-        jpeg_quality: Annotated[tuple[float, float], AfterValidator(check_0plus), AfterValidator(nondecreasing)]
+        jpeg_quality: Annotated[tuple[int, int], AfterValidator(check_0plus), AfterValidator(nondecreasing)]
 
     def __init__(
         self,

--- a/albumentations/augmentations/tk/transform.py
+++ b/albumentations/augmentations/tk/transform.py
@@ -1,0 +1,71 @@
+from typing import Annotated
+from warnings import warn
+
+from pydantic import AfterValidator
+
+from albumentations.augmentations.transforms import ImageCompression
+from albumentations.core.pydantic import check_0plus, nondecreasing
+from albumentations.core.transforms_interface import BaseTransformInitSchema
+
+__all__ = ["RandomJPEG"]
+
+
+class RandomJPEG(ImageCompression):
+    """Apply random JPEG compression to an image.
+
+    This transform applies JPEG compression with randomly sampled quality factor.
+    Lower quality values result in higher compression and more artifacts.
+
+    This is a specialized version of ImageCompression configured for JPEG only.
+    For more advanced use cases (e.g., other compression types, custom parameters),
+    consider using ImageCompression directly.
+
+    Args:
+        jpeg_quality (tuple[int, int]): The range of compression rates to be applied. Range: [0, 100]
+        p (float): probability of applying the transform. Default: 0.5.
+
+    Targets:
+        image
+
+    Image types:
+        uint8, float32
+
+    Note:
+        This transform is implemented as a subset of ImageCompression with fixed parameters:
+        - JPEG compression only
+
+        For more flexibility, including:
+        - Other compression types (PNG, WebP)
+        - Custom compression parameters
+        Consider using albumentations.ImageCompression directly.
+
+    References:
+        - Kornia implementation: https://kornia.readthedocs.io/en/latest/augmentation.html#kornia.augmentation.RandomJPEG
+    """
+
+    class InitSchema(BaseTransformInitSchema):
+        jpeg_quality: Annotated[tuple[float, float], AfterValidator(check_0plus), AfterValidator(nondecreasing)]
+
+    def __init__(
+        self,
+        jpeg_quality: tuple[int, int] = (50, 50),
+        always_apply: bool = False,
+        p: float = 0.5,
+    ):
+        warn(
+            "RandomJPEG is a specialized version of ImageCompression. "
+            "For more flexibility (other compression types, custom parameters), "
+            "consider using ImageCompression directly from albumentations.ImageCompression.",
+            UserWarning,
+            stacklevel=2,
+        )
+        super().__init__(
+            quality_range=jpeg_quality,
+            compression_type="jpeg",
+            always_apply=always_apply,
+            p=p,
+        )
+        self.jpeg_quality = jpeg_quality
+
+    def get_transform_init_args_names(self) -> tuple[str, ...]:
+        return ("jpeg_quality",)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -372,11 +372,8 @@ class ImageCompression(ImageOnlyTransform):
             "image_type": image_type,
         }
 
-    def get_transform_init_args(self) -> dict[str, Any]:
-        return {
-            "quality_range": self.quality_range,
-            "compression_type": self.compression_type,
-        }
+    def get_transform_init_args_names(self) -> tuple[str, ...]:
+        return "quality_range", "compression_type"
 
 
 class RandomSnow(ImageOnlyTransform):

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -382,4 +382,5 @@ AUGMENTATION_CLS_PARAMS = [
     [A.TimeReverse, {}],
     [A.TimeMasking, {"time_mask_param": 10}],
     [A.FrequencyMasking, {"freq_mask_param": 10}],
+    [A.RandomJPEG, {"jpeg_quality": (50, 50)}],
 ]

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -1028,22 +1028,6 @@ def test_image_compression_shapes(image_type, quality, shape, expected_shape):
     assert compressed.shape == expected_shape
     assert compressed.dtype == np.uint8
 
-@pytest.mark.parametrize(
-    "image_type", [".jpg", ".webp"]
-)
-def test_image_compression_quality(image_type):
-    """Test that lower quality results in more compression artifacts."""
-    image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-
-    # Compress with different qualities
-    high_quality = F.image_compression(image, 100, image_type)
-    low_quality = F.image_compression(image, 10, image_type)
-
-    # Lower quality should have more difference from original
-    high_diff = np.abs(image - high_quality).mean()
-    low_diff = np.abs(image - low_quality).mean()
-    assert low_diff > high_diff
-
 
 def test_image_compression_channel_consistency():
     """Test that compression maintains channel independence for extra channels."""
@@ -1083,7 +1067,7 @@ def test_image_compression_supported_shapes(image_type, quality, shape):
 @pytest.mark.parametrize(
     "image_type", [".jpg", ".webp"]
 )
-def test_image_compression_quality(image_type):
+def test_image_compression_quality_with_patterns(image_type):
     """Test that lower quality results in more compression artifacts."""
     # Create an image with high frequency patterns that are sensitive to compression
     x = np.linspace(0, 10, 100)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -1002,3 +1002,100 @@ def test_fancy_pca_zero_alpha(shape, dtype):
     result = F.fancy_pca(image, alpha_vector)
 
     np.testing.assert_array_equal(image, result)
+
+@pytest.mark.parametrize(
+    ["image_type", "quality", "shape", "expected_shape"],
+    [
+        # Test JPEG compression
+        (".jpg", 80, (100, 100, 3), (100, 100, 3)),  # RGB image
+        (".jpg", 10, (50, 50, 1), (50, 50, 1)),      # Grayscale image
+        (".jpg", 90, (30, 30, 2), (30, 30, 2)),      # 2-channel image
+        (".jpg", 70, (40, 40, 4), (40, 40, 4)),      # RGBA image
+        (".jpg", 50, (60, 60, 5), (60, 60, 5)),      # 5-channel image
+
+        # Test WebP compression
+        (".webp", 80, (100, 100, 3), (100, 100, 3)), # RGB image
+        (".webp", 10, (50, 50, 1), (50, 50, 1)),     # Grayscale image
+        (".webp", 90, (30, 30, 2), (30, 30, 2)),     # 2-channel image
+        (".webp", 70, (40, 40, 4), (40, 40, 4)),     # RGBA image
+        (".webp", 50, (60, 60, 5), (60, 60, 5)),     # 5-channel image
+    ]
+)
+def test_image_compression_shapes(image_type, quality, shape, expected_shape):
+    """Test that image_compression preserves input shapes."""
+    image = np.random.randint(0, 256, shape, dtype=np.uint8)
+    compressed = F.image_compression(image, quality, image_type)
+    assert compressed.shape == expected_shape
+    assert compressed.dtype == np.uint8
+
+@pytest.mark.parametrize(
+    "image_type", [".jpg", ".webp"]
+)
+def test_image_compression_quality(image_type):
+    """Test that lower quality results in more compression artifacts."""
+    image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+
+    # Compress with different qualities
+    high_quality = F.image_compression(image, 100, image_type)
+    low_quality = F.image_compression(image, 10, image_type)
+
+    # Lower quality should have more difference from original
+    high_diff = np.abs(image - high_quality).mean()
+    low_diff = np.abs(image - low_quality).mean()
+    assert low_diff > high_diff
+
+
+def test_image_compression_channel_consistency():
+    """Test that compression maintains channel independence for extra channels."""
+    # Create image with 4 channels where last channel is constant
+    image = np.random.randint(0, 256, (100, 100, 4), dtype=np.uint8)
+    image[..., 3] = 128  # Constant alpha channel
+
+    compressed = F.image_compression(image, 80, ".jpg")
+
+    # RGB channels should change due to compression
+    assert not np.array_equal(image[..., :3], compressed[..., :3])
+    # Alpha channel should remain constant
+    assert np.all(compressed[..., 3] == 128)
+
+
+@pytest.mark.parametrize(
+    ["image_type", "quality", "shape"],
+    [
+        # Test JPEG compression - only supports 1 and 3 channels
+        (".jpg", 80, (100, 100, 3)),  # RGB image
+        (".jpg", 10, (50, 50, 1)),    # Grayscale image
+
+        # Test WebP compression - supports 1, 3, and 4 channels
+        (".webp", 80, (100, 100, 3)), # RGB image
+        (".webp", 10, (50, 50, 1)),   # Grayscale image
+        (".webp", 70, (40, 40, 4)),   # RGBA image
+    ]
+)
+def test_image_compression_supported_shapes(image_type, quality, shape):
+    """Test image_compression with supported channel counts."""
+    image = np.random.randint(0, 256, shape, dtype=np.uint8)
+    compressed = F.image_compression(image, quality, image_type)
+    assert compressed.shape == shape
+    assert compressed.dtype == np.uint8
+
+
+@pytest.mark.parametrize(
+    "image_type", [".jpg", ".webp"]
+)
+def test_image_compression_quality(image_type):
+    """Test that lower quality results in more compression artifacts."""
+    # Create an image with high frequency patterns that are sensitive to compression
+    x = np.linspace(0, 10, 100)
+    y = np.linspace(0, 10, 100)
+    xx, yy = np.meshgrid(x, y)
+    image = np.uint8(255 * (np.sin(xx) * np.sin(yy) + 1) / 2)
+    image = np.stack([image] * 3, axis=-1)  # Convert to RGB
+
+    high_quality = F.image_compression(image, 100, image_type)
+    low_quality = F.image_compression(image, 10, image_type)
+
+    high_diff = np.abs(image - high_quality).mean()
+    low_diff = np.abs(image - low_quality).mean()
+
+    assert low_diff > high_diff, f"Low quality diff ({low_diff}) should be greater than high quality diff ({high_diff})"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -93,14 +93,15 @@ def test_augmentations_serialization(augmentation_cls, params, p, seed, image):
     mask = image.copy()
 
     aug = augmentation_cls(p=p, **params)
-    aug.random_generator = np.random.default_rng(0)
+    aug.random_generator = np.random.default_rng(seed)
 
     serialized_aug = A.to_dict(aug)
     deserialized_aug = A.from_dict(serialized_aug)
 
-    deserialized_aug.random_generator = np.random.default_rng(0)
+    deserialized_aug.random_generator = np.random.default_rng(seed)
     aug_data = aug(image=image, mask=mask)
     deserialized_aug_data = deserialized_aug(image=image, mask=mask)
+
     np.testing.assert_array_equal(aug_data["image"], deserialized_aug_data["image"])
     np.testing.assert_array_equal(aug_data["mask"], deserialized_aug_data["mask"])
 


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2097

## Summary by Sourcery

Add the RandomJPEG transform for applying random JPEG compression and enhance the image_compression function to support various channel configurations. Include new tests to ensure functionality and quality consistency.

New Features:
- Introduce the RandomJPEG transform to apply random JPEG compression to images with a specified quality range.

Enhancements:
- Refactor the image_compression function to handle images with different channel counts more effectively, including grayscale, RGB, and images with extra channels.

Tests:
- Add comprehensive tests for the image_compression function to verify shape preservation, quality impact, and channel consistency across different image types and qualities.