### PR TITLE
Fix possible bug in MotionBlur

### DIFF
--- a/albumentations/augmentations/blur/functional.py
+++ b/albumentations/augmentations/blur/functional.py
@@ -196,7 +196,9 @@ def create_motion_kernel(
 
     # Apply direction bias
     if direction != 0:
-        t = t * (1 + direction)
+        t = t * (1 + abs(direction))
+        if direction < 0:
+            t = t * -1
 
     # Generate line coordinates
     x = center + dx * t

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -225,7 +225,7 @@ class MotionBlur(Blur):
         blur_limit: ScaleIntType = 7,
         allow_shifted: bool = True,
         angle_range: tuple[float, float] = (0, 360),
-        direction_range: tuple[float, float] = (-1.0, 1.0),
+        direction_range: tuple[float, float] = (-0.5, 0.5),
         always_apply: bool | None = None,
         p: float = 0.5,
     ):


### PR DESCRIPTION
The current MotionBlur won't work if `direction_range` is set to `-1.0`. This is because the [create_motion_kernel](https://github.com/albumentations-team/albumentations/blob/main/albumentations/augmentations/blur/functional.py#L198-L199) does not handle that case, resulting in a "near zero" kernel (i.e., kernel with very few non-zero values).
Also, I updated the default value of `direction_range` to `(-0.5, 0.5)` to match the description [here](https://github.com/albumentations-team/albumentations/blob/main/albumentations/augmentations/blur/transforms.py#L136)

I hope that my PR correctly fixes the bug. Thanks!

## Summary by Sourcery

Fix the MotionBlur function to handle negative direction values and update the default direction_range for consistency.

Bug Fixes:
- Fix the MotionBlur function to correctly handle negative direction values by adjusting the kernel calculation.

Enhancements:
- Update the default value of direction_range in the MotionBlur transform to (-0.5, 0.5) for consistency with the documentation.