### PR TITLE
Fix blurs

### DIFF
--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -90,7 +90,12 @@ class Blur(ImageOnlyTransform):
         return fblur.blur(img, kernel)
 
     def get_params(self) -> dict[str, Any]:
-        return {"kernel": self.random_generator.choice(list(range(self.blur_limit[0], self.blur_limit[1] + 1, 2)))}
+        kernel = fblur.sample_odd_from_range(
+            self.py_random,
+            self.blur_limit[0],
+            self.blur_limit[1],
+        )
+        return {"kernel": kernel}
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return ("blur_limit",)
@@ -237,9 +242,11 @@ class MotionBlur(Blur):
         return fmain.convolve(img, kernel=kernel)
 
     def get_params(self) -> dict[str, Any]:
-        ksize = self.py_random.choice(list(range(self.blur_limit[0], self.blur_limit[1] + 1, 2)))
-        if ksize <= TWO:
-            raise ValueError(f"ksize must be > 2. Got: {ksize}")
+        ksize = fblur.sample_odd_from_range(
+            self.py_random,
+            self.blur_limit[0],
+            self.blur_limit[1],
+        )
 
         angle = self.py_random.uniform(*self.angle_range)
         direction = self.py_random.uniform(*self.direction_range)
@@ -411,9 +418,11 @@ class GaussianBlur(ImageOnlyTransform):
         return fblur.gaussian_blur(img, ksize, sigma=sigma)
 
     def get_params(self) -> dict[str, float]:
-        ksize = self.py_random.randrange(self.blur_limit[0], self.blur_limit[1] + 1)
-        if ksize != 0 and ksize % 2 != 1:
-            ksize = (ksize + 1) % (self.blur_limit[1] + 1)
+        ksize = fblur.sample_odd_from_range(
+            self.py_random,
+            self.blur_limit[0],
+            self.blur_limit[1],
+        )
 
         return {"ksize": ksize, "sigma": self.py_random.uniform(*self.sigma_limit)}
 
@@ -667,7 +676,7 @@ class AdvancedBlur(ImageOnlyTransform):
         return fmain.convolve(img, kernel=kernel)
 
     def get_params(self) -> dict[str, np.ndarray]:
-        ksize = self.py_random.randrange(self.blur_limit[0], self.blur_limit[1] + 1, 2)
+        ksize = fblur.sample_odd_from_range(self.py_random, self.blur_limit[0], self.blur_limit[1])
         sigma_x = self.py_random.uniform(*self.sigma_x_limit)
         sigma_y = self.py_random.uniform(*self.sigma_y_limit)
         angle = np.deg2rad(self.py_random.uniform(*self.rotate_limit))

--- a/tests/functional/test_blur.py
+++ b/tests/functional/test_blur.py
@@ -1,0 +1,40 @@
+from random import Random
+import pytest
+from albumentations.augmentations.blur import functional as fblur
+
+
+@pytest.mark.parametrize(
+    "low, high, expected_range",
+    [
+        (-8, 7, {3, 5, 7}),           # negative low
+        (2, 6, {3, 5, 7}),               # even values
+        (1, 4, {3, 5}),                  # low < 3
+        (4, 4, {5}),                  # same even value
+        (3, 3, {3}),                  # same odd value
+        (2, 2, {3}),                  # same even value < 3
+        (-4, -2, {3}),                # all negative values
+    ],
+    ids=[
+        "negative_low",
+        "even_values",
+        "low_less_than_3",
+        "same_even_value",
+        "same_odd_value",
+        "same_even_value_less_than_3",
+        "all_negative",
+    ]
+)
+def test_sample_odd_from_range(low: int, high: int, expected_range: set[int]):
+    """Test sampling odd numbers from a range."""
+    random_state = Random(42)
+
+    results = set()
+    for _ in range(50):  # Sample multiple times to get all possible values
+        value = fblur.sample_odd_from_range(random_state, low, high)
+        results.add(value)
+        # Verify each value is odd
+        assert value % 2 == 1
+        # Verify value is >= 3
+        assert value >= 3
+
+    assert results == expected_range, f"Failed for low={low}, high={high}"


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2165

## Summary by Sourcery

Fix the issue with median blur kernel size validation for float32 images and introduce a utility function to sample odd numbers from a range. Add tests for the new utility function to ensure its correctness.

Bug Fixes:
- Fix the issue with invalid kernel size values in median blur for float32 images by removing the restriction on kernel size.

Enhancements:
- Introduce a utility function 'sample_odd_from_range' to sample odd numbers from a specified range, ensuring valid odd numbers are selected.

Tests:
- Add tests for the 'sample_odd_from_range' function to ensure it correctly samples odd numbers from a given range.