### PR TITLE
Add fisheye

### DIFF
--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -1415,8 +1415,11 @@ class OpticalDistortion(BaseDistortion):
             For fisheye model: recommended range (-0.3, 0.3)
             Default: (-0.05, 0.05)
 
-        shift_limit (float | tuple[float, float]): Range of shifts for the image center.
-            If shift_limit is a single float, range will be (-shift_limit, shift_limit).
+        shift_limit (float | tuple[float, float]): Range of relative shifts for the image center.
+            Values are multiplied by image dimensions to get absolute shift in pixels:
+            - dx = shift_x * image_width
+            - dy = shift_y * image_height
+            If shift_limit is a single float value, the range will be (-shift_limit, shift_limit).
             Default: (-0.05, 0.05)
 
         mode (Literal['camera', 'fisheye']): Distortion model to use:


### PR DESCRIPTION
## Summary by Sourcery

Add fisheye distortion model to the OpticalDistortion class, enabling users to choose between camera matrix and fisheye models for image transformations.

New Features:
- Introduce fisheye distortion model to the OpticalDistortion class, allowing for direct radial distortion effects.

Enhancements:
- Add support for selecting between camera matrix and fisheye distortion models in the OpticalDistortion class.