### PR TITLE
Add random invert

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [RandomGamma](https://explore.albumentations.ai/transform/RandomGamma)
 - [RandomGravel](https://explore.albumentations.ai/transform/RandomGravel)
 - [RandomGrayscale](https://explore.albumentations.ai/transform/RandomGrayscale)
+- [RandomInvert](https://explore.albumentations.ai/transform/RandomInvert)
 - [RandomJPEG](https://explore.albumentations.ai/transform/RandomJPEG)
 - [RandomRain](https://explore.albumentations.ai/transform/RandomRain)
 - [RandomShadow](https://explore.albumentations.ai/transform/RandomShadow)

--- a/albumentations/augmentations/tk/transform.py
+++ b/albumentations/augmentations/tk/transform.py
@@ -11,7 +11,7 @@ from typing_extensions import Literal
 from albumentations.augmentations.dropout.coarse_dropout import Erasing
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.geometric.transforms import Affine, HorizontalFlip, Perspective, VerticalFlip
-from albumentations.augmentations.transforms import ImageCompression, ToGray
+from albumentations.augmentations.transforms import ImageCompression, InvertImg, ToGray
 from albumentations.core.pydantic import InterpolationType, check_0plus, nondecreasing
 from albumentations.core.transforms_interface import BaseTransformInitSchema
 from albumentations.core.types import PAIR, ColorType, ScaleFloatType, Targets
@@ -25,6 +25,7 @@ __all__ = [
     "RandomAffine",
     "RandomRotation",
     "RandomErasing",
+    "RandomInvert",
 ]
 
 
@@ -634,3 +635,47 @@ class RandomErasing(Erasing):
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return "scale", "ratio", "value"
+
+
+class RandomInvert(InvertImg):
+    """Invert the input image values randomly with a given probability.
+
+    Args:
+        p (float): probability of applying the transform. Default: 0.5.
+
+    Targets:
+        image
+
+    Image types:
+        uint8, float32
+
+    Note:
+        This is a direct alias for albumentations.Erasing transform with torchvision-compatible parameters.
+        It is provided for compatibility with torchvision and kornia API to make it easier to use Albumentations
+        alongside torchvision.
+
+    Example:
+        >>> transform = A.RandomInvert(p=0.5)
+        >>> # Consider using instead:
+        >>> transform = A.InvertImg(p=0.5)
+
+    References:
+        - torchvision: https://pytorch.org/vision/stable/generated/torchvision.transforms.v2.RandomInvert.html
+        - Kornia: https://kornia.readthedocs.io/en/latest/augmentation.html#kornia.augmentation.RandomInvert
+    """
+
+    class InitSchema(BaseTransformInitSchema):
+        pass
+
+    def __init__(
+        self,
+        p: float = 0.5,
+        always_apply: bool | None = None,
+    ):
+        warn(
+            "RandomInvert is an alias for InvertImg transform. "
+            "Consider using InvertImg directly from albumentations.InvertImg.",
+            UserWarning,
+            stacklevel=2,
+        )
+        super().__init__(p=p)

--- a/albumentations/augmentations/tk/transform.py
+++ b/albumentations/augmentations/tk/transform.py
@@ -649,9 +649,12 @@ class RandomInvert(InvertImg):
     Image types:
         uint8, float32
 
+    Number of channels:
+        Any
+
     Note:
-        This is a direct alias for albumentations.Erasing transform with torchvision-compatible parameters.
-        It is provided for compatibility with torchvision and kornia API to make it easier to use Albumentations
+        This is a direct alias for albumentations.InvertImg transform.
+        It is provided for compatibility with torchvision and Kornia API to make it easier to use Albumentations
         alongside torchvision.
 
     Example:

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -392,4 +392,5 @@ AUGMENTATION_CLS_PARAMS = [
     [A.RandomRotation, {"degrees": 33}],
     [A.Erasing, {}],
     [A.RandomErasing, {}],
+    [A.RandomInvert, {}],
 ]


### PR DESCRIPTION
Addresses: https://github.com/albumentations-team/albumentations/issues/2096

## Summary by Sourcery

Add the RandomInvert transformation to the library, allowing users to randomly invert image values with a specified probability. Update the README to include documentation for this new transformation and add a corresponding test case to ensure its functionality.

New Features:
- Introduce the RandomInvert transformation to randomly invert image values with a specified probability.

Documentation:
- Add documentation entry for the new RandomInvert transformation in the README.

Tests:
- Include a test case for the RandomInvert transformation in the augmentation definitions.