### PR TITLE
Add random equalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [RandomChannelDropout](https://explore.albumentations.ai/transform/RandomChannelDropout)
 - [RandomClahe](https://explore.albumentations.ai/transform/RandomClahe)
 - [RandomContrast](https://explore.albumentations.ai/transform/RandomContrast)
+- [RandomEqualize](https://explore.albumentations.ai/transform/RandomEqualize)
 - [RandomFog](https://explore.albumentations.ai/transform/RandomFog)
 - [RandomGamma](https://explore.albumentations.ai/transform/RandomGamma)
 - [RandomGravel](https://explore.albumentations.ai/transform/RandomGravel)

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -1321,10 +1321,6 @@ class BBoxSafeRandomCrop(BaseCrop):
 
         return {"crop_coords": (crop_x_min, crop_y_min, crop_x_max, crop_y_max)}
 
-    @property
-    def targets_as_params(self) -> list[str]:
-        return ["bboxes"]
-
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return ("erosion_rate",)
 

--- a/albumentations/augmentations/tk/transform.py
+++ b/albumentations/augmentations/tk/transform.py
@@ -15,6 +15,7 @@ from albumentations.augmentations.geometric.transforms import Affine, Horizontal
 from albumentations.augmentations.transforms import (
     CLAHE,
     ColorJitter,
+    Equalize,
     ImageCompression,
     InvertImg,
     RandomBrightnessContrast,
@@ -39,6 +40,7 @@ __all__ = [
     "RandomContrast",
     "RandomBrightness",
     "RandomChannelDropout",
+    "RandomEqualize",
 ]
 
 
@@ -1025,3 +1027,63 @@ class RandomChannelDropout(ChannelDropout):
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return "num_drop_channels", "fill_value"
+
+
+class RandomEqualize(Equalize):
+    """Equalize given image using histogram equalization.
+
+    Args:
+        p (float): probability of applying the transform. Default: 0.5.
+
+    Targets:
+        image
+
+    Image types:
+        uint8, float32
+
+    Note:
+        This transform is a specialized case of Equalize with fixed parameters:
+        - Uses OpenCV's equalization method (mode='cv')
+        - Applies equalization to each channel independently (by_channels=True)
+        - Does not support masking
+
+        For more flexibility, consider using Equalize directly which provides:
+        - Choice between OpenCV and Pillow equalization methods
+        - Option to equalize luminance channel only
+        - Support for masked equalization
+        - Additional parameters for fine-tuning the equalization process
+
+    Example:
+        >>> # RandomEqualize way (Kornia compatibility)
+        >>> transform = A.Compose([A.RandomEqualize(p=0.5)])
+        >>> # Equivalent Equalize way with full functionality
+        >>> transform = A.Compose([A.Equalize(mode='cv', by_channels=True, p=0.5)])
+
+    References:
+        - Kornia: https://kornia.readthedocs.io/en/latest/augmentation.html#kornia.augmentation.RandomEqualize
+    """
+
+    class InitSchema(BaseTransformInitSchema):
+        pass
+
+    def __init__(
+        self,
+        always_apply: bool | None = None,
+        p: float = 0.5,
+    ):
+        warn(
+            "RandomEqualize is a specialized version of Equalize transform. "
+            "Consider using Equalize directly from albumentations.Equalize for more flexibility.",
+            UserWarning,
+            stacklevel=2,
+        )
+        super().__init__(
+            mode="cv",
+            by_channels=True,
+            mask=None,
+            mask_params=(),
+            p=p,
+        )
+
+    def get_transform_init_args_names(self) -> tuple[str, ...]:
+        return ()

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -2107,7 +2107,7 @@ class Equalize(ImageOnlyTransform):
 
     @property
     def targets_as_params(self) -> list[str]:
-        return ["image", *list(self.mask_params)]
+        return [*list(self.mask_params)]
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return "mode", "by_channels", "mask", "mask_params"

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -398,4 +398,5 @@ AUGMENTATION_CLS_PARAMS = [
     [A.RandomContrast, {"contrast": (0.8, 1.2)}],
     [A.RandomBrightness, {"brightness": (0.8, 1.2)}],
     [A.RandomChannelDropout, {}],
+    [A.RandomEqualize, {}],
 ]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1775,7 +1775,7 @@ def test_gauss_noise(mean, image):
     )
 
     assert np.abs(mean - apply_params["gauss"].mean()) < 0.5
-    result = A.Compose([aug])(image=image)
+    result = A.Compose([aug], seed=42)(image=image)
 
     assert not (result["image"] >= image).all()
 


### PR DESCRIPTION
Addresses: https://github.com/albumentations-team/albumentations/issues/2091

## Summary by Sourcery

Add the RandomEqualize transformation to the library, allowing users to apply histogram equalization to images with a specified probability. Enhance the crops and transforms modules by refining the targets_as_params properties. Update tests to include the new RandomEqualize transformation.

New Features:
- Introduce the RandomEqualize transformation, which applies histogram equalization to images with a specified probability.

Enhancements:
- Remove the 'bboxes' target from the targets_as_params property in the crops transforms module.
- Simplify the targets_as_params property in the transforms module by removing the 'image' target.

Tests:
- Add test coverage for the new RandomEqualize transformation.