### PR TITLE
Fix load form HF-Hub

### DIFF
--- a/albumentations/core/hub_mixin.py
+++ b/albumentations/core/hub_mixin.py
@@ -189,7 +189,7 @@ class HubMixin:
         # download the file from the Hub
         try:
             config_file = hf_hub_download(
-                repo_id=directory_or_repo_id,
+                repo_id=str(directory_or_repo_id),
                 filename=filename,
                 revision=revision,
                 cache_dir=cache_dir,


### PR DESCRIPTION
Get the following error on the latest version:

```
File [~/projects/segmentation_models.pytorch/.venv/lib/python3.10/site-packages/albumentations/core/hub_mixin.py:191], in HubMixin.from_pretrained(cls, directory_or_repo_id, key, force_download, proxies, token, cache_dir, local_files_only, revision)
    [189] # download the file from the Hub
    [190] try:
--> [191]     config_file = hf_hub_download(
    [192]         repo_id=directory_or_repo_id,
    [193]         filename=filename,
    [194]         revision=revision,
    [195]         cache_dir=cache_dir,
    [196]         force_download=force_download,
    [197]         proxies=proxies,
    [198]         token=token,
    [199]         local_files_only=local_files_only,
    [200]     )
    [201]     directory, filename = Path(config_file).parent, Path(config_file).name
    [202]     return cls._from_pretrained(save_directory=directory, filename=filename)
...
    [155]         "Repo id must be in the form 'repo_name' or 'namespace/repo_name':"
    [156]         f" '{repo_id}'. Use `repo_type` argument if needed."
    [157]     )

HFValidationError: Repo id must be a string, not <class 'pathlib.PosixPath'>: 'smp-hub/segformer-b2-1024x1024-city-160k'.
```

## Summary by Sourcery

Bug Fixes:
- Fix the HFValidationError by converting the repo_id to a string in the from_pretrained method.