### PR TITLE
Add keypoints to 3d

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,14 +311,14 @@ Where:
 - Volume: 3D array of shape (D, H, W) or (D, H, W, C) where D is depth, H is height, W is width, and C is number of channels (optional)
 - Mask3D: Binary or multi-class 3D mask of shape (D, H, W) where each slice represents segmentation for the corresponding volume slice
 
-| Transform                                                                      | Volume | Mask3D |
-| ------------------------------------------------------------------------------ | :----: | :----: |
-| [CenterCrop3D](https://explore.albumentations.ai/transform/CenterCrop3D)       | ✓      | ✓      |
-| [CoarseDropout3D](https://explore.albumentations.ai/transform/CoarseDropout3D) | ✓      | ✓      |
-| [CubicSymmetry](https://explore.albumentations.ai/transform/CubicSymmetry)     | ✓      | ✓      |
-| [Pad3D](https://explore.albumentations.ai/transform/Pad3D)                     | ✓      | ✓      |
-| [PadIfNeeded3D](https://explore.albumentations.ai/transform/PadIfNeeded3D)     | ✓      | ✓      |
-| [RandomCrop3D](https://explore.albumentations.ai/transform/RandomCrop3D)       | ✓      | ✓      |
+| Transform                                                                      | Volume | Mask3D | Keypoints |
+| ------------------------------------------------------------------------------ | :----: | :----: | :-------: |
+| [CenterCrop3D](https://explore.albumentations.ai/transform/CenterCrop3D)       | ✓      | ✓      | ✓         |
+| [CoarseDropout3D](https://explore.albumentations.ai/transform/CoarseDropout3D) | ✓      | ✓      | ✓         |
+| [CubicSymmetry](https://explore.albumentations.ai/transform/CubicSymmetry)     | ✓      | ✓      | ✓         |
+| [Pad3D](https://explore.albumentations.ai/transform/Pad3D)                     | ✓      | ✓      | ✓         |
+| [PadIfNeeded3D](https://explore.albumentations.ai/transform/PadIfNeeded3D)     | ✓      | ✓      | ✓         |
+| [RandomCrop3D](https://explore.albumentations.ai/transform/RandomCrop3D)       | ✓      | ✓      | ✓         |
 
 ## A few more examples of **augmentations**
 

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -3,6 +3,7 @@ from typing import Literal
 
 import numpy as np
 
+from albumentations.augmentations.utils import handle_empty_array
 from albumentations.core.types import NUM_VOLUME_DIMENSIONS, ColorType
 
 
@@ -163,3 +164,150 @@ def transform_cube(cube: np.ndarray, index: int) -> np.ndarray:
         return np.rot90(temp, rotation_index - 16, axes=(0, 2))
     temp = np.rot90(working_cube, -1, axes=(0, 1))
     return np.rot90(temp, rotation_index - 20, axes=(0, 2))
+
+
+@handle_empty_array("keypoints")
+def filter_keypoints_in_holes3d(keypoints: np.ndarray, holes: np.ndarray) -> np.ndarray:
+    """Filter out keypoints that are inside any of the 3D holes.
+
+    Args:
+        keypoints (np.ndarray): Array of keypoints with shape (num_keypoints, 3+).
+                               The first three columns are x, y, z coordinates.
+        holes (np.ndarray): Array of holes with shape (num_holes, 6).
+                           Each hole is represented as [z1, y1, x1, z2, y2, x2].
+
+    Returns:
+        np.ndarray: Array of keypoints that are not inside any hole.
+    """
+    if holes.size == 0:
+        return keypoints
+
+    # Broadcast keypoints and holes for vectorized comparison
+    # Convert keypoints from XYZ to ZYX for comparison with holes
+    kp_z = keypoints[:, 2][:, np.newaxis]  # Shape: (num_keypoints, 1)
+    kp_y = keypoints[:, 1][:, np.newaxis]  # Shape: (num_keypoints, 1)
+    kp_x = keypoints[:, 0][:, np.newaxis]  # Shape: (num_keypoints, 1)
+
+    # Extract hole coordinates (in ZYX order)
+    hole_z1 = holes[:, 0]  # Shape: (num_holes,)
+    hole_y1 = holes[:, 1]
+    hole_x1 = holes[:, 2]
+    hole_z2 = holes[:, 3]
+    hole_y2 = holes[:, 4]
+    hole_x2 = holes[:, 5]
+
+    # Check if each keypoint is inside each hole
+    inside_hole = (
+        (kp_z >= hole_z1)
+        & (kp_z < hole_z2)
+        & (kp_y >= hole_y1)
+        & (kp_y < hole_y2)
+        & (kp_x >= hole_x1)
+        & (kp_x < hole_x2)
+    )
+
+    # A keypoint is valid if it's not inside any hole
+    valid_keypoints = ~np.any(inside_hole, axis=1)
+
+    # Return filtered keypoints with same dtype as input
+    result = keypoints[valid_keypoints]
+    if len(result) == 0:
+        # Ensure empty result has correct shape and dtype
+        return np.array([], dtype=keypoints.dtype).reshape(0, keypoints.shape[1])
+    return result
+
+
+def keypoints_rot90(
+    keypoints: np.ndarray,
+    k: int,
+    axes: tuple[int, int],
+    volume_shape: tuple[int, int, int],
+) -> np.ndarray:
+    if k == 0 or len(keypoints) == 0:
+        return keypoints.copy()
+
+    # Normalize factor to range [0, 3]
+    k = ((k % 4) + 4) % 4
+
+    result = keypoints.copy()
+
+    # Get dimensions for the rotation axes
+    dims = [volume_shape[ax] for ax in axes]
+
+    # Get coordinates to rotate
+    coords1 = result[:, axes[0]].copy()
+    coords2 = result[:, axes[1]].copy()
+
+    # Apply rotation based on factor (counterclockwise)
+    if k == 1:  # 90 degrees CCW
+        result[:, axes[0]] = (dims[1] - 1) - coords2
+        result[:, axes[1]] = coords1
+    elif k == 2:  # 180 degrees
+        result[:, axes[0]] = (dims[0] - 1) - coords1
+        result[:, axes[1]] = (dims[1] - 1) - coords2
+    elif k == 3:  # 270 degrees CCW
+        result[:, axes[0]] = coords2
+        result[:, axes[1]] = (dims[0] - 1) - coords1
+
+    return result
+
+
+@handle_empty_array("keypoints")
+def transform_cube_keypoints(
+    keypoints: np.ndarray,
+    index: int,
+    volume_shape: tuple[int, int, int],
+) -> np.ndarray:
+    if not (0 <= index < 48):
+        raise ValueError("Index must be between 0 and 47")
+
+    # Convert from XYZ to HWD coordinates (like in the test)
+    working_points = keypoints.copy()
+    working_points = working_points[:, [2, 1, 0]]  # XYZ -> HWD
+
+    current_shape = volume_shape
+
+    # Handle reflection first (indices 24-47)
+    if index >= 24:
+        working_points[:, 2] = current_shape[2] - 1 - working_points[:, 2]  # Reflect W axis
+
+    # Get rotation index (0-23)
+    rotation_index = index % 24
+
+    # Apply the same rotation logic as transform_cube
+    if rotation_index < 4:
+        # First 4: rotate around axis 0
+        result = keypoints_rot90(working_points, k=rotation_index, axes=(1, 2), volume_shape=current_shape)
+    elif rotation_index < 8:
+        # Next 4: flip 180° about axis 1, then rotate around axis 0
+        temp = keypoints_rot90(working_points, k=2, axes=(0, 2), volume_shape=current_shape)
+        # After first rotation: (D,H,W) -> (W,H,D)
+        temp_shape = (current_shape[2], current_shape[1], current_shape[0])
+        result = keypoints_rot90(temp, k=rotation_index - 4, axes=(1, 2), volume_shape=volume_shape)
+    elif rotation_index < 16:
+        # Next 8: split between 90° and 270° about axis 1, then rotate around axis 2
+        if rotation_index < 12:
+            temp = keypoints_rot90(working_points, k=1, axes=(0, 2), volume_shape=current_shape)
+            # After first rotation: (D,H,W) -> (W,H,D)
+            temp_shape = (current_shape[2], current_shape[1], current_shape[0])
+            result = keypoints_rot90(temp, k=rotation_index - 8, axes=(0, 1), volume_shape=temp_shape)
+        else:
+            temp = keypoints_rot90(working_points, k=3, axes=(0, 2), volume_shape=current_shape)
+            # After first rotation: (D,H,W) -> (W,H,D)
+            temp_shape = (current_shape[2], current_shape[1], current_shape[0])
+            result = keypoints_rot90(temp, k=rotation_index - 12, axes=(0, 1), volume_shape=temp_shape)
+
+    # Final 8: split between rotations about axis 2, then rotate around axis 1
+    elif rotation_index < 20:
+        temp = keypoints_rot90(working_points, k=1, axes=(0, 1), volume_shape=current_shape)
+        # After first rotation: (D,H,W) -> (H,D,W)
+        temp_shape = (current_shape[1], current_shape[0], current_shape[2])
+        result = keypoints_rot90(temp, k=rotation_index - 16, axes=(0, 2), volume_shape=temp_shape)
+    else:
+        temp = keypoints_rot90(working_points, k=3, axes=(0, 1), volume_shape=current_shape)
+        # After first rotation: (D,H,W) -> (H,D,W)
+        temp_shape = (current_shape[1], current_shape[0], current_shape[2])
+        result = keypoints_rot90(temp, k=rotation_index - 20, axes=(0, 2), volume_shape=temp_shape)
+
+    # Convert back from DHW to XYZ coordinates
+    return result[:, [2, 1, 0]]  # HWD -> XYZ

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -284,7 +284,6 @@ def transform_cube_keypoints(
     elif rotation_index < 8:
         # Next 4: flip 180° about axis 1, then rotate around axis 0
         temp = keypoints_rot90(working_points, k=2, axes=(0, 2), volume_shape=current_shape)
-        temp_shape = (current_shape[2], current_shape[1], current_shape[0])
         result = keypoints_rot90(temp, k=rotation_index - 4, axes=(1, 2), volume_shape=volume_shape)
     elif rotation_index < 16:
         if rotation_index < 12:

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -48,30 +48,40 @@ def adjust_padding_by_position3d(
 
 def pad_3d_with_params(
     volume: np.ndarray,
-    padding: tuple[int, int, int, int, int, int],  # (d_front, d_back, h_top, h_bottom, w_left, w_right)
+    padding: tuple[int, int, int, int, int, int],
     value: ColorType,
 ) -> np.ndarray:
-    """Pad 3D image with given parameters.
+    """Pad 3D volume with given parameters.
 
     Args:
         volume: Input volume with shape (depth, height, width) or (depth, height, width, channels)
-        padding: Padding values (d_front, d_back, h_top, h_bottom, w_left, w_right)
-        value: Padding value
+        padding: Padding values in format:
+            (depth_front, depth_back, height_top, height_bottom, width_left, width_right)
+            where:
+            - depth_front/back: padding at start/end of depth axis (z)
+            - height_top/bottom: padding at start/end of height axis (y)
+            - width_left/right: padding at start/end of width axis (x)
+        value: Value to fill the padding
 
     Returns:
-        Padded image with same number of dimensions as input
+        Padded volume with same number of dimensions as input
+
+    Note:
+        The padding order matches the volume dimensions (depth, height, width).
+        For each dimension, the first value is padding at the start (smaller indices),
+        and the second value is padding at the end (larger indices).
     """
-    d_front, d_back, h_top, h_bottom, w_left, w_right = padding
+    depth_front, depth_back, height_top, height_bottom, width_left, width_right = padding
 
     # Skip if no padding is needed
-    if d_front == d_back == h_top == h_bottom == w_left == w_right == 0:
+    if all(p == 0 for p in padding):
         return volume
 
     # Handle both 3D and 4D arrays
     pad_width = [
-        (d_front, d_back),  # depth padding
-        (h_top, h_bottom),  # height padding
-        (w_left, w_right),  # width padding
+        (depth_front, depth_back),  # depth (z) padding
+        (height_top, height_bottom),  # height (y) padding
+        (width_left, width_right),  # width (x) padding
     ]
 
     # Add channel padding if 4D array

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -224,7 +224,7 @@ def keypoints_rot90(
     volume_shape: tuple[int, int, int],
 ) -> np.ndarray:
     if k == 0 or len(keypoints) == 0:
-        return keypoints.copy()
+        return keypoints
 
     # Normalize factor to range [0, 3]
     k = ((k % 4) + 4) % 4

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -615,7 +615,7 @@ class CoarseDropout3D(Transform3D):
         p (float): Probability of applying the transform. Default: 0.5
 
     Targets:
-        volume, mask3d
+        volume, mask3d, keypoints
 
     Image types:
         uint8, float32
@@ -645,7 +645,7 @@ class CoarseDropout3D(Transform3D):
         >>> transformed_volume, transformed_mask3d = transformed["volume"], transformed["mask3d"]
     """
 
-    _targets = (Targets.VOLUME, Targets.MASK3D)
+    _targets = (Targets.VOLUME, Targets.MASK3D, Targets.KEYPOINTS)
 
     class InitSchema(Transform3D.InitSchema):
         num_holes_range: Annotated[

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -855,13 +855,15 @@ class CubicSymmetry(Transform3D):
         data: dict[str, Any],
     ) -> dict[str, Any]:
         # Randomly select one of 48 possible transformations
-        return {"index": self.py_random.randint(0, 47)}
+
+        volume_shape = data["volume"].shape
+        return {"index": self.py_random.randint(0, 47), "volume_shape": volume_shape}
 
     def apply_to_volume(self, volume: np.ndarray, index: int, **params: Any) -> np.ndarray:
         return f3d.transform_cube(volume, index)
 
     def apply_to_keypoints(self, keypoints: np.ndarray, index: int, **params: Any) -> np.ndarray:
-        return f3d.transform_cube_keypoints(keypoints, index, volume_shape=params["volume"].shape)
+        return f3d.transform_cube_keypoints(keypoints, index, volume_shape=params["volume_shape"])
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return ()

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -87,8 +87,6 @@ class Pad3D(BasePad3D):
         p (float): probability of applying the transform. Default: 1.0.
 
     Targets:
-
-    Targets:
         volume, mask3d, keypoints
 
     Image types:

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -613,6 +613,7 @@ class Transform3D(DualTransform):
         volumes: Batch of 3D arrays of shape (N, D, H, W) or (N, D, H, W, C)
         mask: 3D numpy array of shape (D, H, W)
         masks: Batch of 3D arrays of shape (N, D, H, W)
+        keypoints: 3D numpy array of shape (N, 3)
     """
 
     def apply_to_volume(self, volume: np.ndarray, *args: Any, **params: Any) -> np.ndarray:
@@ -641,4 +642,5 @@ class Transform3D(DualTransform):
             "volumes": self.apply_to_volumes,
             "mask3d": self.apply_to_mask3d,
             "masks3d": self.apply_to_masks3d,
+            "keypoints": self.apply_to_keypoints,
         }

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -132,7 +132,7 @@ def test_augmentations_serialization_with_custom_parameters(
     mask = image[:, :, 0].copy()
     aug = augmentation_cls(p=p, **params)
     aug.set_random_seed(seed)
-    transforms3d = {A.PadIfNeeded3D, A.RandomCrop3D, A.CenterCrop3D, A.CoarseDropout3D, A.Pad3D}
+    transforms3d = {A.PadIfNeeded3D, A.RandomCrop3D, A.CenterCrop3D, A.CoarseDropout3D, A.Pad3D, A.CubicSymmetry}
 
     serialized_aug = A.to_dict(aug)
     deserialized_aug = A.from_dict(serialized_aug)
@@ -179,7 +179,7 @@ def test_augmentations_serialization_to_file_with_custom_parameters(
     image,
     data_format,
 ):
-    transforms3d = {A.PadIfNeeded3D, A.RandomCrop3D, A.CenterCrop3D, A.CoarseDropout3D, A.Pad3D}
+    transforms3d = {A.PadIfNeeded3D, A.RandomCrop3D, A.CenterCrop3D, A.CoarseDropout3D, A.Pad3D, A.CubicSymmetry}
     mask = image[:, :, 0].copy()
     with patch("builtins.open", OpenMock()):
         aug = augmentation_cls(p=p, **params)
@@ -202,8 +202,7 @@ def test_augmentations_serialization_to_file_with_custom_parameters(
         elif augmentation_cls == A.TextImage:
             data["textimage_metadata"] = []
         elif augmentation_cls in transforms3d:
-            data["volume"] = np.array([image] * 10)
-            data["mask"] = np.array([mask] * 10)
+            data = {"volume": np.array([image] * 10), "mask3d": np.array([mask] * 10)}
 
         aug_data = aug(**data)
         deserialized_aug_data = deserialized_aug(**data)
@@ -213,7 +212,7 @@ def test_augmentations_serialization_to_file_with_custom_parameters(
             np.testing.assert_array_equal(aug_data["mask"], deserialized_aug_data["mask"])
         else:
             np.testing.assert_array_equal(aug_data["volume"], deserialized_aug_data["volume"])
-            np.testing.assert_array_equal(aug_data["mask"], deserialized_aug_data["mask"])
+            np.testing.assert_array_equal(aug_data["mask3d"], deserialized_aug_data["mask3d"])
 
 
 @pytest.mark.parametrize(

--- a/tests/transforms3d/test_functions.py
+++ b/tests/transforms3d/test_functions.py
@@ -26,3 +26,203 @@ def test_uniqueness(input_shape: tuple, n_channels: int | None):
     expected_shape = input_shape
     for t in transformations:
         assert t.shape == expected_shape, f"Wrong shape: got {t.shape}, expected {expected_shape}"
+
+
+@pytest.mark.parametrize(
+    ["keypoints", "holes", "expected"],
+    [
+        # Basic case: single hole, some points inside/outside
+        (
+            np.array([[1, 1, 1], [5, 5, 5], [8, 8, 8]], dtype=np.float32),  # keypoints (XYZ)
+            np.array([[4, 4, 4, 6, 6, 6]], dtype=np.float32),               # holes (Z1,Y1,X1,Z2,Y2,X2)
+            np.array([[1, 1, 1], [8, 8, 8]], dtype=np.float32),            # expected (points outside hole)
+        ),
+        # Multiple holes
+        (
+            np.array([[1, 1, 1], [5, 5, 5], [8, 8, 8]], dtype=np.float32),
+            np.array([
+                [0, 0, 0, 2, 2, 2],    # hole covering [1,1,1]
+                [4, 4, 4, 6, 6, 6],    # hole covering [5,5,5]
+            ], dtype=np.float32),
+            np.array([[8, 8, 8]], dtype=np.float32),     # only last point survives
+        ),
+        # Edge cases: points exactly on boundaries
+        (
+            np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]], dtype=np.float32),
+            np.array([[1, 1, 1, 2, 2, 2]], dtype=np.float32),  # hole with points on boundaries
+            np.array([[2, 2, 2], [3, 3, 3]], dtype=np.float32),  # points on/outside boundaries remain
+        ),
+        # Empty arrays
+        (
+            np.array([], dtype=np.float32).reshape(0, 3),      # no keypoints
+            np.array([[1, 1, 1, 2, 2, 2]], dtype=np.float32),
+            np.array([], dtype=np.float32).reshape(0, 3),
+        ),
+        (
+            np.array([[1, 1, 1], [2, 2, 2]], dtype=np.float32),
+            np.array([], dtype=np.float32).reshape(0, 6),      # no holes
+            np.array([[1, 1, 1], [2, 2, 2]], dtype=np.float32),
+        ),
+        # Extra keypoint dimensions
+        (
+            np.array([[1, 1, 1, 0.9], [5, 5, 5, 0.8]], dtype=np.float32),
+            np.array([[4, 4, 4, 6, 6, 6]], dtype=np.float32),
+            np.array([[1, 1, 1, 0.9]], dtype=np.float32),
+        ),
+        # Overlapping holes
+        (
+            np.array([[1, 1, 1], [3, 3, 3], [5, 5, 5]], dtype=np.float32),
+            np.array([
+                [0, 0, 0, 4, 4, 4],
+                [2, 2, 2, 6, 6, 6],
+            ], dtype=np.float32),
+            np.array([], dtype=np.float32).reshape(0, 3),  # all points inside holes
+        ),
+    ],
+)
+def test_filter_keypoints_in_holes3d(keypoints, holes, expected):
+    result = f3d.filter_keypoints_in_holes3d(keypoints, holes)
+    np.testing.assert_array_equal(
+        result, expected,
+        err_msg=f"Failed with keypoints {keypoints} and holes {holes}"
+    )
+
+def test_filter_keypoints_in_holes3d_invalid_input():
+    """Test error handling for invalid input shapes."""
+    # Invalid keypoint dimensions
+    with pytest.raises(IndexError):
+        f3d.filter_keypoints_in_holes3d(
+            np.array([[1, 1]]),  # only 2D points
+            np.array([[0, 0, 0, 1, 1, 1]])
+        )
+
+    # Invalid hole dimensions
+    with pytest.raises(IndexError):
+        f3d.filter_keypoints_in_holes3d(
+            np.array([[1, 1, 1]]),
+            np.array([[0, 0, 0, 1]])  # incomplete hole specification
+        )
+
+def test_filter_keypoints_in_holes3d_random():
+    """Test with random data to ensure robustness."""
+    rng = np.random.default_rng(42)
+
+    # Generate random keypoints and holes
+    num_keypoints = 100
+    num_holes = 10
+    volume_size = 100
+
+    keypoints = rng.integers(0, volume_size, (num_keypoints, 3))
+    holes = np.array([
+        [
+            rng.integers(0, volume_size-10),  # z1
+            rng.integers(0, volume_size-10),  # y1
+            rng.integers(0, volume_size-10),  # x1
+            rng.integers(10, volume_size),    # z2
+            rng.integers(10, volume_size),    # y2
+            rng.integers(10, volume_size),    # x2
+        ]
+        for _ in range(num_holes)
+    ])
+
+    # Ensure z2>z1, y2>y1, x2>x1 for each hole
+    holes[:, 3:] = holes[:, :3] + holes[:, 3:]
+
+    # Test function
+    result = f3d.filter_keypoints_in_holes3d(keypoints, holes)
+
+    # Verify each surviving point is actually outside all holes
+    for point in result:
+        x, y, z = point
+        for z1, y1, x1, z2, y2, x2 in holes:
+            assert not (
+                z1 <= z < z2 and
+                y1 <= y < y2 and
+                x1 <= x < x2
+            ), f"Point {point} should be outside hole {[z1,y1,x1,z2,y2,x2]}"
+
+@pytest.mark.parametrize(
+    "factor",  # Remove the brackets - it's just the parameter name
+    [
+        1,
+        2,
+        3,
+        -1,
+        5,
+    ]
+)
+@pytest.mark.parametrize(
+    "axes",    # Remove the brackets - it's just the parameter name
+    [
+        (0, 1),  # rotate in HW plane
+        (0, 2),  # rotate in HD plane
+        (1, 2),  # rotate in WD plane
+    ]
+)
+def test_keypoints_rot90_matches_numpy(factor, axes):
+    """Test that keypoints_rot90 matches np.rot90 behavior."""
+    # Create volume with different dimensions to catch edge cases
+    volume = np.zeros((5, 6, 7), dtype=np.uint8)  # (H, W, D)
+
+    # Create test points (avoiding edges for clear results)
+    keypoints = np.array([
+        [1, 1, 1],  # XYZ coordinates
+        [1, 3, 1],
+        [3, 1, 3],
+        [2, 2, 2],
+    ], dtype=np.float32)
+
+    # Convert keypoints from XYZ to HWD ordering
+    keypoints_hwd = keypoints[:, [2, 1, 0]]  # XYZ -> HWD
+
+    # Mark points in volume
+    for h, w, d in keypoints_hwd:
+        volume[int(h), int(w), int(d)] = 1
+
+    # Rotate volume
+    rotated_volume = np.rot90(volume.copy(), factor, axes=axes)
+
+    # Rotate keypoints
+    rotated_keypoints_hwd = f3d.keypoints_rot90(keypoints_hwd, factor, axes, volume_shape=volume.shape)
+
+    # Convert back to XYZ for verification
+    rotated_keypoints = rotated_keypoints_hwd[:, [2, 1, 0]]  # HWD -> XYZ
+
+    # Verify each rotated keypoint matches a marked point in rotated volume
+    for x, y, z in rotated_keypoints:
+        assert rotated_volume[int(z), int(y), int(x)] == 1, (
+            f"Keypoint at ({x}, {y}, {z}) should match marked point in volume "
+            f"after rotation with factor={factor}, axes={axes}"
+        )
+
+
+@pytest.mark.parametrize("index", range(48))
+def test_transform_cube_keypoints_matches_transform_cube(index):
+    """Test that transform_cube_keypoints matches transform_cube behavior."""
+    # Create volume with different dimensions to catch edge cases
+    volume = np.zeros((5, 6, 7), dtype=np.uint8)  # (D, H, W)
+
+    # Create test points (avoiding edges for clear results)
+    keypoints = np.array([
+        [1, 1, 1],  # XYZ coordinates
+        [1, 3, 1],
+        [3, 1, 3],
+        [2, 2, 2],
+    ], dtype=np.float32)
+
+    # Mark points in volume (converting from XYZ to DHW)
+    for x, y, z in keypoints:
+        volume[int(z), int(y), int(x)] = 1
+
+    # Transform volume
+    transformed_volume = f3d.transform_cube(volume.copy(), index)
+
+    # Transform keypoints
+    transformed_keypoints = f3d.transform_cube_keypoints(keypoints.copy(), index, volume_shape=volume.shape)
+
+    # Verify each transformed keypoint matches a marked point in transformed volume
+    for x, y, z in transformed_keypoints:
+        assert transformed_volume[int(z), int(y), int(x)] == 1, (
+            f"Keypoint at ({x}, {y}, {z}) should match marked point in volume "
+            f"after transformation with index={index}"
+        )

--- a/tests/transforms3d/test_targets.py
+++ b/tests/transforms3d/test_targets.py
@@ -67,7 +67,7 @@ def get_targets_from_methods(cls):
 
     return targets
 
-TRASNFORM_3d_DUAL_TARGETS = {
+TRASNFORM_3D_TARGETS = {
 }
 
 str2target = {
@@ -87,7 +87,7 @@ str2target = {
 )
 def test_transform3d(augmentation_cls, params):
     aug = augmentation_cls(p=1, **params)
-    assert set(aug._targets) == set(TRASNFORM_3d_DUAL_TARGETS.get(augmentation_cls, {Targets.MASK3D, Targets.VOLUME, Targets.KEYPOINTS}))
+    assert set(aug._targets) == set(TRASNFORM_3D_TARGETS.get(augmentation_cls, {Targets.MASK3D, Targets.VOLUME, Targets.KEYPOINTS}))
     assert set(aug._targets) <= get_targets_from_methods(augmentation_cls)
 
     targets_from_docstring = {str2target[target] for target in extract_targets_from_docstring(augmentation_cls)}

--- a/tests/transforms3d/test_targets.py
+++ b/tests/transforms3d/test_targets.py
@@ -70,6 +70,8 @@ def get_targets_from_methods(cls):
 TRASNFORM_3d_DUAL_TARGETS = {
     A.PadIfNeeded3D: {Targets.MASK3D, Targets.VOLUME, Targets.KEYPOINTS},
     A.Pad3D: {Targets.MASK3D, Targets.VOLUME, Targets.KEYPOINTS},
+    A.RandomCrop3D: {Targets.MASK3D, Targets.VOLUME, Targets.KEYPOINTS},
+    A.CenterCrop3D: {Targets.MASK3D, Targets.VOLUME, Targets.KEYPOINTS},
 }
 
 str2target = {

--- a/tests/transforms3d/test_targets.py
+++ b/tests/transforms3d/test_targets.py
@@ -67,11 +67,15 @@ def get_targets_from_methods(cls):
 
     return targets
 
-TRASNFORM_3d_DUAL_TARGETS = {}
+TRASNFORM_3d_DUAL_TARGETS = {
+    A.PadIfNeeded3D: {Targets.MASK3D, Targets.VOLUME, Targets.KEYPOINTS},
+    A.Pad3D: {Targets.MASK3D, Targets.VOLUME, Targets.KEYPOINTS},
+}
 
 str2target = {
     "mask3d": Targets.MASK3D,
     "volume": Targets.VOLUME,
+    "keypoints": Targets.KEYPOINTS,
 }
 
 @pytest.mark.parametrize(

--- a/tests/transforms3d/test_targets.py
+++ b/tests/transforms3d/test_targets.py
@@ -68,10 +68,6 @@ def get_targets_from_methods(cls):
     return targets
 
 TRASNFORM_3d_DUAL_TARGETS = {
-    A.PadIfNeeded3D: {Targets.MASK3D, Targets.VOLUME, Targets.KEYPOINTS},
-    A.Pad3D: {Targets.MASK3D, Targets.VOLUME, Targets.KEYPOINTS},
-    A.RandomCrop3D: {Targets.MASK3D, Targets.VOLUME, Targets.KEYPOINTS},
-    A.CenterCrop3D: {Targets.MASK3D, Targets.VOLUME, Targets.KEYPOINTS},
 }
 
 str2target = {
@@ -91,7 +87,7 @@ str2target = {
 )
 def test_transform3d(augmentation_cls, params):
     aug = augmentation_cls(p=1, **params)
-    assert set(aug._targets) == set(TRASNFORM_3d_DUAL_TARGETS.get(augmentation_cls, {Targets.MASK3D, Targets.VOLUME}))
+    assert set(aug._targets) == set(TRASNFORM_3d_DUAL_TARGETS.get(augmentation_cls, {Targets.MASK3D, Targets.VOLUME, Targets.KEYPOINTS}))
     assert set(aug._targets) <= get_targets_from_methods(augmentation_cls)
 
     targets_from_docstring = {str2target[target] for target in extract_targets_from_docstring(augmentation_cls)}

--- a/tools/make_transforms_docs.py
+++ b/tools/make_transforms_docs.py
@@ -240,8 +240,8 @@ def main() -> None:
 
     transforms_3d_table = make_transforms_targets_table(
         transforms_3d,
-        header=["Transform"] + [target.value for target in [Targets.VOLUME, Targets.MASK3D]],
-        targets_to_check=[Targets.VOLUME, Targets.MASK3D]
+        header=["Transform"] + [target.value for target in [Targets.VOLUME, Targets.MASK3D, Targets.KEYPOINTS]],
+        targets_to_check=[Targets.VOLUME, Targets.MASK3D, Targets.KEYPOINTS]
     )
 
     if command == "make":


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Added keypoint support to 3D augmentations such as Pad3D, PadIfNeeded3D, CenterCrop3D, RandomCrop3D, CoarseDropout3D, and CubicSymmetry. Keypoints are now correctly transformed along with volumes and masks, ensuring consistency after augmentation.  Transforms now handle keypoints outside the volume boundaries correctly, filtering them out as needed.  Improved handling of empty keypoint arrays and edge cases like points exactly on volume boundaries.  Added tests to verify keypoint transformations match expected behavior and volume transformations.