### PR TITLE
docs: fix inconsistency in YOLO normalization

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -185,7 +185,7 @@ class Normalize(ImageOnlyTransform):
         - For "standard" normalization, `mean`, `std`, and `max_pixel_value` must be provided.
         - For other normalization types, these parameters are ignored.
         - For inception normalization, use mean values of (0.5, 0.5, 0.5).
-        - For YOLO normalization, use mean values of (0.5, 0.5, 0.5) and std values of (0, 0, 0).
+        - For YOLO normalization, use mean values of (0, 0, 0) and std values of (1, 1, 1).
         - This transform is often used as a final step in image preprocessing pipelines to
           prepare images for neural network input.
 


### PR DESCRIPTION
Earlier in the `normalization` arg for `Normalize` the docs state "The default mean and std are based on ImageNet. You can use mean and std values of (0.5, 0.5, 0.5) for inception normalization. And mean values of (0, 0, 0) and std values of (1, 1, 1) for YOLO."

This seems inconsistent with the note section. Furthermore, filling in a std value of 0 in the standard formula would lead to inifinite values, so I think the earlier mention description is correct.

## Summary by Sourcery

Documentation:
- Correct the documentation for YOLO normalization to use mean values of (0, 0, 0) and std values of (1, 1, 1) instead of the incorrect values previously stated.