### PR TITLE
Add random hue

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [RandomGamma](https://explore.albumentations.ai/transform/RandomGamma)
 - [RandomGravel](https://explore.albumentations.ai/transform/RandomGravel)
 - [RandomGrayscale](https://explore.albumentations.ai/transform/RandomGrayscale)
+- [RandomHue](https://explore.albumentations.ai/transform/RandomHue)
 - [RandomInvert](https://explore.albumentations.ai/transform/RandomInvert)
 - [RandomJPEG](https://explore.albumentations.ai/transform/RandomJPEG)
 - [RandomRain](https://explore.albumentations.ai/transform/RandomRain)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -3562,6 +3562,9 @@ class ColorJitter(ImageOnlyTransform):
     Image types:
         uint8, float32
 
+    Number of channels:
+        1, 3
+
     Note:
         - The order of application for these color transformations is random for each image.
         - The ranges for brightness, contrast, and saturation are applied as multiplicative factors.
@@ -3668,7 +3671,7 @@ class ColorJitter(ImageOnlyTransform):
             img = self.transforms[i](img, color_transforms[i])
         return img
 
-    def get_transform_init_args_names(self) -> tuple[str, str, str, str]:
+    def get_transform_init_args_names(self) -> tuple[str, ...]:
         return "brightness", "contrast", "saturation", "hue"
 
 

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -393,4 +393,5 @@ AUGMENTATION_CLS_PARAMS = [
     [A.Erasing, {}],
     [A.RandomErasing, {}],
     [A.RandomInvert, {}],
+    [A.RandomHue, {"hue": (-0.2, 0.2)}],
 ]

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -607,6 +607,7 @@ def test_mask_fill_value(augmentation_cls, params):
             A.ChromaticAberration,
             A.PlanckianJitter,
             A.RandomGrayscale,
+            A.RandomHue,
         },
     ),
 )
@@ -697,6 +698,7 @@ def test_multichannel_image_augmentations(augmentation_cls, params):
             A.ChromaticAberration,
             A.PlanckianJitter,
             A.RandomGrayscale,
+            A.RandomHue,
         },
     ),
 )
@@ -781,6 +783,7 @@ def test_float_multichannel_image_augmentations(augmentation_cls, params):
             A.ChromaticAberration,
             A.PlanckianJitter,
             A.RandomGrayscale,
+            A.RandomHue,
         },
     ),
 )
@@ -867,6 +870,7 @@ def test_multichannel_image_augmentations_diff_channels(augmentation_cls, params
             A.ChromaticAberration,
             A.PlanckianJitter,
             A.RandomGrayscale,
+            A.RandomHue,
         },
     ),
 )

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1253,6 +1253,7 @@ def test_coarse_dropout_invalid_input(params):
             A.Affine: {"rotate": 10},
             A.Pad: {"padding": 10},
             A.RandomRotation: {"degrees": 10},
+            A.RandomHue: {"hue": (-0.2, 0.2)},
         },
         except_augmentations={
             A.RandomCropNearBBox,
@@ -1321,6 +1322,7 @@ def test_change_image(augmentation_cls, params):
             A.RandomAffine: {"degrees": 10},
             A.Affine: {"rotate": 10},
             A.RandomRotation: {"degrees": 10},
+            A.RandomHue: {"hue": (-0.2, 0.2)},
         },
         except_augmentations={
             A.Crop,
@@ -1865,6 +1867,7 @@ def test_random_sun_flare_invalid_input(params):
                 "read_fn": lambda x: x,
             },
             A.TextImage: dict(font_path="./tests/files/LiberationSerif-Bold.ttf"),
+            A.RandomHue: {"hue": (-0.2, 0.2)},
         },
         except_augmentations={
             A.RandomCropNearBBox,
@@ -1881,7 +1884,7 @@ def test_return_nonzero(augmentation_cls, params):
     """Mistakes in clipping may lead to zero image, testing for that"""
     image = SQUARE_FLOAT_IMAGE if augmentation_cls == A.FromFloat else SQUARE_UINT8_IMAGE
 
-    aug = A.Compose([augmentation_cls(**params, p=1)])
+    aug = A.Compose([augmentation_cls(**params, p=1)], seed=42)
 
     data = {
         "image": image,


### PR DESCRIPTION
Addresses: https://github.com/albumentations-team/albumentations/issues/2095

## Summary by Sourcery

Add the RandomHue transformation to allow hue adjustments in images, update RandomInvert usage examples, and include tests for the new transformation.

New Features:
- Introduce the RandomHue transformation to adjust the hue of input images, providing a specialized version of ColorJitter focused solely on hue adjustments.

Enhancements:
- Update the example usage of RandomInvert to use A.Compose for consistency with other transformations.

Tests:
- Add tests for the new RandomHue transformation to ensure its correct functionality and integration with existing augmentations.