### PR TITLE
Add RandomCrop3D and CenterCrop3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,8 +303,10 @@ Spatial-level transforms will simultaneously change both an input image as well 
 
 | Transform                                                                  | Image | Mask |
 | -------------------------------------------------------------------------- | :---: | :--: |
+| [CenterCrop3D](https://explore.albumentations.ai/transform/CenterCrop3D)   | ✓     | ✓    |
 | [Pad3D](https://explore.albumentations.ai/transform/Pad3D)                 | ✓     | ✓    |
 | [PadIfNeeded3D](https://explore.albumentations.ai/transform/PadIfNeeded3D) | ✓     | ✓    |
+| [RandomCrop3D](https://explore.albumentations.ai/transform/RandomCrop3D)   | ✓     | ✓    |
 
 ## A few more examples of **augmentations**
 

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -173,7 +173,7 @@ class BaseCropAndPad(BaseCrop):
                 border_mode=self.border_mode,
                 value=self.fill,
             )
-        return super().apply(img, crop_coords, **params)
+        return BaseCrop.apply(self, img, crop_coords, **params)
 
     def apply_to_mask(
         self,
@@ -228,10 +228,10 @@ class BaseCropAndPad(BaseCrop):
 
             params["shape"] = padded_shape
 
-            return super().apply_to_bboxes(bboxes_np, crop_coords, **params)
+            return BaseCrop.apply_to_bboxes(self, bboxes_np, crop_coords, **params)
 
         # If no padding, use original function behavior
-        return super().apply_to_bboxes(bboxes, crop_coords, **params)
+        return BaseCrop.apply_to_bboxes(self, bboxes, crop_coords, **params)
 
     def apply_to_keypoints(
         self,
@@ -261,7 +261,7 @@ class BaseCropAndPad(BaseCrop):
             # Update image shape for subsequent crop operation
             params = {**params, "shape": (padded_height, padded_width)}
 
-        return super().apply_to_keypoints(keypoints, crop_coords, **params)
+        return BaseCrop.apply_to_keypoints(self, keypoints, crop_coords, **params)
 
 
 class RandomCrop(BaseCropAndPad):

--- a/albumentations/augmentations/dropout/channel_dropout.py
+++ b/albumentations/augmentations/dropout/channel_dropout.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Annotated, Any
+from warnings import warn
 
 import numpy as np
 from albucore import get_num_channels
-from pydantic import AfterValidator, Field, model_validator
+from pydantic import AfterValidator, model_validator
 from typing_extensions import Self
 
 from albumentations.core.pydantic import check_1plus
@@ -75,13 +76,18 @@ class ChannelDropout(ImageOnlyTransform):
 
     class InitSchema(BaseTransformInitSchema):
         channel_drop_range: Annotated[tuple[int, int], AfterValidator(check_1plus)]
-        fill_value: float | None = Field(deprecated="fill_value is deprecated, use fill instead")
+        fill_value: float | None
         fill: float
 
         @model_validator(mode="after")
         def validate_fill(self) -> Self:
             if self.fill_value is not None:
                 self.fill = self.fill_value
+                warn(
+                    "`fill_value` deprecated. Use `fill` instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             return self
 
     def __init__(

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -2021,10 +2021,7 @@ class Solarize(ImageOnlyTransform):
     """
 
     class InitSchema(BaseTransformInitSchema):
-        threshold: ScaleFloatType | None = Field(
-            default=None,
-            deprecated="threshold parameter is deprecated. Use threshold_range instead.",
-        )
+        threshold: ScaleFloatType | None
         threshold_range: Annotated[
             tuple[float, float],
             AfterValidator(check_01),
@@ -2037,10 +2034,11 @@ class Solarize(ImageOnlyTransform):
             threshold_range: tuple[float, float],
         ) -> tuple[float, float]:
             """Convert legacy threshold or use threshold_range, normalizing to [0,1] range."""
-            if threshold is None:
-                return threshold_range
-            value = to_tuple(threshold, threshold)
-            return (value[0] / 255, value[1] / 255) if value[1] > 1 else value
+            if threshold is not None:
+                warn("`threshold` deprecated. Use `threshold_range` instead.", DeprecationWarning, stacklevel=2)
+                value = to_tuple(threshold, threshold)
+                return (value[0] / 255, value[1] / 255) if value[1] > 1 else value
+            return threshold_range
 
         @model_validator(mode="after")
         def process_threshold(self) -> Self:
@@ -2530,9 +2528,7 @@ class GaussNoise(ImageOnlyTransform):
         var_limit: ScaleFloatType | None = Field(
             deprecated="var_limit parameter is deprecated. Use std_range instead.",
         )
-        mean: float | None = Field(
-            deprecated="mean parameter is deprecated. Use mean_range instead.",
-        )
+        mean: float | None
         std_range: Annotated[
             tuple[float, float],
             AfterValidator(check_01),
@@ -2559,10 +2555,9 @@ class GaussNoise(ImageOnlyTransform):
                         math.sqrt(self.var_limit[0]),
                         math.sqrt(self.var_limit[1]),
                     )
-            if self.mean is not None:
-                self.mean_range = (0.0, 0.0)
 
             if self.mean is not None:
+                warn("`mean` deprecated. Use `mean_range` instead.", DeprecationWarning, stacklevel=2)
                 if self.mean >= 1:
                     # Convert legacy uint8 mean to normalized range
                     self.mean_range = (self.mean / 255, self.mean / 255)

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -84,3 +84,21 @@ def pad_3d_with_params(
         mode="constant",
         constant_values=value,
     )
+
+
+def crop(
+    img: np.ndarray,
+    crop_coords: tuple[int, int, int, int, int, int],
+) -> np.ndarray:
+    """Crop 3D volume using coordinates.
+
+    Args:
+        img: Input volume with shape (z, y, x) or (z, y, x, channels)
+        crop_coords: Tuple of (z_min, z_max, y_min, y_max, x_min, x_max) coordinates for cropping
+
+    Returns:
+        Cropped volume with same number of dimensions as input
+    """
+    z_min, z_max, y_min, y_max, x_min, x_max = crop_coords
+
+    return img[z_min:z_max, y_min:y_max, x_min:x_max]

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -258,6 +258,21 @@ class BaseCropAndPad3D(Transform3D):
         self.fill_mask = fill_mask
         self.pad_position = pad_position
 
+    def _random_pad(self, pad: int) -> tuple[int, int]:
+        """Helper function to calculate random padding for one dimension."""
+        if pad > 0:
+            pad_start = self.py_random.randint(0, pad)
+            pad_end = pad - pad_start
+        else:
+            pad_start = pad_end = 0
+        return pad_start, pad_end
+
+    def _center_pad(self, pad: int) -> tuple[int, int]:
+        """Helper function to calculate center padding for one dimension."""
+        pad_start = pad // 2
+        pad_end = pad - pad_start
+        return pad_start, pad_end
+
     def _get_pad_params(
         self,
         image_shape: tuple[int, int, int],
@@ -280,20 +295,14 @@ class BaseCropAndPad3D(Transform3D):
 
         # For center padding, split equally
         if self.pad_position == "center":
-            z_front = z_pad // 2
-            z_back = z_pad - z_front
-            h_top = h_pad // 2
-            h_bottom = h_pad - h_top
-            w_left = w_pad // 2
-            w_right = w_pad - w_left
+            z_front, z_back = self._center_pad(z_pad)
+            h_top, h_bottom = self._center_pad(h_pad)
+            w_left, w_right = self._center_pad(w_pad)
         # For random padding, randomly distribute the padding
         else:  # random
-            z_front = self.py_random.randint(0, z_pad + 1) if z_pad > 0 else 0
-            z_back = z_pad - z_front
-            h_top = self.py_random.randint(0, h_pad + 1) if h_pad > 0 else 0
-            h_bottom = h_pad - h_top
-            w_left = self.py_random.randint(0, w_pad + 1) if w_pad > 0 else 0
-            w_right = w_pad - w_left
+            z_front, z_back = self._random_pad(z_pad)
+            h_top, h_bottom = self._random_pad(h_pad)
+            w_left, w_right = self._random_pad(w_pad)
 
         return {
             "pad_front": z_front,

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 from typing import Annotated, Any, Literal, cast
 
 import numpy as np
-from pydantic import AfterValidator, model_validator
+from pydantic import AfterValidator, field_validator, model_validator
 from typing_extensions import Self
 
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.transforms3d import functional as f3d
 from albumentations.core.pydantic import check_range_bounds_3d
-from albumentations.core.transforms_interface import Transform3D
+from albumentations.core.transforms_interface import BaseTransformInitSchema, Transform3D
 from albumentations.core.types import ColorType, Targets
 
-__all__ = ["Pad3D", "PadIfNeeded3D"]
+__all__ = ["CenterCrop3D", "Pad3D", "PadIfNeeded3D", "RandomCrop3D"]
 
 NUM_DIMENSIONS = 3
 
@@ -98,6 +98,19 @@ class Pad3D(BasePad3D):
 
     class InitSchema(BasePad3D.InitSchema):
         padding: int | tuple[int, int, int] | tuple[int, int, int, int, int, int]
+
+        @field_validator("padding")
+        @classmethod
+        def validate_padding(
+            cls,
+            v: int | tuple[int, int, int] | tuple[int, int, int, int, int, int],
+        ) -> int | tuple[int, int, int] | tuple[int, int, int, int, int, int]:
+            if isinstance(v, int) and v < 0:
+                raise ValueError("Padding value must be non-negative")
+            if isinstance(v, tuple) and not all(isinstance(i, int) and i >= 0 for i in v):
+                raise ValueError("Padding tuple must contain non-negative integers")
+
+            return v
 
     def __init__(
         self,
@@ -217,3 +230,310 @@ class PadIfNeeded3D(BasePad3D):
             "fill",
             "fill_mask",
         )
+
+
+class BaseCropAndPad3D(Transform3D):
+    """Base class for 3D transforms that need both cropping and padding."""
+
+    _targets = (Targets.IMAGE, Targets.MASK)
+
+    class InitSchema(Transform3D.InitSchema):
+        pad_if_needed: bool
+        fill: ColorType
+        fill_mask: ColorType
+        pad_position: Literal["center", "random"]
+
+    def __init__(
+        self,
+        pad_if_needed: bool,
+        fill: ColorType,
+        fill_mask: ColorType,
+        pad_position: Literal["center", "random"],
+        p: float = 1.0,
+        always_apply: bool | None = None,
+    ):
+        super().__init__(p=p, always_apply=always_apply)
+        self.pad_if_needed = pad_if_needed
+        self.fill = fill
+        self.fill_mask = fill_mask
+        self.pad_position = pad_position
+
+    def _get_pad_params(
+        self,
+        image_shape: tuple[int, int, int],
+        target_shape: tuple[int, int, int],
+    ) -> dict[str, Any] | None:
+        """Calculate padding parameters if needed for 3D volumes."""
+        if not self.pad_if_needed:
+            return None
+
+        z, h, w = image_shape
+        target_z, target_h, target_w = target_shape
+
+        # Calculate total padding needed for each dimension
+        z_pad = max(0, target_z - z)
+        h_pad = max(0, target_h - h)
+        w_pad = max(0, target_w - w)
+
+        if z_pad == 0 and h_pad == 0 and w_pad == 0:
+            return None
+
+        # For center padding, split equally
+        if self.pad_position == "center":
+            z_front = z_pad // 2
+            z_back = z_pad - z_front
+            h_top = h_pad // 2
+            h_bottom = h_pad - h_top
+            w_left = w_pad // 2
+            w_right = w_pad - w_left
+        # For random padding, randomly distribute the padding
+        else:  # random
+            z_front = self.py_random.randint(0, z_pad + 1) if z_pad > 0 else 0
+            z_back = z_pad - z_front
+            h_top = self.py_random.randint(0, h_pad + 1) if h_pad > 0 else 0
+            h_bottom = h_pad - h_top
+            w_left = self.py_random.randint(0, w_pad + 1) if w_pad > 0 else 0
+            w_right = w_pad - w_left
+
+        return {
+            "pad_front": z_front,
+            "pad_back": z_back,
+            "pad_top": h_top,
+            "pad_bottom": h_bottom,
+            "pad_left": w_left,
+            "pad_right": w_right,
+        }
+
+    def apply_to_images(
+        self,
+        images: np.ndarray,
+        crop_coords: tuple[int, int, int, int, int, int],
+        pad_params: dict[str, int] | None,
+        **params: Any,
+    ) -> np.ndarray:
+        # First crop
+        cropped = f3d.crop(images, crop_coords)
+
+        # Then pad if needed
+        if pad_params is not None:
+            padding = (
+                pad_params["pad_front"],
+                pad_params["pad_back"],
+                pad_params["pad_top"],
+                pad_params["pad_bottom"],
+                pad_params["pad_left"],
+                pad_params["pad_right"],
+            )
+            return f3d.pad_3d_with_params(
+                cropped,
+                padding=padding,
+                value=cast(ColorType, self.fill),
+            )
+
+        return cropped
+
+    def apply_to_masks(
+        self,
+        masks: np.ndarray,
+        crop_coords: tuple[int, int, int, int, int, int],
+        pad_params: dict[str, int] | None,
+        **params: Any,
+    ) -> np.ndarray:
+        # First crop
+        cropped = f3d.crop(masks, crop_coords)
+
+        # Then pad if needed
+        if pad_params is not None:
+            padding = (
+                pad_params["pad_front"],
+                pad_params["pad_back"],
+                pad_params["pad_top"],
+                pad_params["pad_bottom"],
+                pad_params["pad_left"],
+                pad_params["pad_right"],
+            )
+            return f3d.pad_3d_with_params(
+                cropped,
+                padding=padding,
+                value=cast(ColorType, self.fill_mask),
+            )
+
+        return cropped
+
+
+class CenterCrop3D(BaseCropAndPad3D):
+    """Crop the center of 3D volume.
+
+    Args:
+        size (tuple[int, int, int]): Desired output size of the crop in format (depth, height, width)
+        pad_if_needed (bool): Whether to pad if the volume is smaller than desired crop size. Default: False
+        fill (ColorType): Padding value for image if pad_if_needed is True. Default: 0
+        fill_mask (ColorType): Padding value for mask if pad_if_needed is True. Default: 0
+        p (float): probability of applying the transform. Default: 1.0
+
+    Targets:
+        images, masks
+
+    Image types:
+        uint8, float32
+    """
+
+    class InitSchema(BaseTransformInitSchema):
+        size: Annotated[tuple[int, int, int], AfterValidator(check_range_bounds_3d(1, None))]
+        pad_if_needed: bool
+        fill: ColorType
+        fill_mask: ColorType
+
+    def __init__(
+        self,
+        size: tuple[int, int, int],
+        pad_if_needed: bool = False,
+        fill: ColorType = 0,
+        fill_mask: ColorType = 0,
+        p: float = 1.0,
+        always_apply: bool | None = None,
+    ):
+        super().__init__(
+            pad_if_needed=pad_if_needed,
+            fill=fill,
+            fill_mask=fill_mask,
+            pad_position="center",  # Center crop always uses center padding
+            p=p,
+        )
+        self.size = size
+
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        volume = data["images"]
+        z, h, w = volume.shape[:3]
+        target_z, target_h, target_w = self.size
+
+        # Get padding params if needed
+        pad_params = self._get_pad_params(
+            image_shape=(z, h, w),
+            target_shape=self.size,
+        )
+
+        # Update dimensions if padding is applied
+        if pad_params is not None:
+            z = z + pad_params["pad_front"] + pad_params["pad_back"]
+            h = h + pad_params["pad_top"] + pad_params["pad_bottom"]
+            w = w + pad_params["pad_left"] + pad_params["pad_right"]
+
+        # Validate dimensions after padding
+        if z < target_z or h < target_h or w < target_w:
+            msg = (
+                f"Crop size {self.size} is larger than padded image size ({z}, {h}, {w}). "
+                f"This should not happen - please report this as a bug."
+            )
+            raise ValueError(msg)
+
+        # For CenterCrop3D:
+        z_start = (z - target_z) // 2
+        h_start = (h - target_h) // 2
+        w_start = (w - target_w) // 2
+
+        crop_coords = (
+            z_start,
+            z_start + target_z,
+            h_start,
+            h_start + target_h,
+            w_start,
+            w_start + target_w,
+        )
+
+        return {
+            "crop_coords": crop_coords,
+            "pad_params": pad_params,
+        }
+
+    def get_transform_init_args_names(self) -> tuple[str, ...]:
+        return "size", "pad_if_needed", "fill", "fill_mask"
+
+
+class RandomCrop3D(BaseCropAndPad3D):
+    """Crop random part of 3D volume.
+
+    Args:
+        size (tuple[int, int, int]): Desired output size of the crop in format (depth, height, width)
+        pad_if_needed (bool): Whether to pad if the volume is smaller than desired crop size. Default: False
+        fill (ColorType): Padding value for image if pad_if_needed is True. Default: 0
+        fill_mask (ColorType): Padding value for mask if pad_if_needed is True. Default: 0
+        p (float): probability of applying the transform. Default: 1.0
+
+    Targets:
+        images, masks
+
+    Image types:
+        uint8, float32
+    """
+
+    class InitSchema(BaseTransformInitSchema):
+        size: Annotated[tuple[int, int, int], AfterValidator(check_range_bounds_3d(1, None))]
+        pad_if_needed: bool
+        fill: ColorType
+        fill_mask: ColorType
+
+    def __init__(
+        self,
+        size: tuple[int, int, int],
+        pad_if_needed: bool = False,
+        fill: ColorType = 0,
+        fill_mask: ColorType = 0,
+        p: float = 1.0,
+        always_apply: bool | None = None,
+    ):
+        super().__init__(
+            pad_if_needed=pad_if_needed,
+            fill=fill,
+            fill_mask=fill_mask,
+            pad_position="random",  # Random crop uses random padding position
+            p=p,
+        )
+        self.size = size
+
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        volume = data["images"]
+        z, h, w = volume.shape[:3]
+        target_z, target_h, target_w = self.size
+
+        # Get padding params if needed
+        pad_params = self._get_pad_params(
+            image_shape=(z, h, w),
+            target_shape=self.size,
+        )
+
+        # Update dimensions if padding is applied
+        if pad_params is not None:
+            z = z + pad_params["pad_front"] + pad_params["pad_back"]
+            h = h + pad_params["pad_top"] + pad_params["pad_bottom"]
+            w = w + pad_params["pad_left"] + pad_params["pad_right"]
+
+        # Calculate random crop coordinates
+        z_start = self.py_random.randint(0, max(0, z - target_z))
+        h_start = self.py_random.randint(0, max(0, h - target_h))
+        w_start = self.py_random.randint(0, max(0, w - target_w))
+
+        crop_coords = (
+            z_start,
+            z_start + target_z,
+            h_start,
+            h_start + target_h,
+            w_start,
+            w_start + target_w,
+        )
+
+        return {
+            "crop_coords": crop_coords,
+            "pad_params": pad_params,
+        }
+
+    def get_transform_init_args_names(self) -> tuple[str, ...]:
+        return "size", "pad_if_needed", "fill", "fill_mask"

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -406,4 +406,6 @@ AUGMENTATION_CLS_PARAMS = [
     [A.AutoContrast, {}],
     [A.PadIfNeeded3D, {"min_zyx": (300, 200, 400), "pad_divisor_zyx": (10, 10, 10), "position": "center", "fill": 10, "fill_mask": 20}],
     [A.Pad3D, {"padding": 10}],
+    [A.CenterCrop3D, {"size": (2, 30, 30)}],
+    [A.RandomCrop3D, {"size": (2, 30, 30)}],
 ]

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -130,7 +130,7 @@ def test_augmentations_serialization_with_custom_parameters(
     mask = image[:, :, 0].copy()
     aug = augmentation_cls(p=p, **params)
     aug.set_random_seed(seed)
-    transforms3d = {A.PadIfNeeded3D}
+    transforms3d = {A.PadIfNeeded3D, A.RandomCrop3D, A.CenterCrop3D, A.Pad3D}
 
     serialized_aug = A.to_dict(aug)
     deserialized_aug = A.from_dict(serialized_aug)
@@ -177,7 +177,7 @@ def test_augmentations_serialization_to_file_with_custom_parameters(
     image,
     data_format,
 ):
-    transforms3d = {A.PadIfNeeded3D}
+    transforms3d = {A.PadIfNeeded3D, A.RandomCrop3D, A.CenterCrop3D}
     mask = image[:, :, 0].copy()
     with patch("builtins.open", OpenMock()):
         aug = augmentation_cls(p=p, **params)
@@ -841,6 +841,8 @@ def test_template_transform_serialization(
             A.GridElasticDeform: {"num_grid_xy": (10, 10), "magnitude": 10},
             A.PadIfNeeded3D: {"min_zyx": (512, 512, 512)},
             A.Pad3D: {"padding": 10, "fill": 0, "fill_mask": 0},
+            A.CenterCrop3D: {"size": (2, 30, 30)},
+            A.RandomCrop3D: {"size": (2, 30, 30)},
         },
         except_augmentations={
             A.FDA,

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -2162,7 +2162,7 @@ def test_random_sun_flare_invalid_input(params):
 
 @pytest.mark.parametrize(
     ["augmentation_cls", "params"],
-    get_transforms(
+    get_2d_transforms(
         custom_arguments={
             A.Crop: {"y_min": 0, "y_max": 10, "x_min": 0, "x_max": 10},
             A.CenterCrop: {"height": 10, "width": 10},
@@ -2202,6 +2202,8 @@ def test_random_sun_flare_invalid_input(params):
             A.TextImage: dict(font_path="./tests/files/LiberationSerif-Bold.ttf"),
             A.PadIfNeeded3D: {"min_zyx": (300, 200, 400), "pad_divisor_zyx": (10, 10, 10), "position": "center", "fill": 10, "fill_mask": 20},
             A.Pad3D: {"padding": 10},
+            A.RandomCrop3D: {"size": (2, 30, 30), "pad_if_needed": True},
+            A.CenterCrop3D: {"size": (2, 30, 30), "pad_if_needed": True},
         },
         except_augmentations={
             A.RandomCropNearBBox,
@@ -2238,9 +2240,6 @@ def test_return_nonzero(augmentation_cls, params):
         mask = np.zeros_like(image)[:, :, 0]
         mask[:20, :20] = 1
         data["mask"] = mask
-    elif augmentation_cls == A.PadIfNeeded3D:
-        data["images"] = np.ones((10, 100, 100), dtype=np.uint8)
-        data["masks"] = np.ones((10, 100, 100), dtype=np.uint8)
 
     result = aug(**data)
 

--- a/tests/transforms3d/test_targets.py
+++ b/tests/transforms3d/test_targets.py
@@ -60,9 +60,7 @@ def get_targets_from_methods(cls):
 
     return targets
 
-TRASNFORM_3d_DUAL_TARGETS = {
-    A.PadIfNeeded3D: (Targets.IMAGE, Targets.MASK),
-}
+TRASNFORM_3d_DUAL_TARGETS = {}
 
 str2target = {
     "images": Targets.IMAGE,
@@ -74,6 +72,8 @@ str2target = {
     get_3d_transforms(custom_arguments={
         A.PadIfNeeded3D: {"min_zyx": (4, 250, 230), "position": "center", "fill": 0, "fill_mask": 0},
         A.Pad3D: {"padding": 10},
+        A.RandomCrop3D: {"size": (2, 30, 30), "pad_if_needed": True},
+        A.CenterCrop3D: {"size": (2, 30, 30), "pad_if_needed": True},
     })
 )
 def test_dual(augmentation_cls, params):

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -381,12 +381,7 @@ def test_crop_3d_shapes(transform, input_shape, expected_shape):
 def test_crop_3d_padding(transform_cls, input_shape, target_shape, description):
     volume = np.random.randint(0, 256, input_shape, dtype=np.uint8)
 
-    transform = transform_cls(
-        size=target_shape,
-        pad_if_needed=True,
-        fill=0,
-        fill_mask=0,
-    )
+    transform = A.Compose([transform_cls(p=1, size=target_shape, pad_if_needed=True, fill=0, fill_mask=0)], seed=0)
 
     transformed = transform(images=volume)
     assert transformed["images"].shape == target_shape
@@ -411,12 +406,7 @@ def test_crop_3d_fill_values(transform_cls, size, fill, fill_mask):
     volume = np.ones((3, 50, 50), dtype=np.uint8)
     mask = np.zeros((3, 50, 50), dtype=np.uint8)
 
-    transform = transform_cls(
-        size=size,
-        pad_if_needed=True,
-        fill=fill,
-        fill_mask=fill_mask,
-    )
+    transform = A.Compose([transform_cls(p=1, size=size, pad_if_needed=True, fill=fill, fill_mask=fill_mask)], seed=0)
 
     transformed = transform(images=volume, masks=mask)
     padded_volume = transformed["images"]

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -3,8 +3,8 @@ import numpy as np
 import albumentations as A
 import cv2
 
-from tests.conftest import RECTANGULAR_UINT8_IMAGE, SQUARE_FLOAT_IMAGE, SQUARE_UINT8_IMAGE
-from tests.utils import get_3d_transforms
+from tests.conftest import RECTANGULAR_UINT8_IMAGE, SQUARE_UINT8_IMAGE
+from tests.utils import get_2d_transforms, get_3d_transforms
 
 @pytest.mark.parametrize(
     ["volume_shape", "min_zyx", "pad_divisor_zyx", "expected_shape"],
@@ -107,6 +107,8 @@ def test_pad_if_needed_3d_fill_values():
         custom_arguments={
             A.PadIfNeeded3D: {"min_zyx": (4, 250, 230), "position": "center", "fill": 0, "fill_mask": 0},
             A.Pad3D: {"padding": 10},
+            A.RandomCrop3D: {"size": (2, 30, 30), "pad_if_needed": True},
+            A.CenterCrop3D: {"size": (2, 30, 30), "pad_if_needed": True},
         },
         except_augmentations={
         },
@@ -271,6 +273,8 @@ def test_pad3d_2d_equivalence(pad3d_padding, pad2d_padding):
         custom_arguments={
             A.PadIfNeeded3D: {"min_zyx": (300, 200, 400), "pad_divisor_zyx": (10, 10, 10), "position": "center", "fill": 10, "fill_mask": 20},
             A.Pad3D: {"padding": 10},
+            A.RandomCrop3D: {"size": (2, 30, 30), "pad_if_needed": True},
+            A.CenterCrop3D: {"size": (2, 30, 30), "pad_if_needed": True},
         },
         except_augmentations={
         },
@@ -292,3 +296,267 @@ def test_change_image(augmentation_cls, params):
 
     assert not np.array_equal(transformed["images"], original_images)
     assert not np.array_equal(transformed["masks"], original_masks)
+
+
+@pytest.mark.parametrize(
+    ["transform", "input_shape", "expected_shape"],
+    [
+        # CenterCrop3D tests
+        (
+            A.CenterCrop3D(size=(4, 60, 60), pad_if_needed=False, fill=0, fill_mask=0),
+            (10, 100, 100),
+            (4, 60, 60),
+        ),
+        # RandomCrop3D tests
+        (
+            A.RandomCrop3D(size=(4, 60, 60), pad_if_needed=False, fill=0, fill_mask=0),
+            (10, 100, 100),
+            (4, 60, 60),
+        ),
+    ],
+    ids=[
+        "center_crop_3d",
+        "random_crop_3d",
+    ]
+)
+def test_crop_3d_shapes(transform, input_shape, expected_shape):
+    volume = np.random.randint(0, 256, input_shape, dtype=np.uint8)
+    transformed = transform(images=volume)
+    assert transformed["images"].shape == expected_shape
+
+
+@pytest.mark.parametrize(
+    "transform_cls",
+    [
+        A.CenterCrop3D,
+        A.RandomCrop3D,
+    ],
+    ids=[
+        "center_crop",
+        "random_crop",
+    ]
+)
+@pytest.mark.parametrize(
+    ["input_shape", "target_shape", "description"],
+    [
+        # Padding needed in all dimensions
+        (
+            (10, 100, 100),
+            (16, 128, 128),
+            "pad_all_dims",
+        ),
+        # Padding needed only in depth
+        (
+            (5, 100, 100),
+            (10, 50, 50),
+            "pad_depth_only",
+        ),
+        # Padding needed only in height
+        (
+            (10, 40, 100),
+            (8, 64, 50),
+            "pad_height_only",
+        ),
+        # Padding needed only in width
+        (
+            (10, 100, 40),
+            (8, 50, 64),
+            "pad_width_only",
+        ),
+        # Padding needed in height and width
+        (
+            (10, 40, 40),
+            (8, 64, 64),
+            "pad_height_width",
+        ),
+        # No padding needed (smaller crop)
+        (
+            (10, 100, 100),
+            (8, 64, 64),
+            "no_padding_needed",
+        ),
+    ],
+    ids=lambda x: x[2] if isinstance(x, tuple) else x,
+)
+def test_crop_3d_padding(transform_cls, input_shape, target_shape, description):
+    volume = np.random.randint(0, 256, input_shape, dtype=np.uint8)
+
+    transform = transform_cls(
+        size=target_shape,
+        pad_if_needed=True,
+        fill=0,
+        fill_mask=0,
+    )
+
+    transformed = transform(images=volume)
+    assert transformed["images"].shape == target_shape
+
+
+@pytest.mark.parametrize(
+    ["transform_cls", "size", "fill", "fill_mask"],
+    [
+        (A.CenterCrop3D, (4, 60, 60), 0, 1),
+        (A.CenterCrop3D, (4, 60, 60), 1, 0),
+        (A.RandomCrop3D, (4, 60, 60), 0, 1),
+        (A.RandomCrop3D, (4, 60, 60), 1, 0),
+    ],
+    ids=[
+        "center_crop_fill_0_mask_1",
+        "center_crop_fill_1_mask_0",
+        "random_crop_fill_0_mask_1",
+        "random_crop_fill_1_mask_0",
+    ]
+)
+def test_crop_3d_fill_values(transform_cls, size, fill, fill_mask):
+    volume = np.ones((3, 50, 50), dtype=np.uint8)
+    mask = np.zeros((3, 50, 50), dtype=np.uint8)
+
+    transform = transform_cls(
+        size=size,
+        pad_if_needed=True,
+        fill=fill,
+        fill_mask=fill_mask,
+    )
+
+    transformed = transform(images=volume, masks=mask)
+    padded_volume = transformed["images"]
+    padded_mask = transformed["masks"]
+
+    # Verify shapes
+    assert padded_volume.shape == size
+    assert padded_mask.shape == size
+
+    # Find padded regions by comparing with fill values
+    is_padding_volume = padded_volume == fill
+    is_padding_mask = padded_mask == fill_mask
+
+    # Check that some padding exists in each dimension that needs it
+    if size[0] > volume.shape[0]:
+        assert np.any(is_padding_volume[:, 0, 0])  # depth padding exists
+        assert np.any(is_padding_mask[:, 0, 0])
+
+    if size[1] > volume.shape[1]:
+        assert np.any(is_padding_volume[0, :, 0])  # height padding exists
+        assert np.any(is_padding_mask[0, :, 0])
+
+    if size[2] > volume.shape[2]:
+        assert np.any(is_padding_volume[0, 0, :])  # width padding exists
+        assert np.any(is_padding_mask[0, 0, :])
+
+    # Check that padding values are consistent
+    assert np.all(padded_volume[is_padding_volume] == fill)
+    assert np.all(padded_mask[is_padding_mask] == fill_mask)
+
+
+def test_random_crop_3d_reproducibility():
+    """Test that RandomCrop3D produces same results with same random seed"""
+    volume = np.random.randint(0, 256, (10, 100, 100), dtype=np.uint8)
+
+    transform = A.RandomCrop3D(size=(4, 60, 60))
+
+    # First run
+    transform.set_random_seed(42)
+    result1 = transform(images=volume)["images"]
+
+    # Second run
+    transform.set_random_seed(42)
+    result2 = transform(images=volume)["images"]
+
+    np.testing.assert_array_equal(result1, result2)
+
+
+@pytest.mark.parametrize(
+    "volume_shape",
+    [
+        (10, 100, 100),      # 3D
+        (10, 100, 100, 1),   # 4D single channel
+        (10, 100, 100, 3),   # 4D multi-channel
+    ],
+    ids=[
+        "3d_volume",
+        "4d_single_channel",
+        "4d_multi_channel",
+    ]
+)
+def test_crop_3d_different_shapes(volume_shape):
+    volume = np.random.randint(0, 256, volume_shape, dtype=np.uint8)
+
+    for transform_cls in [A.CenterCrop3D, A.RandomCrop3D]:
+        transform = transform_cls(size=(4, 60, 60))
+        transformed = transform(images=volume)
+
+        expected_shape = (4, 60, 60)
+        if len(volume_shape) == 4:
+            expected_shape += (volume_shape[3],)
+
+        assert transformed["images"].shape == expected_shape
+
+
+@pytest.mark.parametrize(
+    ["augmentation_cls", "params"],
+    get_3d_transforms(
+        custom_arguments={
+            A.PadIfNeeded3D: {"min_zyx": (300, 200, 400), "pad_divisor_zyx": (10, 10, 10), "position": "center", "fill": 10, "fill_mask": 20},
+            A.Pad3D: {"padding": 10},
+            A.RandomCrop3D: {"size": (2, 30, 30), "pad_if_needed": True},
+            A.CenterCrop3D: {"size": (2, 30, 30), "pad_if_needed": True},
+        },
+        except_augmentations={
+        },
+    ),
+)
+@pytest.mark.parametrize(
+    "masks",
+    [
+        np.stack([np.random.randint(0, 2, (100, 100), dtype=np.uint8)] * 4),
+        np.stack([np.random.randint(0, 2, (100, 100, 3), dtype=np.uint8)] * 4),
+    ],
+)
+def test_masks_as_target(augmentation_cls, params, masks):
+    num_images = masks.shape[0]
+
+    image = SQUARE_UINT8_IMAGE
+
+    data = {
+        "images": np.stack([image] * num_images),
+        "masks": masks,
+    }
+
+    aug = A.Compose(
+        [augmentation_cls(p=1, **params)],
+        seed=42,
+    )
+
+    transformed = aug(**data)
+
+    np.testing.assert_array_equal(transformed["masks"][0], transformed["masks"][1])
+
+    assert transformed["masks"][0].dtype == masks[0].dtype
+
+
+@pytest.mark.parametrize(
+    ["augmentation_cls", "params"],
+    get_3d_transforms(
+        custom_arguments={
+            A.PadIfNeeded3D: {"min_zyx": (300, 200, 400), "pad_divisor_zyx": (10, 10, 10), "position": "center", "fill": 10, "fill_mask": 20},
+            A.Pad3D: {"padding": 10},
+            A.RandomCrop3D: {"size": (2, 30, 30), "pad_if_needed": True},
+            A.CenterCrop3D: {"size": (2, 30, 30), "pad_if_needed": True},
+        },
+        except_augmentations={
+        },
+    ),
+)
+def test_return_nonzero(augmentation_cls, params):
+    """Mistakes in clipping may lead to zero image, testing for that"""
+    images = np.ones((3, 100, 100), dtype=np.uint8)
+
+    aug = A.Compose([augmentation_cls(**params, p=1)], seed=42)
+
+    data = {
+        "images": images,
+    }
+
+    result = aug(**data)
+
+    assert np.max(result["images"]) > 0


### PR DESCRIPTION
## Summary by Sourcery

Add CenterCrop3D and RandomCrop3D transforms for 3D image volumes, including validation for padding values and comprehensive tests.

New Features:
- Introduce CenterCrop3D and RandomCrop3D transforms for 3D image volumes, allowing for center and random cropping with optional padding.

Enhancements:
- Add validation for padding values in Pad3D to ensure non-negative integers.

Documentation:
- Update README to include CenterCrop3D and RandomCrop3D in the list of available 3D transforms.

Tests:
- Add tests for CenterCrop3D and RandomCrop3D to verify correct cropping and padding behavior, including shape validation and reproducibility.