### PR TITLE
Add random plankian jitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [RandomHue](https://explore.albumentations.ai/transform/RandomHue)
 - [RandomInvert](https://explore.albumentations.ai/transform/RandomInvert)
 - [RandomJPEG](https://explore.albumentations.ai/transform/RandomJPEG)
+- [RandomPlanckianJitter](https://explore.albumentations.ai/transform/RandomPlanckianJitter)
 - [RandomRain](https://explore.albumentations.ai/transform/RandomRain)
 - [RandomShadow](https://explore.albumentations.ai/transform/RandomShadow)
 - [RandomSnow](https://explore.albumentations.ai/transform/RandomSnow)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -4926,7 +4926,7 @@ class PlanckianJitter(ImageOnlyTransform):
         uint8, float32
 
     Number of channels:
-        Any
+        3
 
     Note:
         - The transform preserves the overall brightness of the image while shifting its color.

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -400,4 +400,5 @@ AUGMENTATION_CLS_PARAMS = [
     [A.RandomChannelDropout, {}],
     [A.RandomEqualize, {}],
     [A.RandomGaussianBlur, {}],
+    [A.RandomPlanckianJitter, {}],
 ]

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -391,6 +391,7 @@ def test_augmentations_wont_change_float_input(augmentation_cls, params):
             A.RandomRain,
             A.RandomGravel,
             A.RandomChannelDropout,
+            A.RandomPlanckianJitter,
         },
     ),
 )

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1356,6 +1356,7 @@ def test_change_image(augmentation_cls, params):
             A.ChannelShuffle,
             A.ChromaticAberration,
             A.PlanckianJitter,
+            A.RandomPlanckianJitter,
             A.OverlayElements,
             A.FromFloat,
             A.TextImage,


### PR DESCRIPTION
Addresses: https://github.com/albumentations-team/albumentations/issues/2102

## Summary by Sourcery

Add a new RandomPlanckianJitter transform to simulate realistic illumination changes using a blackbody radiation model, enhancing the library's augmentation capabilities. Update PlanckianJitter to restrict it to 3-channel images and include tests for the new transform.

New Features:
- Introduce RandomPlanckianJitter transform to simulate realistic illumination changes using blackbody radiation model.

Enhancements:
- Restrict PlanckianJitter transform to operate on images with 3 channels.

Tests:
- Add tests for the new RandomPlanckianJitter transform to ensure it functions correctly.