### PR TITLE
Boost version

### DIFF
--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -1083,14 +1083,8 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
             AfterValidator(check_range_bounds(0, None)),
             AfterValidator(nondecreasing),
         ]
-        width: int | None = Field(
-            None,
-            deprecated="Initializing with 'height' and 'width' is deprecated. Use size instead.",
-        )
-        height: int | None = Field(
-            None,
-            deprecated="Initializing with 'height' and 'width' is deprecated. Use size instead.",
-        )
+        width: int | None
+        height: int | None
         size: ScaleIntType | None
         interpolation: InterpolationType
         mask_interpolation: InterpolationType

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [ "setuptools>=45", "wheel" ]
 [project]
 name = "albumentations"
 
-version = "1.4.22"
+version = "1.4.23"
 
 description = "Fast, flexible, and advanced image augmentation library for deep learning and computer vision. Albumentations offers a wide range of transformations for images, masks, bounding boxes, and keypoints, with optimized performance and seamless integration into ML workflows."
 readme = "README.md"


### PR DESCRIPTION
## Summary by Sourcery

Remove deprecation warnings for 'height' and 'width' fields in InitSchema and bump project version to 1.4.23.

Enhancements:
- Remove deprecation warnings for 'height' and 'width' fields in InitSchema.

Build:
- Bump project version from 1.4.22 to 1.4.23 in pyproject.toml.