### PR TITLE
Feature/flexible sunflare brightness

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -925,15 +925,27 @@ def add_sun_flare_overlay(
     overlay = img.copy()
     output = img.copy()
 
+    weighted_brightness = 0.
+    total_radius_length = 0.
+
     for alpha, (x, y), rad3, (r_color, g_color, b_color) in circles:
+        weighted_brightness += alpha * rad3
+        total_radius_length += rad3
         cv2.circle(overlay, (x, y), rad3, (r_color, g_color, b_color), -1)
         output = add_weighted(overlay, alpha, output, 1 - alpha)
+
 
     point = [int(x) for x in flare_center]
 
     overlay = output.copy()
     num_times = src_radius // 10
-    alpha = np.linspace(0.0, 1, num=num_times)
+
+    # max_alpha is calculated using weighted_brightness and total_radii_length times 5
+    # meaning the higher the alpha with larger area, the brighter the bright spot will be
+    # for list of alphas in range [0.05, 0.2], the max_alpha should below 1
+    max_alpha = weighted_brightness / total_radius_length * 5
+    alpha = np.linspace(0.0, min(max_alpha, 1), num=num_times)
+
     rad = np.linspace(1, src_radius, num=num_times)
 
     for i in range(num_times):

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -925,15 +925,14 @@ def add_sun_flare_overlay(
     overlay = img.copy()
     output = img.copy()
 
-    weighted_brightness = 0.
-    total_radius_length = 0.
+    weighted_brightness = 0.0
+    total_radius_length = 0.0
 
     for alpha, (x, y), rad3, (r_color, g_color, b_color) in circles:
         weighted_brightness += alpha * rad3
         total_radius_length += rad3
         cv2.circle(overlay, (x, y), rad3, (r_color, g_color, b_color), -1)
         output = add_weighted(overlay, alpha, output, 1 - alpha)
-
 
     point = [int(x) for x in flare_center]
 

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -944,7 +944,7 @@ def add_sun_flare_overlay(
     # meaning the higher the alpha with larger area, the brighter the bright spot will be
     # for list of alphas in range [0.05, 0.2], the max_alpha should below 1
     max_alpha = weighted_brightness / total_radius_length * 5
-    alpha = np.linspace(0.0, min(max_alpha, 1), num=num_times)
+    alpha = np.linspace(0.0, min(max_alpha, 1.0), num=num_times)
 
     rad = np.linspace(1, src_radius, num=num_times)
 


### PR DESCRIPTION
fix #2067

My approach is to find the weighted brightness from the flare circles and use it to define the max alpha (max brightness) of the spots. The brighter and larger the flare circles, the brighter the spots will be. Max alpha could still be high (>0.8), meaning blocking the object behind it, but for alpha currently in range (0.05, 0.2), max alpha will mostly be around 0.5-0.7.

That should give a more natural look at the whole effect.

![](https://github.com/user-attachments/assets/80b1d0d6-66c8-4126-bfc9-8cbce90e6a4f)
![](https://github.com/user-attachments/assets/799eaab6-4a52-46ed-9f72-f481e042e6e0)
![](https://github.com/user-attachments/assets/d213bdc8-2f1c-4c55-b70a-7a4357988e58)

RandomSunFlare(
                            flare_roi=[0,0,1,0.5],
                            src_radius=400,
                            src_color=[255,255,255],
                            angle_range=[0,1],
                            num_flare_circles_range=[6,10],
                            method="overlay",
                            p=1))

## Summary by Sourcery

New Features:
- Introduce a flexible sunflare brightness feature that adjusts the maximum alpha of flare spots based on the weighted brightness and size of flare circles.