### PR TITLE
Can pass images as np.array (num_images, height, width, num_channels) 

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -5537,6 +5537,7 @@ class PlanckianJitter(ImageOnlyTransform):
         self.sampling_method = sampling_method
 
     def apply(self, img: np.ndarray, temperature: int, **params: Any) -> np.ndarray:
+        non_rgb_error(img)
         return fmain.planckian_jitter(img, temperature, mode=self.mode)
 
     def get_params(self) -> dict[str, Any]:

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -504,8 +504,27 @@ class Compose(BaseCompose, HubMixin):
 
     @staticmethod
     def _check_multi_data(data_name: str, data: Any) -> tuple[int, int]:
+        """Check multi-image data format and return shape.
+
+        Args:
+            data_name: Name of the data field being checked
+            data: Input data in one of these formats:
+                - List-like of numpy arrays
+                - Numpy array of shape (N, H, W, C) or (N, H, W)
+
+        Returns:
+            tuple: (height, width) of the first image
+
+        Raises:
+            TypeError: If data format is invalid
+        """
+        if isinstance(data, np.ndarray):
+            if data.ndim not in [3, 4]:  # (N,H,W) or (N,H,W,C)
+                raise TypeError(f"{data_name} as numpy array must be 3D or 4D")
+            return data.shape[1:3]  # Return (H,W)
+
         if not isinstance(data, Sequence) or not isinstance(data[0], np.ndarray):
-            raise TypeError(f"{data_name} must be list of numpy arrays")
+            raise TypeError(f"{data_name} must be either a numpy array or a list of numpy arrays")
         return data[0].shape[:2]
 
     @staticmethod

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1118,7 +1118,9 @@ def test_transform_always_apply_warning() -> None:
 @pytest.mark.parametrize("shape", [(101, 99, 3), (101, 99)])
 def test_images_as_target(augmentation_cls, params, as_array, shape):
     if len(shape) == 2:
-        if augmentation_cls == A.ChannelDropout:
+        if augmentation_cls in {A.ChannelDropout, A.Spatter, A.ISONoise,
+                                A.RandomGravel, A.ChromaticAberration, A.PlanckianJitter, A.PixelDistributionAdaptation,
+                                A.MaskDropout, A.ChannelShuffle, A.ToRGB}:
             pytest.skip("ChannelDropout is not applicable to grayscale images")
 
 
@@ -1152,19 +1154,21 @@ def test_images_as_target(augmentation_cls, params, as_array, shape):
     # Check output format matches input format
     if as_array:
         assert isinstance(transformed["images"], np.ndarray)
+
         assert transformed["images"].ndim == len(shape) + 1, f"Expected {len(shape) + 1} dimensions, got {transformed['images'].ndim}"
 
         assert transformed["images"].flags["C_CONTIGUOUS"]  # Ensure memory is contiguous
 
         # Verify exact shape matches expected dimensions
-        N, H, W, C = transformed["images"].shape
+        N, H, W = transformed["images"].shape[:3]
         assert N == 2  # Two images as input
-        assert C == image.shape[2]  # Channels match input
+        if len(shape) == 3:
+            assert transformed["images"].shape[-1] == image.shape[2]  # Channels match input
 
         if augmentation_cls not in [A.RandomCrop, A.RandomResizedCrop, A.Resize, A.RandomSizedCrop, A.RandomSizedBBoxSafeCrop,
                                     A.BBoxSafeRandomCrop, A.Transpose, A.RandomCropNearBBox, A.CenterCrop, A.Crop, A.CropAndPad,
                                     A.LongestMaxSize, A.RandomScale, A.PadIfNeeded, A.SmallestMaxSize, A.RandomCropFromBorders,
-                                    A.RandomRotate90]:
+                                    A.RandomRotate90, A.D4]:
             assert H == image.shape[0]  # Height matches input
             assert W == image.shape[1]  # Width matches input
     else:


### PR DESCRIPTION
## Summary by Sourcery

Allow images to be passed as numpy arrays with shape (num_images, height, width, num_channels) to transformation functions, ensuring output format consistency. Update tests to cover both list and numpy array input formats.

New Features:
- Enable passing images as numpy arrays with shape (num_images, height, width, num_channels) to the transformation functions.

Enhancements:
- Ensure that transformed images maintain the same format as the input, whether as a list or a numpy array.

Tests:
- Add parameterized tests to verify that transformations work correctly with both list and numpy array formats for images.