### PR TITLE
Boost version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         files: setup.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.1
+    rev: v0.8.2
     hooks:
       # Run the linter.
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [ "setuptools>=45", "wheel" ]
 [project]
 name = "albumentations"
 
-version = "1.4.21"
+version = "1.4.22"
 
 description = "Fast, flexible, and advanced image augmentation library for deep learning and computer vision. Albumentations offers a wide range of transformations for images, masks, bounding boxes, and keypoints, with optimized performance and seamless integration into ML workflows."
 readme = "README.md"


### PR DESCRIPTION
## Summary by Sourcery

Update the pre-commit configuration to use the latest version of Ruff and bump the project version to 1.4.22.

Build:
- Update pre-commit configuration to use Ruff version 0.8.2.

Chores:
- Bump project version from 1.4.21 to 1.4.22.