### PR TITLE
Add salt and pepper

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [RandomSunFlare](https://explore.albumentations.ai/transform/RandomSunFlare)
 - [RandomToneCurve](https://explore.albumentations.ai/transform/RandomToneCurve)
 - [RingingOvershoot](https://explore.albumentations.ai/transform/RingingOvershoot)
+- [SaltAndPepper](https://explore.albumentations.ai/transform/SaltAndPepper)
 - [Sharpen](https://explore.albumentations.ai/transform/Sharpen)
 - [ShotNoise](https://explore.albumentations.ai/transform/ShotNoise)
 - [Solarize](https://explore.albumentations.ai/transform/Solarize)

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -2170,3 +2170,25 @@ def sharpen_gaussian(img: np.ndarray, alpha: float, kernel_size: int, sigma: flo
     """Sharpen image using Gaussian blur."""
     blurred = cv2.GaussianBlur(img, ksize=(kernel_size, kernel_size), sigmaX=sigma, sigmaY=sigma)
     return add_weighted(blurred, 1 - alpha, img, alpha)
+
+
+def apply_salt_and_pepper(
+    img: np.ndarray,
+    salt_mask: np.ndarray,
+    pepper_mask: np.ndarray,
+) -> np.ndarray:
+    """Apply salt and pepper noise to image using pre-computed masks.
+
+    Args:
+        img: Input image
+        salt_mask: Boolean mask for salt (white) noise
+        pepper_mask: Boolean mask for pepper (black) noise
+
+    Returns:
+        Image with applied salt and pepper noise
+    """
+    result = img.copy()
+
+    result[salt_mask] = MAX_VALUES_BY_DTYPE[img.dtype]
+    result[pepper_mask] = 0
+    return result

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -407,4 +407,5 @@ AUGMENTATION_CLS_PARAMS = [
     [A.RandomSaturation, {}],
     [A.GaussianNoise, {}],
     [A.AdditiveNoise, {}],
+    [A.SaltAndPepper, {}],
 ]


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2108

## Summary by Sourcery

Add a new 'SaltAndPepper' image transformation to introduce salt and pepper noise, update documentation, and include tests for the new feature.

New Features:
- Introduce a new image transformation class 'SaltAndPepper' to apply salt and pepper noise to images, allowing control over the amount and ratio of salt to pepper noise.

Documentation:
- Add documentation for the new 'SaltAndPepper' transformation in the README, including a link to its detailed description.

Tests:
- Include a test case for the 'SaltAndPepper' transformation in the augmentation definitions test suite.