### PR TITLE
Add random median blur

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [RandomHue](https://explore.albumentations.ai/transform/RandomHue)
 - [RandomInvert](https://explore.albumentations.ai/transform/RandomInvert)
 - [RandomJPEG](https://explore.albumentations.ai/transform/RandomJPEG)
+- [RandomMedianBlur](https://explore.albumentations.ai/transform/RandomMedianBlur)
 - [RandomPlanckianJitter](https://explore.albumentations.ai/transform/RandomPlanckianJitter)
 - [RandomRain](https://explore.albumentations.ai/transform/RandomRain)
 - [RandomShadow](https://explore.albumentations.ai/transform/RandomShadow)

--- a/albumentations/augmentations/tk/transform.py
+++ b/albumentations/augmentations/tk/transform.py
@@ -1293,7 +1293,7 @@ class RandomMedianBlur(MedianBlur):
         p: float = 0.5,
     ):
         warn(
-            "RandomMedianBlur is an alias for MedianBlur transform. "
+            "RandomMedianBlur is a specialized version of MedianBlur with a probability parameter. "
             "Consider using MedianBlur directly from albumentations.MedianBlur.",
             UserWarning,
             stacklevel=2,

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -401,4 +401,5 @@ AUGMENTATION_CLS_PARAMS = [
     [A.RandomEqualize, {}],
     [A.RandomGaussianBlur, {}],
     [A.RandomPlanckianJitter, {}],
+    [A.RandomMedianBlur, {}],
 ]


### PR DESCRIPTION
Adreses: https://github.com/albumentations-team/albumentations/issues/2100

## Summary by Sourcery

Add RandomMedianBlur transform to apply median blur with a fixed kernel size, ensuring compatibility with Kornia API, and include corresponding test case.

New Features:
- Introduce RandomMedianBlur transform for applying median blur with fixed kernel size, compatible with Kornia API.

Tests:
- Add test case for RandomMedianBlur in the augmentation definitions.