### PR TITLE
Added ConstrainedCoarseDropout class

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here is an example of how you can apply some [pixel-level](#pixel-level-transfor
 - **Rich Augmentation Library**: [70+ high-quality augmentations](https://albumentations.ai/docs/api_reference/transforms/) to enhance your training data.
 - **Fast**: Consistently benchmarked as the [fastest augmentation library](https://albumentations.ai/docs/benchmarks/), with optimizations for production use.
 - **Deep Learning Integration**: Works with [PyTorch](https://pytorch.org/), [TensorFlow](https://www.tensorflow.org/), and other frameworks. Part of the [PyTorch ecosystem](https://pytorch.org/ecosystem/).
-- **Created by Experts**: Built by [developers with deep experience in computer vision and machine learning competitions](https://albumentations.ai/docs/#authors).
+- **Created by Experts**: Built by [developers with deep experience in computer vision and machine learning competitions](#authors).
 
 ## Community-Driven Project, Supported By
 
@@ -142,11 +142,11 @@ transformed_image = transformed["image"]
 
 ### I am new to image augmentation
 
-Please start with the [introduction articles](https://albumentations.ai/docs/#introduction-to-image-augmentation) about why image augmentation is important and how it helps to build better models.
+Please start with the [introduction articles](https://albumentations.ai/docs/#learning-path) about why image augmentation is important and how it helps to build better models.
 
 ### I want to use Albumentations for the specific task such as classification or segmentation
 
-If you want to use Albumentations for a specific task such as classification, segmentation, or object detection, refer to the [set of articles](https://albumentations.ai/docs/#getting-started-with-albumentations) that has an in-depth description of this task. We also have a [list of examples](https://albumentations.ai/docs/examples/) on applying Albumentations for different use cases.
+If you want to use Albumentations for a specific task such as classification, segmentation, or object detection, refer to the [set of articles](https://albumentations.ai/docs/#quick-start-guide) that has an in-depth description of this task. We also have a [list of examples](https://albumentations.ai/docs/examples/) on applying Albumentations for different use cases.
 
 ### I want to know how to use Albumentations with deep learning frameworks
 
@@ -302,6 +302,24 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [Transpose](https://explore.albumentations.ai/transform/Transpose)                               | ✓     | ✓    | ✓      | ✓         | ✓      | ✓      |
 | [VerticalFlip](https://explore.albumentations.ai/transform/VerticalFlip)                         | ✓     | ✓    | ✓      | ✓         | ✓      | ✓      |
 | [XYMasking](https://explore.albumentations.ai/transform/XYMasking)                               | ✓     | ✓    | ✓      | ✓         | ✓      | ✓      |
+
+### 3D transforms
+
+3D transforms operate on volumetric data and can modify both the input volume and associated 3D mask.
+
+Where:
+
+- Volume: 3D array of shape (D, H, W) or (D, H, W, C) where D is depth, H is height, W is width, and C is number of channels (optional)
+- Mask3D: Binary or multi-class 3D mask of shape (D, H, W) where each slice represents segmentation for the corresponding volume slice
+
+| Transform                                                                      | Volume | Mask3D | Keypoints |
+| ------------------------------------------------------------------------------ | :----: | :----: | :-------: |
+| [CenterCrop3D](https://explore.albumentations.ai/transform/CenterCrop3D)       | ✓      | ✓      | ✓         |
+| [CoarseDropout3D](https://explore.albumentations.ai/transform/CoarseDropout3D) | ✓      | ✓      | ✓         |
+| [CubicSymmetry](https://explore.albumentations.ai/transform/CubicSymmetry)     | ✓      | ✓      | ✓         |
+| [Pad3D](https://explore.albumentations.ai/transform/Pad3D)                     | ✓      | ✓      | ✓         |
+| [PadIfNeeded3D](https://explore.albumentations.ai/transform/PadIfNeeded3D)     | ✓      | ✓      | ✓         |
+| [RandomCrop3D](https://explore.albumentations.ai/transform/RandomCrop3D)       | ✓      | ✓      | ✓         |
 
 ## A few more examples of **augmentations**
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [BBoxSafeRandomCrop](https://explore.albumentations.ai/transform/BBoxSafeRandomCrop)             | ✓     | ✓    | ✓      | ✓         | ✓      | ✓      |
 | [CenterCrop](https://explore.albumentations.ai/transform/CenterCrop)                             | ✓     | ✓    | ✓      | ✓         | ✓      | ✓      |
 | [CoarseDropout](https://explore.albumentations.ai/transform/CoarseDropout)                       | ✓     | ✓    | ✓      | ✓         | ✓      | ✓      |
+| [ConstrainedCoarseDropout](https://explore.albumentations.ai/transform/ConstrainedCoarseDropout) | ✓     | ✓    |        |           |        |        |
 | [Crop](https://explore.albumentations.ai/transform/Crop)                                         | ✓     | ✓    | ✓      | ✓         | ✓      | ✓      |
 | [CropAndPad](https://explore.albumentations.ai/transform/CropAndPad)                             | ✓     | ✓    | ✓      | ✓         | ✓      | ✓      |
 | [CropNonEmptyMaskIfExists](https://explore.albumentations.ai/transform/CropNonEmptyMaskIfExists) | ✓     | ✓    | ✓      | ✓         | ✓      | ✓      |
@@ -301,24 +302,6 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [Transpose](https://explore.albumentations.ai/transform/Transpose)                               | ✓     | ✓    | ✓      | ✓         | ✓      | ✓      |
 | [VerticalFlip](https://explore.albumentations.ai/transform/VerticalFlip)                         | ✓     | ✓    | ✓      | ✓         | ✓      | ✓      |
 | [XYMasking](https://explore.albumentations.ai/transform/XYMasking)                               | ✓     | ✓    | ✓      | ✓         | ✓      | ✓      |
-
-### 3D transforms
-
-3D transforms operate on volumetric data and can modify both the input volume and associated 3D mask.
-
-Where:
-
-- Volume: 3D array of shape (D, H, W) or (D, H, W, C) where D is depth, H is height, W is width, and C is number of channels (optional)
-- Mask3D: Binary or multi-class 3D mask of shape (D, H, W) where each slice represents segmentation for the corresponding volume slice
-
-| Transform                                                                      | Volume | Mask3D | Keypoints |
-| ------------------------------------------------------------------------------ | :----: | :----: | :-------: |
-| [CenterCrop3D](https://explore.albumentations.ai/transform/CenterCrop3D)       | ✓      | ✓      | ✓         |
-| [CoarseDropout3D](https://explore.albumentations.ai/transform/CoarseDropout3D) | ✓      | ✓      | ✓         |
-| [CubicSymmetry](https://explore.albumentations.ai/transform/CubicSymmetry)     | ✓      | ✓      | ✓         |
-| [Pad3D](https://explore.albumentations.ai/transform/Pad3D)                     | ✓      | ✓      | ✓         |
-| [PadIfNeeded3D](https://explore.albumentations.ai/transform/PadIfNeeded3D)     | ✓      | ✓      | ✓         |
-| [RandomCrop3D](https://explore.albumentations.ai/transform/RandomCrop3D)       | ✓      | ✓      | ✓         |
 
 ## A few more examples of **augmentations**
 

--- a/albumentations/augmentations/dropout/transforms.py
+++ b/albumentations/augmentations/dropout/transforms.py
@@ -13,7 +13,7 @@ from albumentations.augmentations.dropout.functional import (
 from albumentations.core.bbox_utils import BboxProcessor, denormalize_bboxes, normalize_bboxes
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
-from albumentations.core.types import ALL_TARGETS, ColorType, DropoutFillValue
+from albumentations.core.types import ALL_TARGETS, ColorType, DropoutFillValue, Targets
 
 
 class BaseDropout(DualTransform):
@@ -36,7 +36,7 @@ class BaseDropout(DualTransform):
         uint8, float32
     """
 
-    _targets = ALL_TARGETS
+    _targets: tuple[Targets, ...] | Targets = ALL_TARGETS
 
     class InitSchema(BaseTransformInitSchema):
         fill: DropoutFillValue

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -36,6 +36,23 @@ AUGMENTATION_CLS_PARAMS = [
         },
     ],
     [
+        A.ConstrainedCoarseDropout,
+        {
+            "num_holes_range": (2, 5),
+            "hole_height_range": (0.1, 0.2),
+            "hole_width_range": (0.2, 0.3),
+            "class_indices" : [2,3]
+        },
+    ],
+    [
+        A.ConstrainedCoarseDropout,
+        {
+            "num_holes_range": (2, 5),
+            "hole_height_range": (0.1, 0.2),
+            "hole_width_range": (0.2, 0.3)
+        },
+    ],
+    [
         A.RandomSnow,
         {"snow_point_range": (0.2, 0.4), "brightness_coeff": 4},
     ],

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -334,7 +334,7 @@ def test_augmentations_wont_change_float_input(augmentation_cls, params):
             "text": "May the transformations be ever in your favor!",
             "bbox": (0.1, 0.1, 0.9, 0.2),
         }
-    elif augmentation_cls == A.MaskDropout:
+    elif augmentation_cls == A.MaskDropout or augmentation_cls == A.ConstrainedCoarseDropout:
         mask = np.zeros_like(image)[:, :, 0]
         mask[:20, :20] = 1
         data["mask"] = mask
@@ -492,6 +492,7 @@ def test_augmentations_wont_change_shape_grayscale(augmentation_cls, params, sha
             A.PadIfNeeded,
             A.RandomScale,
             A.RandomCropFromBorders,
+            A.ConstrainedCoarseDropout
         },
     ),
 )
@@ -644,7 +645,7 @@ def test_multichannel_image_augmentations(augmentation_cls, params):
             "text": "May the transformations be ever in your favor!",
             "bbox": (0.1, 0.1, 0.9, 0.2),
         }
-    elif augmentation_cls == A.MaskDropout:
+    elif augmentation_cls == A.MaskDropout or augmentation_cls == A.ConstrainedCoarseDropout:
         mask = np.zeros_like(image)[:, :, 0]
         mask[:20, :20] = 1
         data["mask"] = mask
@@ -735,7 +736,7 @@ def test_float_multichannel_image_augmentations(augmentation_cls, params):
             "text": "May the transformations be ever in your favor!",
             "bbox": (0.1, 0.1, 0.9, 0.2),
         }
-    elif augmentation_cls == A.MaskDropout:
+    elif augmentation_cls == A.MaskDropout or augmentation_cls == A.ConstrainedCoarseDropout:
         mask = np.zeros_like(image)[:, :, 0]
         mask[:20, :20] = 1
         data["mask"] = mask
@@ -823,7 +824,7 @@ def test_multichannel_image_augmentations_diff_channels(augmentation_cls, params
             "text": "May the transformations be ever in your favor!",
             "bbox": (0.1, 0.1, 0.9, 0.2),
         }
-    elif augmentation_cls == A.MaskDropout:
+    elif augmentation_cls == A.MaskDropout or augmentation_cls == A.ConstrainedCoarseDropout:
         mask = np.zeros_like(image)[:, :, 0]
         mask[:20, :20] = 1
         data["mask"] = mask
@@ -910,7 +911,7 @@ def test_float_multichannel_image_augmentations_diff_channels(augmentation_cls, 
             "text": "May the transformations be ever in your favor!",
             "bbox": (0.1, 0.1, 0.9, 0.2),
         }
-    elif augmentation_cls == A.MaskDropout:
+    elif augmentation_cls == A.MaskDropout or augmentation_cls == A.ConstrainedCoarseDropout:
         mask = np.zeros_like(image)[:, :, 0]
         mask[:20, :20] = 1
         data["mask"] = mask
@@ -1129,7 +1130,7 @@ def test_augmentations_match_uint8_float32(augmentation_cls, params):
     transform = A.Compose([augmentation_cls(p=1, **params)], seed=42)
 
     data = {"image": image_uint8}
-    if augmentation_cls == A.MaskDropout:
+    if augmentation_cls == A.MaskDropout or augmentation_cls == A.ConstrainedCoarseDropout:
         mask = np.zeros_like(image_uint8)[:, :, 0]
         mask[:20, :20] = 1
         data["mask"] = mask

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -741,7 +741,7 @@ def test_contiguous_output_dual(augmentation_cls, params):
     transform = augmentation_cls(p=1, **params)
 
     data = {"image": image, "mask": mask}
-    if augmentation_cls == A.MaskDropout:
+    if augmentation_cls == A.MaskDropout or augmentation_cls == A.ConstrainedCoarseDropout:
         mask = np.zeros_like(image)[:, :, 0]
         mask[:20, :20] = 1
         data["mask"] = mask
@@ -1118,7 +1118,8 @@ def test_images_as_target(augmentation_cls, params, as_array, shape):
     if len(shape) == 2:
         if augmentation_cls in {A.ChannelDropout, A.Spatter, A.ISONoise,
                                 A.RandomGravel, A.ChromaticAberration, A.PlanckianJitter, A.PixelDistributionAdaptation,
-                                A.MaskDropout, A.ChannelShuffle, A.ToRGB, A.RandomSunFlare, A.RandomFog, A.RandomSnow, A.RandomRain}:
+                                A.MaskDropout, A.ConstrainedCoarseDropout, A.ChannelShuffle, A.ToRGB, A.RandomSunFlare,
+                                A.RandomFog, A.RandomSnow, A.RandomRain}:
             pytest.skip("ChannelDropout is not applicable to grayscale images")
 
 
@@ -1134,7 +1135,7 @@ def test_images_as_target(augmentation_cls, params, as_array, shape):
         # Original list format
         data = {"images": [image, image2]}
 
-    if augmentation_cls == A.MaskDropout:
+    if augmentation_cls == A.MaskDropout or augmentation_cls == A.ConstrainedCoarseDropout:
         mask = np.zeros_like(image)[:, :, 0]
         mask[:20, :20] = 1
         data["mask"] = mask
@@ -1272,7 +1273,7 @@ def test_non_contiguous_input_with_compose(augmentation_cls, params, bboxes):
             # requires float image
             image = (image / 255).astype(np.float32)
             assert not image.flags["C_CONTIGUOUS"]
-        elif augmentation_cls == A.MaskDropout:
+        elif augmentation_cls == A.MaskDropout or augmentation_cls == A.ConstrainedCoarseDropout:
             # requires single channel mask
             mask = mask[:, :, 0]
 
@@ -1410,6 +1411,7 @@ def test_masks_as_target(augmentation_cls, params, masks):
             A.RandomCropNearBBox,
             A.GridDropout,
             A.CoarseDropout,
+            A.ConstrainedCoarseDropout,
             A.PadIfNeeded,
         },
     ),

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -118,7 +118,6 @@ def test_image_only(augmentation_cls, params):
 )
 def test_dual(augmentation_cls, params):
     aug = augmentation_cls(p=1, **params)
-    print(set(aug._targets),set(DUAL_TARGETS.get(augmentation_cls, ALL_TARGETS)))
     assert set(aug._targets) == set(DUAL_TARGETS.get(augmentation_cls, ALL_TARGETS))
     assert set(aug._targets) <= get_targets_from_methods(augmentation_cls)
 

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -118,6 +118,7 @@ def test_image_only(augmentation_cls, params):
 )
 def test_dual(augmentation_cls, params):
     aug = augmentation_cls(p=1, **params)
+    print(set(aug._targets),set(DUAL_TARGETS.get(augmentation_cls, ALL_TARGETS)))
     assert set(aug._targets) == set(DUAL_TARGETS.get(augmentation_cls, ALL_TARGETS))
     assert set(aug._targets) <= get_targets_from_methods(augmentation_cls)
 

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -48,6 +48,7 @@ def extract_targets_from_docstring(cls):
 
 DUAL_TARGETS = {
     A.OverlayElements: (Targets.IMAGE, Targets.MASK),
+    A.ConstrainedCoarseDropout : (Targets.IMAGE, Targets.MASK)
 }
 
 


### PR DESCRIPTION
Added a new transform - Constrained coarse droput, which is a modification of the coarse dropout transform. 
In constrained coarse dropout, rectangular regions are only dropped out from the foreground objects belonging to the class specified by the user.

## Summary by Sourcery

Introduce the ConstrainedCoarseDropout transform. This transform drops out rectangular regions within user-specified foreground object classes, enhancing the CoarseDropout functionality.

New Features:
- Added a new transform called `ConstrainedCoarseDropout`. This transform allows for dropping out rectangular regions exclusively from foreground objects belonging to specific user-defined classes.

Tests:
- Added unit tests for the `ConstrainedCoarseDropout` transform.