### PR TITLE
Add empty array processing to pad with params

### DIFF
--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -1348,6 +1348,11 @@ def copy_make_border_with_value_extension(
     border_mode: int,
     value: ColorType,
 ) -> np.ndarray:
+    # For 0-channel images, return empty array of correct padded size
+    if img.size == 0:
+        height, width = img.shape[:2]
+        return np.zeros((height + top + bottom, width + left + right, 0), dtype=img.dtype)
+
     num_channels = get_num_channels(img)
     extended_value = extend_value(value, num_channels)
 

--- a/tests/functional/test_geometric.py
+++ b/tests/functional/test_geometric.py
@@ -7,6 +7,7 @@ from tests.utils import set_seed
 
 import albumentations as A
 import math
+import cv2
 
 
 @pytest.mark.parametrize(
@@ -421,3 +422,24 @@ def test_projection_matrix_properties() -> None:
         matrix,
         rtol=1e-2,
     )
+
+def test_copy_make_border_with_value_extension_zero_channels():
+    """Test that border extension works correctly with 0-channel images."""
+    # Create a 0-channel image
+    img = np.zeros((10, 10, 0), dtype=np.uint8)
+
+    # Test with different padding values
+    result = fgeometric.copy_make_border_with_value_extension(
+        img=img,
+        top=2,
+        bottom=3,
+        left=4,
+        right=5,
+        border_mode=cv2.BORDER_CONSTANT,
+        value=0,
+    )
+
+    # Check result shape
+    assert result.shape == (15, 19, 0)  # 10+2+3, 10+4+5, 0
+    assert result.dtype == np.uint8
+    assert result.size == 0


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2162

## Summary by Sourcery

Fix handling of 0-channel images in the copy_make_border_with_value_extension function and add a corresponding test to ensure correct behavior.

Bug Fixes:
- Fix processing of 0-channel images in the copy_make_border_with_value_extension function to return an empty array of the correct padded size.

Tests:
- Add a test to verify that the copy_make_border_with_value_extension function correctly handles 0-channel images by checking the shape, dtype, and size of the result.