### PR TITLE
Add additive noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Check the [online demo of the library](https://albumentations-demo.herokuapp.com
 
 Pixel-level transforms will change just an input image and will leave any additional targets such as masks, bounding boxes, and keypoints unchanged. The list of pixel-level transforms:
 
+- [AdditiveNoise](https://explore.albumentations.ai/transform/AdditiveNoise)
 - [AdvancedBlur](https://explore.albumentations.ai/transform/AdvancedBlur)
 - [Blur](https://explore.albumentations.ai/transform/Blur)
 - [CLAHE](https://explore.albumentations.ai/transform/CLAHE)

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -82,7 +82,6 @@ __all__ = [
     "chromatic_aberration",
     "erode",
     "dilate",
-    "generate_approx_gaussian_noise",
 ]
 
 
@@ -1825,27 +1824,6 @@ def planckian_jitter(img: np.ndarray, temperature: int, mode: Literal["blackbody
     img[:, :, 2] = multiply_by_constant(img[:, :, 2], coeffs[2] / coeffs[1], inplace=True)
 
     return img
-
-
-def generate_approx_gaussian_noise(
-    shape: tuple[int, ...],
-    mean: float,
-    sigma: float,
-    scale: float,
-    random_generator: np.random.Generator,
-) -> np.ndarray:
-    # Determine the low-resolution shape
-    downscaled_height = int(shape[0] * scale)
-    downsaled_width = int(shape[1] * scale)
-
-    if len(shape) == NUM_MULTI_CHANNEL_DIMENSIONS:
-        low_res_noise = random_generator.normal(mean, sigma, (downscaled_height, downsaled_width, shape[-1]))
-    else:
-        low_res_noise = random_generator.normal(mean, sigma, (downscaled_height, downsaled_width))
-
-    # Upsample the noise to the original shape using OpenCV
-    result = cv2.resize(low_res_noise, (shape[1], shape[0]), interpolation=cv2.INTER_LINEAR)
-    return result.reshape(shape)
 
 
 @clipped

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -2146,86 +2146,6 @@ class Equalize(ImageOnlyTransform):
         return "mode", "by_channels", "mask", "mask_params"
 
 
-class RGBShift(ImageOnlyTransform):
-    """Randomly shift values for each channel of the input RGB image.
-
-    Args:
-        r_shift_limit ((int, int) or int): range for changing values for the red channel. If r_shift_limit is a
-            single int, the range will be (-r_shift_limit, r_shift_limit). Default: (-20, 20).
-        g_shift_limit ((int, int) or int): range for changing values for the green channel. If g_shift_limit is a
-            single int, the range will be (-g_shift_limit, g_shift_limit). Default: (-20, 20).
-        b_shift_limit ((int, int) or int): range for changing values for the blue channel. If b_shift_limit is a
-            single int, the range will be (-b_shift_limit, b_shift_limit). Default: (-20, 20).
-        p (float): probability of applying the transform. Default: 0.5.
-
-    Targets:
-        image
-
-    Image types:
-        uint8, float32
-
-    Note:
-        - For uint8 images, the shift values represent absolute pixel values in the range [0, 255].
-          For example, a shift of 20 for a uint8 image would add 20 to the corresponding channel.
-        - For float32 images, the shift values represent fractions of the full value range [0, 1].
-          For example, a shift of 0.1 for a float32 image would add 0.1 to the corresponding channel.
-        - The shift values are applied independently to each channel.
-        - After applying the shift, values are clipped to the valid range for the image dtype:
-          [0, 255] for uint8 and [0, 1] for float32.
-
-    Examples:
-        >>> import numpy as np
-        >>> import albumentations as A
-        >>>
-        # Shift RGB channels for uint8 image
-        >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-        >>> transform = A.RGBShift(r_shift_limit=30, g_shift_limit=30, b_shift_limit=30, p=1.0)
-        >>> shifted_image = transform(image=image)['image']
-        >>>
-        # Shift RGB channels for float32 image
-        >>> image = np.random.rand(100, 100, 3).astype(np.float32)
-        >>> transform = A.RGBShift(r_shift_limit=0.1, g_shift_limit=0.1, b_shift_limit=0.1, p=1.0)
-        >>> shifted_image = transform(image=image)['image']
-
-    """
-
-    class InitSchema(BaseTransformInitSchema):
-        r_shift_limit: SymmetricRangeType
-        g_shift_limit: SymmetricRangeType
-        b_shift_limit: SymmetricRangeType
-
-    def __init__(
-        self,
-        r_shift_limit: ScaleFloatType = (-20, 20),
-        g_shift_limit: ScaleFloatType = (-20, 20),
-        b_shift_limit: ScaleFloatType = (-20, 20),
-        always_apply: bool | None = None,
-        p: float = 0.5,
-    ):
-        super().__init__(p=p, always_apply=always_apply)
-        self.r_shift_limit = cast(tuple[float, float], r_shift_limit)
-        self.g_shift_limit = cast(tuple[float, float], g_shift_limit)
-        self.b_shift_limit = cast(tuple[float, float], b_shift_limit)
-
-    def apply(self, img: np.ndarray, shift: np.ndarray, **params: Any) -> np.ndarray:
-        non_rgb_error(img)
-        return albucore.add_vector(img, shift, inplace=False)
-
-    def get_params(self) -> dict[str, Any]:
-        return {
-            "shift": np.array(
-                [
-                    self.py_random.uniform(*self.r_shift_limit),
-                    self.py_random.uniform(*self.g_shift_limit),
-                    self.py_random.uniform(*self.b_shift_limit),
-                ],
-            ),
-        }
-
-    def get_transform_init_args_names(self) -> tuple[str, ...]:
-        return "r_shift_limit", "g_shift_limit", "b_shift_limit"
-
-
 class RandomBrightnessContrast(ImageOnlyTransform):
     """Randomly changes the brightness and contrast of the input image.
 
@@ -5416,3 +5336,130 @@ class AdditiveNoise(ImageOnlyTransform):
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return "noise_type", "spatial_mode", "noise_params", "approximation"
+
+
+class RGBShift(AdditiveNoise):
+    """Randomly shift values for each channel of the input RGB image.
+
+    A specialized version of AdditiveNoise that applies constant uniform shifts to RGB channels.
+    Each channel (R,G,B) can have its own shift range specified.
+
+    Args:
+        r_shift_limit ((int, int) or int): Range for shifting the red channel. Options:
+            - If tuple (min, max): Sample shift value from this range
+            - If int: Sample shift value from (-r_shift_limit, r_shift_limit)
+            - For uint8 images: Values represent absolute shifts in [0, 255]
+            - For float images: Values represent relative shifts in [0, 1]
+            Default: (-20, 20)
+
+        g_shift_limit ((int, int) or int): Range for shifting the green channel. Options:
+            - If tuple (min, max): Sample shift value from this range
+            - If int: Sample shift value from (-g_shift_limit, g_shift_limit)
+            - For uint8 images: Values represent absolute shifts in [0, 255]
+            - For float images: Values represent relative shifts in [0, 1]
+            Default: (-20, 20)
+
+        b_shift_limit ((int, int) or int): Range for shifting the blue channel. Options:
+            - If tuple (min, max): Sample shift value from this range
+            - If int: Sample shift value from (-b_shift_limit, b_shift_limit)
+            - For uint8 images: Values represent absolute shifts in [0, 255]
+            - For float images: Values represent relative shifts in [0, 1]
+            Default: (-20, 20)
+
+        p (float): Probability of applying the transform. Default: 0.5.
+
+    Targets:
+        image
+
+    Image types:
+        uint8, float32
+
+    Note:
+        - Values are shifted independently for each channel
+        - For uint8 images:
+            * Input ranges like (-20, 20) represent pixel value shifts
+            * A shift of 20 means adding 20 to that channel
+            * Final values are clipped to [0, 255]
+        - For float32 images:
+            * Input ranges like (-0.1, 0.1) represent relative shifts
+            * A shift of 0.1 means adding 0.1 to that channel
+            * Final values are clipped to [0, 1]
+
+    Examples:
+        >>> import numpy as np
+        >>> import albumentations as A
+
+        # Shift RGB channels of uint8 image
+        >>> transform = A.RGBShift(
+        ...     r_shift_limit=30,  # Will sample red shift from [-30, 30]
+        ...     g_shift_limit=(-20, 20),  # Will sample green shift from [-20, 20]
+        ...     b_shift_limit=(-10, 10),  # Will sample blue shift from [-10, 10]
+        ...     p=1.0
+        ... )
+        >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+        >>> shifted = transform(image=image)["image"]
+
+        # Same effect using AdditiveNoise
+        >>> transform = A.AdditiveNoise(
+        ...     noise_type="uniform",
+        ...     spatial_mode="constant",  # One value per channel
+        ...     noise_params={
+        ...         "ranges": [(-30/255, 30/255), (-20/255, 20/255), (-10/255, 10/255)]
+        ...     },
+        ...     p=1.0
+        ... )
+
+    See Also:
+        - AdditiveNoise: More general noise transform with various options:
+            * Different noise distributions (uniform, gaussian, laplace, beta, poisson)
+            * Spatial modes (constant, per-pixel, shared)
+            * Approximation for faster computation
+        - RandomToneCurve: For non-linear color transformations
+        - RandomBrightnessContrast: For combined brightness and contrast adjustments
+        - PlankianJitter: For color temperature adjustments
+        - HueSaturationValue: For HSV color space adjustments
+        - ColorJitter: For combined brightness, contrast, saturation adjustments
+    """
+
+    class InitSchema(BaseTransformInitSchema):
+        r_shift_limit: SymmetricRangeType
+        g_shift_limit: SymmetricRangeType
+        b_shift_limit: SymmetricRangeType
+
+    def __init__(
+        self,
+        r_shift_limit: ScaleFloatType = (-20, 20),
+        g_shift_limit: ScaleFloatType = (-20, 20),
+        b_shift_limit: ScaleFloatType = (-20, 20),
+        always_apply: bool | None = None,
+        p: float = 0.5,
+    ):
+        # Convert RGB shift limits to normalized ranges if needed
+        def normalize_range(limit: tuple[float, float]) -> tuple[float, float]:
+            # If any value is > 1, assume uint8 range and normalize
+            if abs(limit[0]) > 1 or abs(limit[1]) > 1:
+                return (limit[0] / 255.0, limit[1] / 255.0)
+            return limit
+
+        ranges = [
+            normalize_range(cast(tuple[float, float], r_shift_limit)),
+            normalize_range(cast(tuple[float, float], g_shift_limit)),
+            normalize_range(cast(tuple[float, float], b_shift_limit)),
+        ]
+
+        # Initialize with fixed noise type and spatial mode
+        super().__init__(
+            noise_type="uniform",
+            spatial_mode="constant",
+            noise_params={"ranges": ranges},
+            approximation=1.0,
+            p=p,
+        )
+
+        # Store original limits for get_transform_init_args
+        self.r_shift_limit = cast(tuple[float, float], r_shift_limit)
+        self.g_shift_limit = cast(tuple[float, float], g_shift_limit)
+        self.b_shift_limit = cast(tuple[float, float], b_shift_limit)
+
+    def get_transform_init_args_names(self) -> tuple[str, ...]:
+        return "r_shift_limit", "g_shift_limit", "b_shift_limit"

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -406,4 +406,5 @@ AUGMENTATION_CLS_PARAMS = [
     [A.RandomPosterize, {}],
     [A.RandomSaturation, {}],
     [A.GaussianNoise, {}],
+    [A.AdditiveNoise, {}],
 ]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1779,7 +1779,7 @@ def test_gauss_noise(mean, image):
         data={"image": image},
     )
 
-    assert np.abs(mean - apply_params["gauss"].mean() / MAX_VALUES_BY_DTYPE[image.dtype]) < 0.5
+    assert np.abs(mean - apply_params["noise_map"].mean() / MAX_VALUES_BY_DTYPE[image.dtype]) < 0.5
     result = A.Compose([aug], seed=42)(image=image)
 
     assert not (result["image"] >= image).all()

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1257,6 +1257,7 @@ def test_coarse_dropout_invalid_input(params):
             A.RandomContrast: {"contrast": (0.8, 1.2)},
             A.RandomBrightness: {"brightness": (0.8, 1.2)},
             A.RandomSaturation: {"saturation": (0.8, 1.2)},
+            A.AdditiveNoise: {"noise_type": "uniform", "spatial_mode": "constant", "noise_params": {"ranges": [(-0.2, 0.2), (-0.1, 0.1), (-0.1, 0.1)]}},
         },
         except_augmentations={
             A.RandomCropNearBBox,
@@ -1329,6 +1330,7 @@ def test_change_image(augmentation_cls, params):
             A.RandomContrast: {"contrast": (0.8, 1.2)},
             A.RandomBrightness: {"brightness": (0.8, 1.2)},
             A.RandomSaturation: {"saturation": (0.8, 1.2)},
+            A.AdditiveNoise: {"noise_type": "uniform", "spatial_mode": "constant", "noise_params": {"ranges": [(-0.2, 0.2), (-0.1, 0.1), (-0.1, 0.1)]}},
         },
         except_augmentations={
             A.Crop,


### PR DESCRIPTION
## Summary by Sourcery

Add the AdditiveNoise transform to apply random noise using various distributions and refactor RGBShift to utilize this new transform. Update tests to cover the new functionality.

New Features:
- Introduce the AdditiveNoise transform, which applies random noise to image channels using various noise distributions such as uniform, gaussian, laplace, beta, and poisson. It supports different spatial modes and allows for configurable noise parameters.

Enhancements:
- Refactor the RGBShift transform to be a specialized version of the new AdditiveNoise transform, focusing on applying constant uniform shifts to RGB channels.

Tests:
- Add tests for the new AdditiveNoise transform to ensure its functionality and integration with existing augmentation pipelines.