### PR TITLE
Fix make docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [FDA](https://explore.albumentations.ai/transform/FDA)
 - [FancyPCA](https://explore.albumentations.ai/transform/FancyPCA)
 - [FromFloat](https://explore.albumentations.ai/transform/FromFloat)
+- [GaussNoise](https://explore.albumentations.ai/transform/GaussNoise)
 - [GaussianBlur](https://explore.albumentations.ai/transform/GaussianBlur)
 - [GlassBlur](https://explore.albumentations.ai/transform/GlassBlur)
 - [HistogramMatching](https://explore.albumentations.ai/transform/HistogramMatching)
@@ -277,6 +278,7 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [PixelDropout](https://explore.albumentations.ai/transform/PixelDropout)                         | ✓     | ✓    | ✓      | ✓         |
 | [RandomCrop](https://explore.albumentations.ai/transform/RandomCrop)                             | ✓     | ✓    | ✓      | ✓         |
 | [RandomCropFromBorders](https://explore.albumentations.ai/transform/RandomCropFromBorders)       | ✓     | ✓    | ✓      | ✓         |
+| [RandomCropNearBBox](https://explore.albumentations.ai/transform/RandomCropNearBBox)             | ✓     | ✓    | ✓      | ✓         |
 | [RandomGridShuffle](https://explore.albumentations.ai/transform/RandomGridShuffle)               | ✓     | ✓    | ✓      | ✓         |
 | [RandomResizedCrop](https://explore.albumentations.ai/transform/RandomResizedCrop)               | ✓     | ✓    | ✓      | ✓         |
 | [RandomRotate90](https://explore.albumentations.ai/transform/RandomRotate90)                     | ✓     | ✓    | ✓      | ✓         |

--- a/tools/make_transforms_docs.py
+++ b/tools/make_transforms_docs.py
@@ -38,16 +38,24 @@ def make_separator(width: int, align_center: bool) -> str:
         return ":" + "-" * (width - 2) + ":"
     return "-" * width
 
-import warnings
 
 def is_deprecated(cls) -> bool:
     """
-    Check if a given class is deprecated.
+    Check if a given class is deprecated by looking for deprecation notices at the start of the docstring,
+    not in the Args section.
     """
-    for warning in cls.__doc__.split('\n'):  # Assuming deprecation warnings are in the docstring
-        if "deprecated" in warning.lower():
-            return True  # The class itself is marked as deprecated
-    return False
+    if not cls.__doc__:
+        return False
+
+    # Split docstring into sections and look only at the first section (before Args:)
+    main_desc = cls.__doc__.split('Args:')[0]
+
+    # Check if there's a deprecation notice in the main description
+    return any(
+        "deprecated" in line.lower()
+        for line in main_desc.split('\n')
+        if line.strip()
+    )
 
 
 def get_image_only_transforms_info():


### PR DESCRIPTION
## Summary by Sourcery

Fix the deprecation check logic in the 'is_deprecated' function and update the README to include missing transform documentation.

Bug Fixes:
- Fix the deprecation check in the 'is_deprecated' function to correctly identify deprecation notices in the main description of the docstring.

Documentation:
- Add documentation entries for 'GaussNoise' and 'RandomCropNearBBox' transforms in the README.