### PR TITLE
Install `eval-type-backport` only on 3.10 and older

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ INSTALL_REQUIRES = [
     "typing-extensions>=4.9.0; python_version<'3.10'",
     "pydantic>=2.9.2",
     "albucore==0.0.22",
-    "eval-type-backport",
+    "eval-type-backport; python_version<'3.10'",
 ]
 
 MIN_OPENCV_VERSION = "4.9.0.80"


### PR DESCRIPTION
I assume you added this for pydantic, but that library is [basically useless on newer versions](https://github.com/alexmojaki/eval_type_backport/issues/24#issuecomment-2555757695). Also, `eval-type-backport` is broken on 3.12+ currently (see https://github.com/alexmojaki/eval_type_backport/issues/24)

## Summary by Sourcery

Bug Fixes:
- Fix incompatibility issues with `eval-type-backport` on Python 3.12 and later.