### PR TITLE
Add rotate and project

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [RandomVerticalFlip](https://explore.albumentations.ai/transform/RandomVerticalFlip)             | ✓     | ✓    | ✓      | ✓         |
 | [Resize](https://explore.albumentations.ai/transform/Resize)                                     | ✓     | ✓    | ✓      | ✓         |
 | [Rotate](https://explore.albumentations.ai/transform/Rotate)                                     | ✓     | ✓    | ✓      | ✓         |
+| [RotateAndProject](https://explore.albumentations.ai/transform/RotateAndProject)                 | ✓     | ✓    | ✓      | ✓         |
 | [SafeRotate](https://explore.albumentations.ai/transform/SafeRotate)                             | ✓     | ✓    | ✓      | ✓         |
 | [ShiftScaleRotate](https://explore.albumentations.ai/transform/ShiftScaleRotate)                 | ✓     | ✓    | ✓      | ✓         |
 | [SmallestMaxSize](https://explore.albumentations.ai/transform/SmallestMaxSize)                   | ✓     | ✓    | ✓      | ✓         |

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -419,7 +419,7 @@ class Perspective(DualTransform):
             matrix,
             max_width,
             max_height,
-            self.pad_val,
+            self.mask_pad_val,
             self.pad_mode,
             self.keep_size,
             self.mask_interpolation,
@@ -428,7 +428,7 @@ class Perspective(DualTransform):
     def apply_to_bboxes(
         self,
         bboxes: np.ndarray,
-        matrix: np.ndarray,
+        matrix_bbox: np.ndarray,
         max_height: int,
         max_width: int,
         **params: Any,
@@ -436,7 +436,7 @@ class Perspective(DualTransform):
         return fgeometric.perspective_bboxes(
             bboxes,
             params["shape"],
-            matrix,
+            matrix_bbox,
             max_width,
             max_height,
             self.keep_size,
@@ -472,7 +472,7 @@ class Perspective(DualTransform):
         if self.fit_output:
             matrix, max_width, max_height = fgeometric.expand_transform(matrix, image_shape)
 
-        return {"matrix": matrix, "max_height": max_height, "max_width": max_width}
+        return {"matrix": matrix, "max_height": max_height, "max_width": max_width, "matrix_bbox": matrix}
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return (

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -413,4 +413,5 @@ AUGMENTATION_CLS_PARAMS = [
     [A.Illumination, {}],
     [A.ThinPlateSpline, {}],
     [A.AutoContrast, {}],
+    [A.RotateAndProject, {}],
 ]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -100,6 +100,13 @@ def test_binary_mask_interpolation(augmentation_cls, params):
             A.Resize: {"height": 113, "width": 113},
             A.GridElasticDeform: {"num_grid_xy": (10, 10), "magnitude": 10},
             A.CropAndPad: {"px": 10},
+            A.RotateAndProject: {
+                "x_angle_range": (0, 0),
+                "y_angle_range": (0, 0),
+                "z_angle_range": (0, 0),
+                "focal_range": (1, 1),
+                "mask_interpolation": cv2.INTER_NEAREST,
+            },
         },
         except_augmentations={
             A.RandomSizedBBoxSafeCrop,
@@ -2081,6 +2088,7 @@ def test_mask_dropout_bboxes(remove_invisible, expected_keypoints):
             A.RandomVerticalFlip,
             A.RandomAffine,
             A.RandomErasing,
+            A.RotateAndProject
         },
     ),
 )


### PR DESCRIPTION
Adresses: https://github.com/albumentations-team/albumentations/issues/2118

## Summary by Sourcery

Add the RotateAndProject transformation to apply 3D rotation and perspective projection to images, along with corresponding tests and documentation updates.

New Features:
- Introduce the RotateAndProject transformation, which applies 3D rotation to an image and projects it back to a 2D plane using perspective projection. This feature supports images, masks, keypoints, and bounding boxes, maintaining aspect ratios and handling different center calculations.

Documentation:
- Update README.md to include documentation for the new RotateAndProject transformation.

Tests:
- Add tests for the new RotateAndProject transformation, including tests for 3D rotation matrices and projection matrix properties.