### PR TITLE
Add pad

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         files: setup.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.2
+    rev: v0.8.3
     hooks:
       # Run the linter.
       - id: ruff

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Spatial-level transforms will simultaneously change both an input image as well 
 
 | Transform                                                                  | Image | Mask |
 | -------------------------------------------------------------------------- | :---: | :--: |
+| [Pad3D](https://explore.albumentations.ai/transform/Pad3D)                 | ✓     | ✓    |
 | [PadIfNeeded3D](https://explore.albumentations.ai/transform/PadIfNeeded3D) | ✓     | ✓    |
 
 ## A few more examples of **augmentations**

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -429,17 +429,20 @@ class CenterCrop(BaseCropAndPad):
         border_mode: BorderModeType
         fill: ColorType
         fill_mask: ColorType
-        pad_mode: BorderModeType | None = Field(deprecated="pad_mode is deprecated, use border_mode instead")
-        pad_cval: ColorType | None = Field(deprecated="pad_cval is deprecated, use fill instead")
-        pad_cval_mask: ColorType | None = Field(deprecated="pad_cval_mask is deprecated, use fill_mask instead")
+        pad_mode: BorderModeType | None
+        pad_cval: ColorType | None
+        pad_cval_mask: ColorType | None
 
         @model_validator(mode="after")
         def validate_dimensions(self) -> Self:
             if self.pad_mode is not None:
+                warn("pad_mode is deprecated, use border_mode instead", DeprecationWarning, stacklevel=2)
                 self.border_mode = self.pad_mode
             if self.pad_cval is not None:
+                warn("pad_cval is deprecated, use fill instead", DeprecationWarning, stacklevel=2)
                 self.fill = self.pad_cval
             if self.pad_cval_mask is not None:
+                warn("pad_cval_mask is deprecated, use fill_mask instead", DeprecationWarning, stacklevel=2)
                 self.fill_mask = self.pad_cval_mask
             return self
 
@@ -561,9 +564,9 @@ class Crop(BaseCropAndPad):
         border_mode: BorderModeType
         fill: ColorType
         fill_mask: ColorType
-        pad_mode: BorderModeType | None = Field(deprecated="pad_mode is deprecated, use border_mode instead")
-        pad_cval: ColorType | None = Field(deprecated="pad_cval is deprecated, use fill instead")
-        pad_cval_mask: ColorType | None = Field(deprecated="pad_cval_mask is deprecated, use fill_mask instead")
+        pad_mode: BorderModeType | None
+        pad_cval: ColorType | None
+        pad_cval_mask: ColorType | None
 
         @model_validator(mode="after")
         def validate_coordinates(self) -> Self:
@@ -575,10 +578,13 @@ class Crop(BaseCropAndPad):
                 raise ValueError(msg)
 
             if self.pad_mode is not None:
+                warn("pad_mode is deprecated, use border_mode instead", DeprecationWarning, stacklevel=2)
                 self.border_mode = self.pad_mode
             if self.pad_cval is not None:
+                warn("pad_cval is deprecated, use fill instead", DeprecationWarning, stacklevel=2)
                 self.fill = self.pad_cval
             if self.pad_cval_mask is not None:
+                warn("pad_cval_mask is deprecated, use fill_mask instead", DeprecationWarning, stacklevel=2)
                 self.fill_mask = self.pad_cval_mask
 
             return self
@@ -1603,9 +1609,9 @@ class CropAndPad(DualTransform):
     class InitSchema(BaseTransformInitSchema):
         px: PxType | None
         percent: PercentType | None
-        pad_mode: BorderModeType | None = Field(deprecated="pad_mode is deprecated, use border_mode instead")
-        pad_cval: ColorType | None = Field(deprecated="pad_cval is deprecated, use fill instead")
-        pad_cval_mask: ColorType | None = Field(deprecated="pad_cval_mask is deprecated, use fill_mask instead")
+        pad_mode: BorderModeType | None
+        pad_cval: ColorType | None
+        pad_cval_mask: ColorType | None
         keep_size: bool
         sample_independently: bool
         interpolation: InterpolationType
@@ -1623,10 +1629,13 @@ class CropAndPad(DualTransform):
                 msg = "Only px or percent may be set!"
                 raise ValueError(msg)
             if self.pad_mode is not None:
+                warn("pad_mode is deprecated, use border_mode instead", DeprecationWarning, stacklevel=2)
                 self.border_mode = self.pad_mode
             if self.pad_cval is not None:
+                warn("pad_cval is deprecated, use fill instead", DeprecationWarning, stacklevel=2)
                 self.fill = self.pad_cval
             if self.pad_cval_mask is not None:
+                warn("pad_cval_mask is deprecated, use fill_mask instead", DeprecationWarning, stacklevel=2)
                 self.fill_mask = self.pad_cval_mask
 
             return self

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import math
 from typing import Any, cast
+from warnings import warn
 
 import cv2
 import numpy as np
-from pydantic import Field, model_validator
+from pydantic import model_validator
 from typing_extensions import Literal, Self
 
 from albumentations.augmentations.crops import functional as fcrops
@@ -156,20 +157,16 @@ class Rotate(DualTransform):
         fill: ColorType
         fill_mask: ColorType
 
-        value: ColorType | None = Field(
-            default=None,
-            deprecated="Deprecated use fill instead",
-        )
-        mask_value: ColorType | None = Field(
-            default=None,
-            deprecated="Deprecated use fill_mask instead",
-        )
+        value: ColorType | None
+        mask_value: ColorType | None
 
         @model_validator(mode="after")
         def validate_value(self) -> Self:
             if self.value is not None:
+                warn("value is deprecated, use fill instead", DeprecationWarning, stacklevel=2)
                 self.fill = self.value
             if self.mask_value is not None:
+                warn("mask_value is deprecated, use fill_mask instead", DeprecationWarning, stacklevel=2)
                 self.fill_mask = self.mask_value
             return self
 

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -675,18 +675,9 @@ class Affine(DualTransform):
         interpolation: InterpolationType
         mask_interpolation: InterpolationType
 
-        cval: ColorType | None = Field(
-            default=None,
-            deprecated="Deprecated use fill instead",
-        )
-        cval_mask: ColorType | None = Field(
-            default=None,
-            deprecated="Deprecated use fill_mask instead",
-        )
-        mode: BorderModeType | None = Field(
-            default=None,
-            deprecated="Deprecated use border_mode instead",
-        )
+        cval: ColorType | None
+        cval_mask: ColorType | None
+        mode: BorderModeType | None
 
         fill: ColorType
         fill_mask: ColorType
@@ -762,10 +753,13 @@ class Affine(DualTransform):
         def validate_fill_types(self) -> Self:
             if self.cval is not None:
                 self.fill = self.cval
+                warn("cval is deprecated, use fill instead", DeprecationWarning, stacklevel=2)
             if self.cval_mask is not None:
                 self.fill_mask = self.cval_mask
+                warn("cval_mask is deprecated, use fill_mask instead", DeprecationWarning, stacklevel=2)
             if self.mode is not None:
                 self.border_mode = self.mode
+                warn("mode is deprecated, use border_mode instead", DeprecationWarning, stacklevel=2)
             return self
 
     def __init__(
@@ -2388,10 +2382,8 @@ class PadIfNeeded(Pad):
         pad_width_divisor: int | None = Field(ge=1)
         position: PositionType
         border_mode: BorderModeType
-        value: ColorType | None = Field(deprecated="Deprecated. Use 'fill' instead.")
-        mask_value: ColorType | None = Field(
-            deprecated="Deprecated. Use 'fill_mask' instead.",
-        )
+        value: ColorType | None
+        mask_value: ColorType | None
 
         fill: ColorType
         fill_mask: ColorType
@@ -2410,9 +2402,11 @@ class PadIfNeeded(Pad):
                 raise ValueError(msg)
 
             if self.mask_value is not None:
+                warn("mask_value is deprecated, use fill_mask instead", DeprecationWarning, stacklevel=2)
                 self.fill_mask = self.mask_value
 
             if self.value is not None:
+                warn("value is deprecated, use fill instead", DeprecationWarning, stacklevel=2)
                 self.fill = self.value
 
             return self

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -405,4 +405,5 @@ AUGMENTATION_CLS_PARAMS = [
     [A.ThinPlateSpline, {}],
     [A.AutoContrast, {}],
     [A.PadIfNeeded3D, {"min_zyx": (300, 200, 400), "pad_divisor_zyx": (10, 10, 10), "position": "center", "fill": 10, "fill_mask": 20}],
+    [A.Pad3D, {"padding": 10}],
 ]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1118,6 +1118,7 @@ def test_transform_always_apply_warning() -> None:
             A.OverlayElements,
             A.TextImage,
             A.PadIfNeeded3D,
+            A.Pad3D,
         },
     ),
 )
@@ -1228,6 +1229,7 @@ def test_images_as_target(augmentation_cls, params, as_array, shape):
             A.TextImage: dict(font_path="./tests/files/LiberationSerif-Bold.ttf"),
             A.GridElasticDeform: {"num_grid_xy": (10, 10), "magnitude": 10},
             A.PadIfNeeded3D: {"min_zyx": (300, 200, 400), "pad_divisor_zyx": (10, 10, 10), "position": "center", "fill": 10, "fill_mask": 20},
+            A.Pad3D: {"padding": 10},
         },
     ),
 )
@@ -1239,7 +1241,7 @@ def test_non_contiguous_input_with_compose(augmentation_cls, params, bboxes):
     assert not image.flags["C_CONTIGUOUS"]
     assert not mask.flags["C_CONTIGUOUS"]
 
-    transforms3d = {A.PadIfNeeded3D}
+    transforms3d = {A.PadIfNeeded3D, A.Pad3D}
 
     if augmentation_cls == A.RandomCropNearBBox:
         # requires "cropping_bbox" arg
@@ -1345,6 +1347,7 @@ def test_non_contiguous_input_with_compose(augmentation_cls, params, bboxes):
                 "transform_type": "standard",
             },
             A.PadIfNeeded3D: {"min_zyx": (300, 200, 400), "pad_divisor_zyx": (10, 10, 10), "position": "center", "fill": 10, "fill_mask": 20},
+            A.Pad3D: {"padding": 10},
         },
         except_augmentations={
             A.FDA,
@@ -1372,7 +1375,7 @@ def test_non_contiguous_input_with_compose(augmentation_cls, params, bboxes):
 def test_masks_as_target(augmentation_cls, params, masks):
     image = SQUARE_UINT8_IMAGE
 
-    transforms3d = {A.PadIfNeeded3D}
+    transforms3d = {A.PadIfNeeded3D, A.Pad3D}
 
     data = {
         "image": image,

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -840,6 +840,7 @@ def test_template_transform_serialization(
             A.TextImage: dict(font_path="./tests/files/LiberationSerif-Bold.ttf"),
             A.GridElasticDeform: {"num_grid_xy": (10, 10), "magnitude": 10},
             A.PadIfNeeded3D: {"min_zyx": (512, 512, 512)},
+            A.Pad3D: {"padding": 10, "fill": 0, "fill_mask": 0},
         },
         except_augmentations={
             A.FDA,

--- a/tests/transforms3d/test_targets.py
+++ b/tests/transforms3d/test_targets.py
@@ -60,22 +60,20 @@ def get_targets_from_methods(cls):
 
     return targets
 
-
 TRASNFORM_3d_DUAL_TARGETS = {
     A.PadIfNeeded3D: (Targets.IMAGE, Targets.MASK),
 }
-
 
 str2target = {
     "images": Targets.IMAGE,
     "masks": Targets.MASK,
 }
 
-
 @pytest.mark.parametrize(
     ["augmentation_cls", "params"],
     get_3d_transforms(custom_arguments={
         A.PadIfNeeded3D: {"min_zyx": (4, 250, 230), "position": "center", "fill": 0, "fill_mask": 0},
+        A.Pad3D: {"padding": 10},
     })
 )
 def test_dual(augmentation_cls, params):

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -1,7 +1,6 @@
 import pytest
 import numpy as np
 import albumentations as A
-from albucore import to_float
 import cv2
 
 from tests.conftest import RECTANGULAR_UINT8_IMAGE, SQUARE_FLOAT_IMAGE, SQUARE_UINT8_IMAGE
@@ -32,7 +31,6 @@ def test_pad_if_needed_3d_shapes(volume_shape, min_zyx, pad_divisor_zyx, expecte
         min_zyx=min_zyx,
         pad_divisor_zyx=pad_divisor_zyx,
         position="center",
-        border_mode=cv2.BORDER_CONSTANT,
         fill=0,
         fill_mask=0
     )
@@ -45,7 +43,6 @@ def test_pad_if_needed_3d_positions(position):
     transform = A.PadIfNeeded3D(
         min_zyx=(10, 100, 100),
         position=position,
-        border_mode=cv2.BORDER_CONSTANT,
         fill=0,
         fill_mask=0
     )
@@ -63,7 +60,6 @@ def test_pad_if_needed_3d_2d_equivalence():
     transform_3d = A.PadIfNeeded3D(
         min_zyx=(10, 128, 128),
         position="center",
-        border_mode=cv2.BORDER_CONSTANT,
         fill=0,
         fill_mask=0
     )
@@ -75,8 +71,8 @@ def test_pad_if_needed_3d_2d_equivalence():
         min_width=128,
         position="center",
         border_mode=cv2.BORDER_CONSTANT,
-        value=0,
-        mask_value=0
+        fill=0,
+        fill_mask=0
     )
     transformed_2d = transform_2d(image=slice_2d)
 
@@ -94,7 +90,6 @@ def test_pad_if_needed_3d_fill_values():
     transform = A.PadIfNeeded3D(
         min_zyx=(10, 100, 100),
         position="center",
-        border_mode=cv2.BORDER_CONSTANT,
         fill=255,
         fill_mask=128
     )
@@ -106,12 +101,12 @@ def test_pad_if_needed_3d_fill_values():
     assert np.all(transformed["masks"][:, :25, :] == 128)  # top padding in mask
 
 
-
 @pytest.mark.parametrize(
     ["augmentation_cls", "params"],
     get_3d_transforms(
         custom_arguments={
             A.PadIfNeeded3D: {"min_zyx": (4, 250, 230), "position": "center", "fill": 0, "fill_mask": 0},
+            A.Pad3D: {"padding": 10},
         },
         except_augmentations={
         },
@@ -135,3 +130,165 @@ def test_augmentations_match_uint8_float32(augmentation_cls, params):
     transformed_float32 = transform(**data)["images"]
 
     np.testing.assert_array_almost_equal(transformed_uint8 / 255.0, transformed_float32, decimal=2)
+
+
+@pytest.mark.parametrize(
+    ["padding", "expected_shape"],
+    [
+        # Single int - pad all sides equally
+        (2, (14, 14, 14, 1)),  # 10+2+2 = 14 for each dimension
+
+        # 3-tuple - symmetric padding per dimension
+        ((1, 2, 3), (12, 14, 16, 1)),  # d+2, h+4, w+6
+
+        # 6-tuple - specific padding per side
+        ((1, 2, 3, 2, 1, 4), (13, 15, 15, 1)),  # (d+3, h+3, w+7)
+
+        # Zero padding
+        (0, (10, 10, 10, 1)),  # Original shape
+    ],
+)
+def test_pad3d_shapes(padding, expected_shape):
+    volume = np.ones((10, 10, 10, 1), dtype=np.float32)
+    augmentation = A.Pad3D(padding=padding)
+    padded = augmentation(images=volume)["images"]
+    assert padded.shape == expected_shape
+
+
+@pytest.mark.parametrize(
+    ["fill", "fill_mask"],
+    [
+        (0, 1),
+        (1, 0),
+    ],
+)
+def test_pad3d_fill_values(fill, fill_mask):
+    volume = np.ones((3, 3, 3, 1), dtype=np.float32)
+    masks = np.ones((3, 3, 3, 1), dtype=np.float32)
+
+    augmentation = A.Pad3D(padding=1, fill=fill, fill_mask=fill_mask)
+    transformed = augmentation(images=volume, masks=masks)
+
+    padded_volume = transformed["images"]
+    padded_mask = transformed["masks"]
+
+    # Check fill values in padded regions
+    assert np.all(padded_volume[0, :, :] == fill)  # front slice
+    assert np.all(padded_mask[0, :, :] == fill_mask)  # front slice of mask
+
+
+@pytest.mark.parametrize(
+    "volume_shape",
+    [
+        (10, 10, 10),      # 3D
+        (10, 10, 10, 1),   # 4D single channel
+        (10, 10, 10, 3),   # 4D multi-channel
+    ],
+)
+def test_pad3d_different_shapes(volume_shape):
+    volume = np.ones(volume_shape, dtype=np.float32)
+    augmentation = A.Pad3D(padding=2)
+    padded = augmentation(images=volume)["images"]
+
+    expected_shape = tuple(s + 4 for s in volume_shape[:3])  # +4 because padding=2 on each side
+    if len(volume_shape) == 4:
+        expected_shape += (volume_shape[3],)
+
+    assert padded.shape == expected_shape
+
+
+def test_pad3d_different_dtypes():
+    for dtype in [np.uint8, np.float32]:
+        volume = np.ones((5, 5, 5), dtype=dtype)
+        augmentation = A.Pad3D(padding=1)
+        padded = augmentation(images=volume)["images"]
+        assert padded.dtype == dtype
+
+
+def test_pad3d_preservation():
+    """Test that the original data is preserved in the non-padded region"""
+    volume = np.random.randint(0, 255, (5, 5, 5), dtype=np.uint8)
+    augmentation = A.Pad3D(padding=2)
+    padded = augmentation(images=volume)["images"]
+
+    # Check if the original volume is preserved in the center
+    np.testing.assert_array_equal(
+        padded[2:-2, 2:-2, 2:-2],
+        volume
+    )
+
+@pytest.mark.parametrize(
+    ["pad3d_padding", "pad2d_padding"],
+    [
+        # 6-tuple for 3D (z_front, z_back, y_top, y_bottom, x_left, x_right) vs
+        # 4-tuple for 2D (y_top, y_bottom, x_left, x_right)
+        ((0, 0, 10, 10, 20, 20), (20, 10, 20, 10)),
+        # 3-tuple for 3D (d,h,w) vs 2-tuple for 2D (w,h) - symmetric padding
+        ((0, 10, 20), (20, 10)),
+    ],
+    ids=[
+        "explicit_padding",
+        "symmetric_padding",
+    ]
+)
+def test_pad3d_2d_equivalence(pad3d_padding, pad2d_padding):
+    """Test that Pad3D behaves like Pad when no z-padding is applied"""
+    # Create a volume with multiple identical slices
+    num_slices = 4
+    slice_2d = np.random.randint(0, 256, (3, 3), dtype=np.uint8)
+    volume_3d = np.stack([slice_2d] * num_slices)  # 10 identical slices
+
+    # Apply 3D padding with no z-axis changes
+    transform_3d = A.Pad3D(
+        padding=pad3d_padding,
+        fill=0,
+        fill_mask=0
+    )
+    transformed_3d = transform_3d(images=volume_3d)
+
+    # Apply 2D padding to a single slice
+    transform_2d = A.Pad(
+        padding=pad2d_padding,
+        fill=0,
+        fill_mask=0
+    )
+    transformed_2d = transform_2d(image=slice_2d)
+
+    # Compare each slice of 3D result with 2D result
+    for slice_idx in range(num_slices):
+        np.testing.assert_array_equal(
+            transformed_3d["images"][slice_idx],
+            transformed_2d["image"]
+        )
+
+    # Also verify that z dimension hasn't changed
+    assert transformed_3d["images"].shape[0] == volume_3d.shape[0]
+
+
+@pytest.mark.parametrize(
+    ["augmentation_cls", "params"],
+    get_3d_transforms(
+        custom_arguments={
+            A.PadIfNeeded3D: {"min_zyx": (300, 200, 400), "pad_divisor_zyx": (10, 10, 10), "position": "center", "fill": 10, "fill_mask": 20},
+            A.Pad3D: {"padding": 10},
+        },
+        except_augmentations={
+        },
+    ),
+)
+def test_change_image(augmentation_cls, params):
+    """Checks whether resulting image is different from the original one."""
+    aug = A.Compose([augmentation_cls(p=1, **params)], seed=0)
+
+    images = np.array([SQUARE_UINT8_IMAGE] * 4)
+    original_images = images.copy()
+
+    data = {
+        "images": images,
+        "masks": np.array([SQUARE_UINT8_IMAGE] * 3),
+    }
+    original_masks = data["masks"].copy()
+    transformed = aug(**data)
+
+    assert not np.array_equal(transformed["images"], original_images)
+    assert not np.array_equal(transformed["masks"], original_masks)


### PR DESCRIPTION
## Summary by Sourcery

Add a new Pad3D class for padding 3D volumes, refactor existing padding logic into a BasePad3D class, and update tests and documentation accordingly. Deprecate old padding parameters with warnings for backward compatibility.

New Features:
- Introduce Pad3D class for padding 3D volumes with specified padding values and fill options.

Enhancements:
- Refactor PadIfNeeded3D to inherit from a new BasePad3D class, improving code reuse and structure.
- Deprecate old padding-related parameters in favor of new ones with warnings for backward compatibility.

Documentation:
- Add documentation entry for the new Pad3D transform in the README.

Tests:
- Add tests for the new Pad3D class, covering various padding configurations and data types.
- Update existing tests to accommodate changes in padding parameter names and deprecations.

Chores:
- Update pre-commit configuration to use ruff version 0.8.3.