### PR TITLE
Delets `always_apply` from the code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         files: setup.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.5
+    rev: v0.8.6
     hooks:
       # Run the linter.
       - id: ruff

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -104,9 +104,8 @@ class Blur(ImageOnlyTransform):
         self,
         blur_limit: ScaleIntType = (3, 7),
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.blur_limit = cast(tuple[int, int], blur_limit)
 
     def apply(self, img: np.ndarray, kernel: int, **params: Any) -> np.ndarray:
@@ -254,7 +253,6 @@ class MotionBlur(Blur):
         angle_range: tuple[float, float] = (0, 360),
         direction_range: tuple[float, float] = (-1.0, 1.0),
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
         super().__init__(blur_limit=blur_limit, p=p)
         self.allow_shifted = allow_shifted
@@ -351,9 +349,8 @@ class MedianBlur(Blur):
         self,
         blur_limit: ScaleIntType = 7,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(blur_limit=blur_limit, p=p, always_apply=always_apply)
+        super().__init__(blur_limit=blur_limit, p=p)
 
     def apply(self, img: np.ndarray, kernel: int, **params: Any) -> np.ndarray:
         return fblur.median_blur(img, kernel)
@@ -448,10 +445,9 @@ class GaussianBlur(ImageOnlyTransform):
         self,
         blur_limit: ScaleIntType = (3, 7),
         sigma_limit: ScaleFloatType = 0,
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p, always_apply)
+        super().__init__(p=p)
         self.blur_limit = cast(tuple[int, int], blur_limit)
         self.sigma_limit = cast(tuple[float, float], sigma_limit)
 
@@ -551,10 +547,9 @@ class GlassBlur(ImageOnlyTransform):
         max_delta: int = 4,
         iterations: int = 2,
         mode: Literal["fast", "exact"] = "fast",
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.sigma = sigma
         self.max_delta = max_delta
         self.iterations = iterations
@@ -720,10 +715,9 @@ class AdvancedBlur(ImageOnlyTransform):
         rotate_limit: ScaleIntType = (-90, 90),
         beta_limit: ScaleFloatType = (0.5, 8.0),
         noise_limit: ScaleFloatType = (0.9, 1.1),
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
         if sigmaX_limit is not None:
             warnings.warn(
@@ -848,7 +842,7 @@ class Defocus(ImageOnlyTransform):
         >>> import numpy as np
         >>> import albumentations as A
         >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-        >>> transform = A.Defocus(radius=(4, 8), alias_blur=(0.2, 0.4), always_apply=True)
+        >>> transform = A.Defocus(radius=(4, 8), alias_blur=(0.2, 0.4))
         >>> result = transform(image=image)
         >>> defocused_image = result['image']
 
@@ -865,10 +859,9 @@ class Defocus(ImageOnlyTransform):
         self,
         radius: ScaleIntType = (3, 10),
         alias_blur: ScaleFloatType = (0.1, 0.5),
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.radius = cast(tuple[int, int], radius)
         self.alias_blur = cast(tuple[float, float], alias_blur)
 
@@ -921,10 +914,9 @@ class ZoomBlur(ImageOnlyTransform):
         self,
         max_factor: ScaleFloatType = (1, 1.31),
         step_factor: ScaleFloatType = (0.01, 0.03),
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.max_factor = cast(tuple[float, float], max_factor)
         self.step_factor = cast(tuple[float, float], step_factor)
 

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -116,7 +116,6 @@ class BaseCropAndPad(BaseCrop):
         fill_mask: ColorType,
         pad_position: PositionType,
         p: float,
-        always_apply: bool | None = None,
     ):
         super().__init__(p=p)
         self.pad_if_needed = pad_if_needed
@@ -328,7 +327,6 @@ class RandomCrop(BaseCropAndPad):
         fill: ColorType = 0.0,
         fill_mask: ColorType = 0.0,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
         super().__init__(
             pad_if_needed=pad_if_needed,
@@ -463,7 +461,6 @@ class CenterCrop(BaseCropAndPad):
         fill: ColorType = 0.0,
         fill_mask: ColorType = 0.0,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
         super().__init__(
             pad_if_needed=pad_if_needed,
@@ -608,7 +605,6 @@ class Crop(BaseCropAndPad):
         fill: ColorType = 0,
         fill_mask: ColorType = 0,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
         super().__init__(
             pad_if_needed=pad_if_needed,
@@ -736,7 +732,6 @@ class CropNonEmptyMaskIfExists(BaseCrop):
         ignore_values: list[int] | None = None,
         ignore_channels: list[int] | None = None,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
         super().__init__(p=p)
 
@@ -823,10 +818,9 @@ class _BaseRandomSizedCrop(DualTransform):
         size: tuple[int, int],
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
-        always_apply: bool | None = None,
         p: float = 1.0,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.size = size
         self.interpolation = interpolation
         self.mask_interpolation = mask_interpolation
@@ -984,7 +978,6 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
         super().__init__(
             size=cast(tuple[int, int], size),
@@ -1129,7 +1122,6 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
         super().__init__(
             size=cast(tuple[int, int], size),
@@ -1235,7 +1227,6 @@ class RandomCropNearBBox(BaseCrop):
         max_part_shift: ScaleFloatType = (0, 0.3),
         cropping_bbox_key: str = "cropping_bbox",
         cropping_box_key: str | None = None,  # Deprecated
-        always_apply: bool | None = None,
         p: float = 1.0,
     ):
         super().__init__(p=p)
@@ -1355,7 +1346,7 @@ class BBoxSafeRandomCrop(BaseCrop):
             le=1.0,
         )
 
-    def __init__(self, erosion_rate: float = 0.0, p: float = 1.0, always_apply: bool | None = None):
+    def __init__(self, erosion_rate: float = 0.0, p: float = 1.0):
         super().__init__(p=p)
         self.erosion_rate = erosion_rate
 
@@ -1493,7 +1484,6 @@ class RandomSizedBBoxSafeCrop(BBoxSafeRandomCrop):
         erosion_rate: float = 0.0,
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
-        always_apply: bool | None = None,
         p: float = 1.0,
     ):
         super().__init__(erosion_rate=erosion_rate, p=p)
@@ -1671,9 +1661,8 @@ class CropAndPad(DualTransform):
         fill: ColorType = 0,
         fill_mask: ColorType = 0,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
         self.px = px
         self.percent = percent
@@ -1987,7 +1976,6 @@ class RandomCropFromBorders(BaseCrop):
         crop_right: float = 0.1,
         crop_top: float = 0.1,
         crop_bottom: float = 0.1,
-        always_apply: bool | None = None,
         p: float = 1.0,
     ):
         super().__init__(p=p)
@@ -2089,9 +2077,8 @@ class AtLeastOneBBoxRandomCrop(BaseCrop):
         width: int,
         erosion_factor: float = 0.0,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.height = height
         self.width = width
         self.erosion_factor = erosion_factor

--- a/albumentations/augmentations/domain_adaptation/transforms.py
+++ b/albumentations/augmentations/domain_adaptation/transforms.py
@@ -103,9 +103,8 @@ class HistogramMatching(ImageOnlyTransform):
         blend_ratio: tuple[float, float] = (0.5, 1.0),
         read_fn: Callable[[Any], np.ndarray] = read_rgb_image,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.reference_images = reference_images
         self.read_fn = read_fn
         self.blend_ratio = blend_ratio
@@ -203,9 +202,8 @@ class FDA(ImageOnlyTransform):
         beta_limit: ScaleFloatType = (0, 0.1),
         read_fn: Callable[[Any], np.ndarray] = read_rgb_image,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.reference_images = reference_images
         self.read_fn = read_fn
         self.beta_limit = cast(tuple[float, float], beta_limit)
@@ -320,9 +318,8 @@ class PixelDistributionAdaptation(ImageOnlyTransform):
         read_fn: Callable[[Any], np.ndarray] = read_rgb_image,
         transform_type: Literal["pca", "standard", "minmax"] = "pca",
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.reference_images = reference_images
         self.read_fn = read_fn
         self.blend_ratio = blend_ratio
@@ -469,9 +466,8 @@ class TemplateTransform(ImageOnlyTransform):
         template_transform: Compose | BasicTransform | None = None,
         name: str | None = None,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.templates = templates
         self.img_weight = cast(tuple[float, float], img_weight)
         self.template_transform = template_transform

--- a/albumentations/augmentations/dropout/channel_dropout.py
+++ b/albumentations/augmentations/dropout/channel_dropout.py
@@ -96,9 +96,8 @@ class ChannelDropout(ImageOnlyTransform):
         fill_value: float | None = None,
         fill: float = 0,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
         self.channel_drop_range = channel_drop_range
         self.fill = fill

--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -180,7 +180,6 @@ class CoarseDropout(BaseDropout):
         fill: DropoutFillValue = 0,
         fill_mask: ColorType | None = None,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
         super().__init__(fill=fill, fill_mask=fill_mask, p=p)
         self.num_holes_range = num_holes_range
@@ -320,7 +319,6 @@ class Erasing(BaseDropout):
         ratio: tuple[float, float] = (0.3, 3.3),
         fill: DropoutFillValue = 0,
         fill_mask: ColorType | None = None,
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
         super().__init__(fill=fill, fill_mask=fill_mask, p=p)
@@ -539,7 +537,6 @@ class ConstrainedCoarseDropout(BaseDropout):
         p: float = 0.5,
         mask_indices: list[int] | None = None,
         bbox_labels: list[str | int | float] | None = None,
-        always_apply: bool | None = None,
     ):
         super().__init__(fill=fill, fill_mask=fill_mask, p=p)
         self.num_holes_range = num_holes_range

--- a/albumentations/augmentations/dropout/grid_dropout.py
+++ b/albumentations/augmentations/dropout/grid_dropout.py
@@ -163,7 +163,6 @@ class GridDropout(BaseDropout):
         fill: DropoutFillValue = 0,
         fill_mask: ColorType | None = None,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
         super().__init__(fill=fill, fill_mask=fill_mask, p=p)
         self.ratio = ratio

--- a/albumentations/augmentations/dropout/mask_dropout.py
+++ b/albumentations/augmentations/dropout/mask_dropout.py
@@ -88,9 +88,8 @@ class MaskDropout(DualTransform):
         fill: float | Literal["inpaint"] = 0,
         fill_mask: float = 0,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.max_objects = cast(tuple[int, int], max_objects)
         self.fill = fill  # type: ignore[assignment]
         self.fill_mask = fill_mask

--- a/albumentations/augmentations/dropout/transforms.py
+++ b/albumentations/augmentations/dropout/transforms.py
@@ -47,9 +47,8 @@ class BaseDropout(DualTransform):
         fill: DropoutFillValue,
         fill_mask: ColorType | None,
         p: float,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.fill = fill
         self.fill_mask = fill_mask
 

--- a/albumentations/augmentations/dropout/xy_masking.py
+++ b/albumentations/augmentations/dropout/xy_masking.py
@@ -103,7 +103,6 @@ class XYMasking(BaseDropout):
         fill: DropoutFillValue = 0,
         fill_mask: ColorType | None = None,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
         super().__init__(p=p, fill=fill, fill_mask=fill_mask)
         self.num_masks_x = cast(tuple[int, int], num_masks_x)

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -82,9 +82,8 @@ class RandomScale(DualTransform):
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.scale_limit = cast(tuple[float, float], scale_limit)
         self.interpolation = interpolation
         self.mask_interpolation = mask_interpolation
@@ -154,9 +153,8 @@ class MaxSizeTransform(DualTransform):
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
         p: float = 1,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.max_size = max_size
         self.max_size_hw = max_size_hw
         self.interpolation = interpolation
@@ -464,9 +462,8 @@ class Resize(DualTransform):
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
         p: float = 1,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.height = height
         self.width = width
         self.interpolation = interpolation

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -183,9 +183,8 @@ class Rotate(DualTransform):
         fill: ColorType = 0,
         fill_mask: ColorType = 0,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.limit = cast(tuple[float, float], limit)
         self.interpolation = interpolation
         self.mask_interpolation = mask_interpolation
@@ -467,7 +466,6 @@ class SafeRotate(Affine):
         fill: ColorType = 0,
         fill_mask: ColorType = 0,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
         super().__init__(
             rotate=limit,

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -125,9 +125,8 @@ class BaseDistortion(DualTransform):
         interpolation: int,
         mask_interpolation: int,
         p: float,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.interpolation = interpolation
         self.mask_interpolation = mask_interpolation
 
@@ -276,7 +275,6 @@ class ElasticTransform(BaseDistortion):
         mask_interpolation: int = cv2.INTER_NEAREST,
         noise_distribution: Literal["gaussian", "uniform"] = "gaussian",
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
         super().__init__(
             interpolation=interpolation,
@@ -375,7 +373,7 @@ class Perspective(DualTransform):
         >>> import albumentations as A
         >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
         >>> transform = A.Compose([
-        ...     A.Perspective(scale=(0.05, 0.1), keep_size=True, always_apply=False, p=0.5),
+        ...     A.Perspective(scale=(0.05, 0.1), keep_size=True, p=0.5),
         ... ])
         >>> result = transform(image=image)
         >>> transformed_image = result['image']
@@ -423,9 +421,8 @@ class Perspective(DualTransform):
         fill: ColorType = 0,
         fill_mask: ColorType = 0,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p, always_apply=always_apply)
+        super().__init__(p)
         self.scale = cast(tuple[float, float], scale)
         self.keep_size = keep_size
         self.border_mode = border_mode
@@ -778,9 +775,8 @@ class Affine(DualTransform):
         fill: ColorType = 0,
         fill_mask: ColorType = 0,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
         self.interpolation = interpolation
         self.mask_interpolation = mask_interpolation
@@ -1113,7 +1109,6 @@ class ShiftScaleRotate(Affine):
         fill: ColorType = 0,
         fill_mask: ColorType = 0,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
         shift_limit_x = cast(tuple[float, float], shift_limit_x)
         shift_limit_y = cast(tuple[float, float], shift_limit_y)
@@ -1130,7 +1125,6 @@ class ShiftScaleRotate(Affine):
             fit_output=False,
             keep_ratio=False,
             rotate_method=rotate_method,
-            always_apply=always_apply,
             p=p,
         )
         warn(
@@ -1262,7 +1256,6 @@ class PiecewiseAffine(BaseDistortion):
         mode: Literal["constant", "edge", "symmetric", "reflect", "wrap"] | None = None,
         absolute_scale: bool = False,
         p: float = 0.5,
-        always_apply: bool | None = None,
         keypoints_threshold: float = 0.01,
     ):
         super().__init__(
@@ -1555,7 +1548,6 @@ class OpticalDistortion(BaseDistortion):
         mask_interpolation: int = cv2.INTER_NEAREST,
         mode: Literal["camera", "fisheye"] = "camera",
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
         super().__init__(
             interpolation=interpolation,
@@ -1688,7 +1680,6 @@ class GridDistortion(BaseDistortion):
         normalized: bool = True,
         mask_interpolation: int = cv2.INTER_NEAREST,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
         super().__init__(
             interpolation=interpolation,
@@ -1794,9 +1785,8 @@ class D4(DualTransform):
     def __init__(
         self,
         p: float = 1,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
     def apply(
         self,
@@ -1883,9 +1873,8 @@ class GridElasticDeform(DualTransform):
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.num_grid_xy = num_grid_xy
         self.magnitude = magnitude
         self.interpolation = interpolation
@@ -2054,9 +2043,8 @@ class RandomGridShuffle(DualTransform):
         self,
         grid: tuple[int, int] = (3, 3),
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.grid = grid
 
     def apply(
@@ -2161,9 +2149,8 @@ class Pad(DualTransform):
         fill_mask: ColorType = 0,
         border_mode: BorderModeType = cv2.BORDER_CONSTANT,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.padding = padding
         self.fill = fill
         self.fill_mask = fill_mask
@@ -2390,7 +2377,6 @@ class PadIfNeeded(Pad):
         fill: ColorType = 0,
         fill_mask: ColorType = 0,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
         # Initialize with dummy padding that will be calculated later
         super().__init__(
@@ -2550,7 +2536,6 @@ class ThinPlateSpline(BaseDistortion):
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
         super().__init__(
             interpolation=interpolation,

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -55,9 +55,8 @@ class OverlayElements(DualTransform):
         self,
         metadata_key: str = "overlay_metadata",
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.metadata_key = metadata_key
 
     @property

--- a/albumentations/augmentations/spectrogram/transform.py
+++ b/albumentations/augmentations/spectrogram/transform.py
@@ -58,7 +58,6 @@ class TimeReverse(HorizontalFlip):
     def __init__(
         self,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
         warn(
             "TimeReverse is an alias for HorizontalFlip transform. "
@@ -121,7 +120,6 @@ class TimeMasking(XYMasking):
         self,
         time_mask_param: int = 40,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
         warn(
             "TimeMasking is a specialized version of XYMasking. "
@@ -196,7 +194,6 @@ class FrequencyMasking(XYMasking):
         self,
         freq_mask_param: int = 30,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
         warn(
             "FrequencyMasking is a specialized version of XYMasking. "

--- a/albumentations/augmentations/text/transforms.py
+++ b/albumentations/augmentations/text/transforms.py
@@ -95,10 +95,9 @@ class TextImage(ImageOnlyTransform):
         font_color: list[ColorType | str] | ColorType | str = "black",
         clear_bg: bool = False,
         metadata_key: str = "textimage_metadata",
-        always_apply: bool | None = None,
         p: float = 0.5,
     ) -> None:
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.metadata_key = metadata_key
         self.font_path = font_path
         self.fraction_range = fraction_range

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -244,10 +244,9 @@ class Normalize(ImageOnlyTransform):
             "min_max",
             "min_max_per_channel",
         ] = "standard",
-        always_apply: bool | None = None,
         p: float = 1.0,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.mean = mean
         self.mean_np = np.array(mean, dtype=np.float32) * max_pixel_value
         self.std = std
@@ -392,10 +391,9 @@ class ImageCompression(ImageOnlyTransform):
         quality_upper: int | None = None,
         compression_type: Literal["jpeg", "webp"] = "jpeg",
         quality_range: tuple[int, int] = (99, 100),
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.quality_range = quality_range
         self.compression_type = compression_type
 
@@ -556,10 +554,9 @@ class RandomSnow(ImageOnlyTransform):
         brightness_coeff: float = 2.5,
         snow_point_range: tuple[float, float] = (0.1, 0.3),
         method: Literal["bleach", "texture"] = "bleach",
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
         self.snow_point_range = snow_point_range
         self.brightness_coeff = brightness_coeff
@@ -701,10 +698,9 @@ class RandomGravel(ImageOnlyTransform):
         self,
         gravel_roi: tuple[float, float, float, float] = (0.1, 0.4, 0.9, 0.9),
         number_of_patches: int = 2,
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p, always_apply)
+        super().__init__(p=p)
         self.gravel_roi = gravel_roi
         self.number_of_patches = number_of_patches
 
@@ -905,10 +901,9 @@ class RandomRain(ImageOnlyTransform):
         blur_value: int = 7,
         brightness_coefficient: float = 0.7,
         rain_type: RainMode = "default",
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.slant_range = slant_range
         self.drop_length = drop_length
         self.drop_width = drop_width
@@ -1094,10 +1089,9 @@ class RandomFog(ImageOnlyTransform):
         fog_coef_upper: float | None = None,
         alpha_coef: float = 0.08,
         fog_coef_range: tuple[float, float] = (0.3, 1),
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.fog_coef_range = fog_coef_range
         self.alpha_coef = alpha_coef
 
@@ -1408,10 +1402,9 @@ class RandomSunFlare(ImageOnlyTransform):
         angle_range: tuple[float, float] = (0, 1),
         num_flare_circles_range: tuple[int, int] = (6, 10),
         method: Literal["overlay", "physics_based"] = "overlay",
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
         self.angle_range = angle_range
         self.num_flare_circles_range = num_flare_circles_range
@@ -1664,10 +1657,9 @@ class RandomShadow(ImageOnlyTransform):
         num_shadows_upper: int | None = None,
         shadow_dimension: int = 5,
         shadow_intensity_range: tuple[float, float] = (0.5, 0.5),
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
         self.shadow_roi = shadow_roi
         self.shadow_dimension = shadow_dimension
@@ -1806,10 +1798,9 @@ class RandomToneCurve(ImageOnlyTransform):
         self,
         scale: float = 0.1,
         per_channel: bool = False,
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.scale = scale
         self.per_channel = per_channel
 
@@ -1928,10 +1919,9 @@ class HueSaturationValue(ImageOnlyTransform):
         hue_shift_limit: ScaleFloatType = (-20, 20),
         sat_shift_limit: ScaleFloatType = (-30, 30),
         val_shift_limit: ScaleFloatType = (-20, 20),
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.hue_shift_limit = cast(tuple[float, float], hue_shift_limit)
         self.sat_shift_limit = cast(tuple[float, float], sat_shift_limit)
         self.val_shift_limit = cast(tuple[float, float], val_shift_limit)
@@ -2062,9 +2052,8 @@ class Solarize(ImageOnlyTransform):
         threshold: ScaleFloatType | None = None,
         threshold_range: tuple[float, float] = (0.5, 0.5),
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.threshold_range = threshold_range
 
     def apply(self, img: np.ndarray, threshold: float, **params: Any) -> np.ndarray:
@@ -2165,9 +2154,8 @@ class Posterize(ImageOnlyTransform):
         self,
         num_bits: int | tuple[int, int] | list[tuple[int, int]] = 4,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.num_bits = cast(Union[tuple[int, int], list[tuple[int, int]]], num_bits)
 
     def apply(
@@ -2280,10 +2268,9 @@ class Equalize(ImageOnlyTransform):
         by_channels: bool = True,
         mask: np.ndarray | Callable[..., Any] | None = None,
         mask_params: Sequence[str] = (),
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
         self.mode = mode
         self.by_channels = by_channels
@@ -2429,10 +2416,9 @@ class RandomBrightnessContrast(ImageOnlyTransform):
         contrast_limit: ScaleFloatType = (-0.2, 0.2),
         brightness_by_max: bool = True,
         ensure_safe_range: bool = False,
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.brightness_limit = cast(tuple[float, float], brightness_limit)
         self.contrast_limit = cast(tuple[float, float], contrast_limit)
         self.brightness_by_max = brightness_by_max
@@ -2588,10 +2574,9 @@ class GaussNoise(ImageOnlyTransform):
         mean_range: tuple[float, float] = (0.0, 0.0),
         per_channel: bool = True,
         noise_scale_factor: float = 1,
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.std_range = std_range
         self.mean_range = mean_range
         self.per_channel = per_channel
@@ -2706,10 +2691,9 @@ class ISONoise(ImageOnlyTransform):
         self,
         color_shift: tuple[float, float] = (0.01, 0.05),
         intensity: tuple[float, float] = (0.1, 0.5),
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.intensity = intensity
         self.color_shift = color_shift
 
@@ -2806,10 +2790,9 @@ class CLAHE(ImageOnlyTransform):
         self,
         clip_limit: ScaleFloatType = 4.0,
         tile_grid_size: tuple[int, int] = (8, 8),
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.clip_limit = cast(tuple[float, float], clip_limit)
         self.tile_grid_size = tile_grid_size
 
@@ -2964,10 +2947,9 @@ class RandomGamma(ImageOnlyTransform):
     def __init__(
         self,
         gamma_limit: ScaleFloatType = (80, 120),
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.gamma_limit = cast(tuple[float, float], gamma_limit)
 
     def apply(self, img: np.ndarray, gamma: float, **params: Any) -> np.ndarray:
@@ -3054,10 +3036,9 @@ class ToGray(ImageOnlyTransform):
             "max",
             "pca",
         ] = "weighted_average",
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.num_output_channels = num_output_channels
         self.method = method
 
@@ -3125,9 +3106,8 @@ class ToRGB(ImageOnlyTransform):
         self,
         num_output_channels: int = 3,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
         self.num_output_channels = num_output_channels
 
@@ -3219,8 +3199,8 @@ class ToSepia(ImageOnlyTransform):
         ToGray: For converting images to grayscale instead of sepia.
     """
 
-    def __init__(self, p: float = 0.5, always_apply: bool | None = None):
-        super().__init__(p, always_apply)
+    def __init__(self, p: float = 0.5):
+        super().__init__(p=p)
         self.sepia_transformation_matrix = np.array(
             [[0.393, 0.769, 0.189], [0.349, 0.686, 0.168], [0.272, 0.534, 0.131]],
         )
@@ -3303,9 +3283,8 @@ class ToFloat(ImageOnlyTransform):
         self,
         max_value: float | None = None,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p, always_apply)
+        super().__init__(p=p)
         self.max_value = max_value
 
     def apply(self, img: np.ndarray, **params: Any) -> np.ndarray:
@@ -3364,10 +3343,9 @@ class FromFloat(ImageOnlyTransform):
         self,
         dtype: Literal["uint8", "uint16", "float32", "float64"] = "uint8",
         max_value: float | None = None,
-        always_apply: bool | None = None,
         p: float = 1.0,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.dtype = np.dtype(dtype)
         self.max_value = max_value
 
@@ -3505,10 +3483,9 @@ class Downscale(ImageOnlyTransform):
         interpolation_pair: InterpolationDict = InterpolationDict(
             {"upscale": cv2.INTER_NEAREST, "downscale": cv2.INTER_NEAREST},
         ),
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.scale_range = scale_range
         self.interpolation_pair = interpolation_pair
 
@@ -3556,10 +3533,9 @@ class Lambda(NoOp):
         keypoints: Callable[..., Any] | None = None,
         bboxes: Callable[..., Any] | None = None,
         name: str | None = None,
-        always_apply: bool | None = None,
         p: float = 1.0,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
         self.name = name
         self.custom_apply_fns = {
@@ -3705,9 +3681,8 @@ class MultiplicativeNoise(ImageOnlyTransform):
         per_channel: bool = False,
         elementwise: bool = False,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.multiplier = cast(tuple[float, float], multiplier)
         self.elementwise = elementwise
         self.per_channel = per_channel
@@ -3810,9 +3785,8 @@ class FancyPCA(ImageOnlyTransform):
         self,
         alpha: float = 0.1,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.alpha = alpha
 
     def apply(
@@ -3955,9 +3929,8 @@ class ColorJitter(ImageOnlyTransform):
         saturation: ScaleFloatType = (0.8, 1.2),
         hue: ScaleFloatType = (-0.5, 0.5),
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
         self.brightness = cast(tuple[float, float], brightness)
         self.contrast = cast(tuple[float, float], contrast)
@@ -4148,9 +4121,8 @@ class Sharpen(ImageOnlyTransform):
         kernel_size: int = 5,
         sigma: float = 1.0,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.alpha = alpha
         self.lightness = lightness
         self.method = method
@@ -4260,9 +4232,8 @@ class Emboss(ImageOnlyTransform):
         alpha: tuple[float, float] = (0.2, 0.5),
         strength: tuple[float, float] = (0.2, 0.7),
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.alpha = alpha
         self.strength = strength
 
@@ -4405,9 +4376,8 @@ class Superpixels(ImageOnlyTransform):
         max_size: int | None = 128,
         interpolation: int = cv2.INTER_LINEAR,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.p_replace = cast(tuple[float, float], p_replace)
         self.n_segments = cast(tuple[int, int], n_segments)
         self.max_size = max_size
@@ -4543,9 +4513,8 @@ class RingingOvershoot(ImageOnlyTransform):
         blur_limit: ScaleIntType = (7, 15),
         cutoff: tuple[float, float] = (np.pi / 4, np.pi / 2),
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.blur_limit = cast(tuple[int, int], blur_limit)
         self.cutoff = cutoff
 
@@ -4665,9 +4634,8 @@ class UnsharpMask(ImageOnlyTransform):
         alpha: ScaleFloatType = (0.2, 0.5),
         threshold: int = 10,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.blur_limit = cast(tuple[int, int], blur_limit)
         self.sigma_limit = cast(tuple[float, float], sigma_limit)
         self.alpha = cast(tuple[float, float], alpha)
@@ -4783,9 +4751,8 @@ class PixelDropout(DualTransform):
         drop_value: ScaleFloatType | None = 0,
         mask_drop_value: ScaleFloatType | None = None,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.dropout_prob = dropout_prob
         self.per_channel = per_channel
         self.drop_value = drop_value
@@ -5016,9 +4983,8 @@ class Spatter(ImageOnlyTransform):
         mode: SpatterMode | Sequence[SpatterMode] = "rain",
         color: Sequence[int] | dict[str, Sequence[int]] | None = None,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.mean = cast(tuple[float, float], mean)
         self.std = cast(tuple[float, float], std)
         self.gauss_sigma = cast(tuple[float, float], gauss_sigma)
@@ -5192,9 +5158,8 @@ class ChromaticAberration(ImageOnlyTransform):
         mode: ChromaticAberrationMode = "green_purple",
         interpolation: InterpolationType = cv2.INTER_LINEAR,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.primary_distortion_limit = cast(
             tuple[float, float],
             primary_distortion_limit,
@@ -5344,9 +5309,8 @@ class Morphological(DualTransform):
         scale: ScaleIntType = (2, 3),
         operation: MorphologyMode = "dilation",
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.scale = cast(tuple[int, int], scale)
         self.operation = operation
 
@@ -5541,9 +5505,8 @@ class PlanckianJitter(ImageOnlyTransform):
         temperature_limit: tuple[int, int] | None = None,
         sampling_method: Literal["uniform", "gaussian"] = "uniform",
         p: float = 0.5,
-        always_apply: bool | None = None,
     ) -> None:
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
         self.mode = mode
         self.temperature_limit = cast(tuple[int, int], temperature_limit)
@@ -5671,9 +5634,8 @@ class ShotNoise(ImageOnlyTransform):
         self,
         scale_range: tuple[float, float] = (0.1, 0.3),
         p: float = 0.5,
-        always_apply: bool = False,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.scale_range = scale_range
 
     def apply(
@@ -5910,9 +5872,8 @@ class AdditiveNoise(ImageOnlyTransform):
         noise_params: dict[str, Any] | None = None,
         approximation: float = 1.0,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.noise_type = noise_type
         self.spatial_mode = spatial_mode
         self.noise_params = noise_params
@@ -6044,7 +6005,6 @@ class RGBShift(AdditiveNoise):
         g_shift_limit: ScaleFloatType = (-20, 20),
         b_shift_limit: ScaleFloatType = (-20, 20),
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
         # Convert RGB shift limits to normalized ranges if needed
         def normalize_range(limit: tuple[float, float]) -> tuple[float, float]:
@@ -6166,9 +6126,8 @@ class SaltAndPepper(ImageOnlyTransform):
         amount: tuple[float, float] = (0.01, 0.06),
         salt_vs_pepper: tuple[float, float] = (0.4, 0.6),
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.amount = amount
         self.salt_vs_pepper = salt_vs_pepper
 
@@ -6343,10 +6302,9 @@ class PlasmaBrightnessContrast(ImageOnlyTransform):
         contrast_range: tuple[float, float] = (-0.3, 0.3),
         plasma_size: int = 256,
         roughness: float = 3.0,
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.brightness_range = brightness_range
         self.contrast_range = contrast_range
         self.plasma_size = plasma_size
@@ -6503,9 +6461,8 @@ class PlasmaShadow(ImageOnlyTransform):
         plasma_size: int = 256,
         roughness: float = 3.0,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.shadow_intensity_range = shadow_intensity_range
         self.plasma_size = plasma_size
         self.roughness = roughness
@@ -6704,10 +6661,9 @@ class Illumination(ImageOnlyTransform):
         angle_range: tuple[float, float] = (0, 360),
         center_range: tuple[float, float] = (0.1, 0.9),
         sigma_range: tuple[float, float] = (0.2, 1.0),
-        always_apply: bool | None = None,
         p: float = 0.5,
     ):
-        super().__init__(always_apply=always_apply, p=p)
+        super().__init__(p=p)
         self.mode = mode
         self.intensity_range = intensity_range
         self.effect_type = effect_type
@@ -6807,9 +6763,8 @@ class AutoContrast(ImageOnlyTransform):
     def __init__(
         self,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
     def apply(self, img: np.ndarray, **params: Any) -> np.ndarray:
         return fmain.auto_contrast(img)

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -32,9 +32,8 @@ class BasePad3D(Transform3D):
         fill: ColorType = 0,
         fill_mask: ColorType = 0,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.fill = fill
         self.fill_mask = fill_mask
 
@@ -120,7 +119,6 @@ class Pad3D(BasePad3D):
         fill: ColorType = 0,
         fill_mask: ColorType = 0,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
         super().__init__(fill=fill, fill_mask=fill_mask, p=p)
         self.padding = padding
@@ -192,7 +190,6 @@ class PadIfNeeded3D(BasePad3D):
         fill: ColorType = 0,
         fill_mask: ColorType = 0,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
         super().__init__(fill=fill, fill_mask=fill_mask, p=p)
         self.min_zyx = min_zyx
@@ -252,9 +249,8 @@ class BaseCropAndPad3D(Transform3D):
         fill_mask: ColorType,
         pad_position: Literal["center", "random"],
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.pad_if_needed = pad_if_needed
         self.fill = fill
         self.fill_mask = fill_mask
@@ -439,7 +435,6 @@ class CenterCrop3D(BaseCropAndPad3D):
         fill: ColorType = 0,
         fill_mask: ColorType = 0,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
         super().__init__(
             pad_if_needed=pad_if_needed,
@@ -537,7 +532,6 @@ class RandomCrop3D(BaseCropAndPad3D):
         fill: ColorType = 0,
         fill_mask: ColorType = 0,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
         super().__init__(
             pad_if_needed=pad_if_needed,
@@ -695,9 +689,8 @@ class CoarseDropout3D(Transform3D):
         fill: ColorType = 0,
         fill_mask: ColorType | None = None,
         p: float = 0.5,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
         self.num_holes_range = num_holes_range
         self.hole_depth_range = hole_depth_range
         self.hole_height_range = hole_height_range
@@ -845,9 +838,8 @@ class CubicSymmetry(Transform3D):
     def __init__(
         self,
         p: float = 1.0,
-        always_apply: bool | None = None,
     ):
-        super().__init__(p=p, always_apply=always_apply)
+        super().__init__(p=p)
 
     def get_params_dependent_on_data(
         self,

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -35,7 +35,6 @@ class Interpolation:
 
 class BaseTransformInitSchema(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    always_apply: bool | None
     p: ProbabilityType
 
 
@@ -63,23 +62,8 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
     class InitSchema(BaseTransformInitSchema):
         pass
 
-    def __init__(self, p: float = 0.5, always_apply: bool | None = None):
+    def __init__(self, p: float = 0.5):
         self.p = p
-        if always_apply is not None:
-            if always_apply:
-                warn(
-                    "always_apply is deprecated. Use `p=1` if you want to always apply the transform."
-                    " self.p will be set to 1.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                self.p = 1.0
-            else:
-                warn(
-                    "always_apply is deprecated.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
         self._additional_targets: dict[str, str] = {}
         # replay mode params
         self.params: dict[Any, Any] = {}

--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -30,8 +30,8 @@ class ToTensorV2(BasicTransform):
 
     _targets = (Targets.IMAGE, Targets.MASK)
 
-    def __init__(self, transpose_mask: bool = False, p: float = 1.0, always_apply: bool | None = None):
-        super().__init__(p=p, always_apply=always_apply)
+    def __init__(self, transpose_mask: bool = False, p: float = 1.0):
+        super().__init__(p=p)
         self.transpose_mask = transpose_mask
 
     @property
@@ -116,8 +116,8 @@ class ToTensor3D(BasicTransform):
 
     _targets = (Targets.IMAGE, Targets.MASK)
 
-    def __init__(self, p: float = 1.0, always_apply: bool | None = None):
-        super().__init__(p=p, always_apply=always_apply)
+    def __init__(self, p: float = 1.0):
+        super().__init__(p=p)
 
     @property
     def targets(self) -> dict[str, Any]:

--- a/tests/files/transform_serialization_v2_with_totensor.json
+++ b/tests/files/transform_serialization_v2_with_totensor.json
@@ -6,7 +6,6 @@
         "transforms": [
             {
                 "__class_fullname__": "Blur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -15,7 +14,6 @@
             },
             {
                 "__class_fullname__": "CLAHE",
-                "always_apply": false,
                 "p": 0.5,
                 "clip_limit": [
                     1,
@@ -28,7 +26,6 @@
             },
             {
                 "__class_fullname__": "ChannelDropout",
-                "always_apply": false,
                 "p": 0.5,
                 "channel_drop_range": [
                     1,
@@ -38,12 +35,10 @@
             },
             {
                 "__class_fullname__": "ChannelShuffle",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "CoarseDropout",
-                "always_apply": false,
                 "p": 0.5,
                 "max_holes": 8,
                 "max_height": 8,
@@ -56,7 +51,6 @@
             },
             {
                 "__class_fullname__": "Downscale",
-                "always_apply": false,
                 "p": 0.5,
                 "scale_min": 0.25,
                 "scale_max": 0.25,
@@ -64,7 +58,6 @@
             },
             {
                 "__class_fullname__": "ElasticTransform",
-                "always_apply": false,
                 "p": 0.5,
                 "alpha": 1,
                 "sigma": 50,
@@ -76,20 +69,17 @@
             },
             {
                 "__class_fullname__": "Equalize",
-                "always_apply": false,
                 "p": 0.5,
                 "mode": "cv",
                 "by_channels": true
             },
             {
                 "__class_fullname__": "FancyPCA",
-                "always_apply": false,
                 "p": 0.5,
                 "alpha": 0.1
             },
             {
                 "__class_fullname__": "GaussNoise",
-                "always_apply": false,
                 "p": 0.5,
                 "var_limit": [
                     10.0,
@@ -98,7 +88,6 @@
             },
             {
                 "__class_fullname__": "GaussianBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -111,7 +100,6 @@
             },
             {
                 "__class_fullname__": "GlassBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "sigma": 0.7,
                 "max_delta": 4,
@@ -119,7 +107,6 @@
             },
             {
                 "__class_fullname__": "GridDistortion",
-                "always_apply": false,
                 "p": 0.5,
                 "num_steps": 5,
                 "distort_limit": [
@@ -133,12 +120,10 @@
             },
             {
                 "__class_fullname__": "HorizontalFlip",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "HueSaturationValue",
-                "always_apply": false,
                 "p": 0.5,
                 "hue_shift_limit": [
                     -20,
@@ -155,7 +140,6 @@
             },
             {
                 "__class_fullname__": "ISONoise",
-                "always_apply": false,
                 "p": 0.5,
                 "intensity": [
                     0.1,
@@ -168,7 +152,6 @@
             },
             {
                 "__class_fullname__": "ImageCompression",
-                "always_apply": false,
                 "p": 0.5,
                 "quality_lower": 99,
                 "quality_upper": 100,
@@ -176,19 +159,16 @@
             },
             {
                 "__class_fullname__": "InvertImg",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "LongestMaxSize",
-                "always_apply": false,
                 "p": 1,
                 "max_size": 1024,
                 "interpolation": 1
             },
             {
                 "__class_fullname__": "MedianBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -197,7 +177,6 @@
             },
             {
                 "__class_fullname__": "MotionBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -206,7 +185,6 @@
             },
             {
                 "__class_fullname__": "MultiplicativeNoise",
-                "always_apply": false,
                 "p": 0.5,
                 "multiplier": [
                     0.9,
@@ -217,12 +195,10 @@
             },
             {
                 "__class_fullname__": "NoOp",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "OpticalDistortion",
-                "always_apply": false,
                 "p": 0.5,
                 "distort_limit": [
                     -0.05,
@@ -233,7 +209,6 @@
             },
             {
                 "__class_fullname__": "PadIfNeeded",
-                "always_apply": false,
                 "p": 1.0,
                 "min_height": 1024,
                 "min_width": 1024,
@@ -245,7 +220,6 @@
             },
             {
                 "__class_fullname__": "Posterize",
-                "always_apply": false,
                 "p": 0.5,
                 "num_bits": [
                     4,
@@ -254,7 +228,6 @@
             },
             {
                 "__class_fullname__": "RGBShift",
-                "always_apply": false,
                 "p": 0.5,
                 "r_shift_limit": [
                     -20,
@@ -271,7 +244,6 @@
             },
             {
                 "__class_fullname__": "RandomBrightnessContrast",
-                "always_apply": false,
                 "p": 0.5,
                 "brightness_limit": [
                     -0.2,
@@ -285,7 +257,6 @@
             },
             {
                 "__class_fullname__": "RandomFog",
-                "always_apply": false,
                 "p": 0.5,
                 "fog_coef_lower": 0.3,
                 "fog_coef_upper": 1,
@@ -293,7 +264,6 @@
             },
             {
                 "__class_fullname__": "RandomGamma",
-                "always_apply": false,
                 "p": 0.5,
                 "gamma_limit": [
                     80,
@@ -302,7 +272,6 @@
             },
             {
                 "__class_fullname__": "RandomGridShuffle",
-                "always_apply": false,
                 "p": 0.5,
                 "grid": [
                     2,
@@ -311,7 +280,6 @@
             },
             {
                 "__class_fullname__": "RandomRain",
-                "always_apply": false,
                 "p": 0.5,
                 "slant_lower": -10,
                 "slant_upper": 10,
@@ -328,12 +296,10 @@
             },
             {
                 "__class_fullname__": "RandomRotate90",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "RandomScale",
-                "always_apply": false,
                 "p": 0.5,
                 "interpolation": 1,
                 "scale_limit": [
@@ -343,7 +309,6 @@
             },
             {
                 "__class_fullname__": "RandomShadow",
-                "always_apply": false,
                 "p": 0.5,
                 "shadow_roi": [
                     0,
@@ -359,7 +324,6 @@
             },
             {
                 "__class_fullname__": "RandomSnow",
-                "always_apply": false,
                 "p": 0.5,
                 "snow_point_lower": 0.1,
                 "snow_point_upper": 0.3,
@@ -367,7 +331,6 @@
             },
             {
                 "__class_fullname__": "RandomSunFlare",
-                "always_apply": false,
                 "p": 0.5,
                 "flare_roi": [
                     0,
@@ -388,7 +351,6 @@
             },
             {
                 "__class_fullname__": "Rotate",
-                "always_apply": false,
                 "p": 0.5,
                 "limit": [
                     -90,
@@ -401,7 +363,6 @@
             },
             {
                 "__class_fullname__": "ShiftScaleRotate",
-                "always_apply": false,
                 "p": 0.5,
                 "shift_limit_x": [
                     -0.0625,
@@ -426,14 +387,12 @@
             },
             {
                 "__class_fullname__": "SmallestMaxSize",
-                "always_apply": false,
                 "p": 1,
                 "max_size": 1024,
                 "interpolation": 1
             },
             {
                 "__class_fullname__": "Solarize",
-                "always_apply": false,
                 "p": 0.5,
                 "threshold": [
                     128,
@@ -442,34 +401,28 @@
             },
             {
                 "__class_fullname__": "ToGray",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "ToSepia",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "Transpose",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "VerticalFlip",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "RandomCrop",
-                "always_apply": false,
                 "p": 1.0,
                 "height": 32,
                 "width": 32
             },
             {
                 "__class_fullname__": "Normalize",
-                "always_apply": false,
                 "p": 1.0,
                 "mean": [
                     0.485,
@@ -485,7 +438,6 @@
             },
             {
                 "__class_fullname__": "ToTensorV2",
-                "always_apply": true,
                 "p": 1.0,
                 "transpose_mask": false
             }

--- a/tests/files/transform_serialization_v2_without_totensor.json
+++ b/tests/files/transform_serialization_v2_without_totensor.json
@@ -6,7 +6,6 @@
         "transforms": [
             {
                 "__class_fullname__": "Blur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -15,7 +14,6 @@
             },
             {
                 "__class_fullname__": "CLAHE",
-                "always_apply": false,
                 "p": 0.5,
                 "clip_limit": [
                     1,
@@ -28,7 +26,6 @@
             },
             {
                 "__class_fullname__": "ChannelDropout",
-                "always_apply": false,
                 "p": 0.5,
                 "channel_drop_range": [
                     1,
@@ -38,12 +35,10 @@
             },
             {
                 "__class_fullname__": "ChannelShuffle",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "CoarseDropout",
-                "always_apply": false,
                 "p": 0.5,
                 "max_holes": 8,
                 "max_height": 8,
@@ -56,7 +51,6 @@
             },
             {
                 "__class_fullname__": "Downscale",
-                "always_apply": false,
                 "p": 0.5,
                 "scale_min": 0.25,
                 "scale_max": 0.25,
@@ -64,7 +58,6 @@
             },
             {
                 "__class_fullname__": "ElasticTransform",
-                "always_apply": false,
                 "p": 0.5,
                 "alpha": 1,
                 "sigma": 50,
@@ -76,20 +69,17 @@
             },
             {
                 "__class_fullname__": "Equalize",
-                "always_apply": false,
                 "p": 0.5,
                 "mode": "cv",
                 "by_channels": true
             },
             {
                 "__class_fullname__": "FancyPCA",
-                "always_apply": false,
                 "p": 0.5,
                 "alpha": 0.1
             },
             {
                 "__class_fullname__": "GaussNoise",
-                "always_apply": false,
                 "p": 0.5,
                 "var_limit": [
                     10.0,
@@ -100,7 +90,6 @@
             },
             {
                 "__class_fullname__": "GaussianBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -113,7 +102,6 @@
             },
             {
                 "__class_fullname__": "GlassBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "sigma": 0.7,
                 "max_delta": 4,
@@ -121,7 +109,6 @@
             },
             {
                 "__class_fullname__": "GridDistortion",
-                "always_apply": false,
                 "p": 0.5,
                 "num_steps": 5,
                 "distort_limit": [
@@ -135,12 +122,10 @@
             },
             {
                 "__class_fullname__": "HorizontalFlip",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "HueSaturationValue",
-                "always_apply": false,
                 "p": 0.5,
                 "hue_shift_limit": [
                     -20,
@@ -157,7 +142,6 @@
             },
             {
                 "__class_fullname__": "ISONoise",
-                "always_apply": false,
                 "p": 0.5,
                 "intensity": [
                     0.1,
@@ -170,7 +154,6 @@
             },
             {
                 "__class_fullname__": "ImageCompression",
-                "always_apply": false,
                 "p": 0.5,
                 "quality_lower": 99,
                 "quality_upper": 100,
@@ -178,19 +161,16 @@
             },
             {
                 "__class_fullname__": "InvertImg",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "LongestMaxSize",
-                "always_apply": false,
                 "p": 1,
                 "max_size": 1024,
                 "interpolation": 1
             },
             {
                 "__class_fullname__": "MedianBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -199,7 +179,6 @@
             },
             {
                 "__class_fullname__": "MotionBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -208,7 +187,6 @@
             },
             {
                 "__class_fullname__": "MultiplicativeNoise",
-                "always_apply": false,
                 "p": 0.5,
                 "multiplier": [
                     0.9,
@@ -219,12 +197,10 @@
             },
             {
                 "__class_fullname__": "NoOp",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "OpticalDistortion",
-                "always_apply": false,
                 "p": 0.5,
                 "distort_limit": [
                     -0.05,
@@ -235,7 +211,6 @@
             },
             {
                 "__class_fullname__": "PadIfNeeded",
-                "always_apply": false,
                 "p": 1.0,
                 "min_height": 1024,
                 "min_width": 1024,
@@ -247,7 +222,6 @@
             },
             {
                 "__class_fullname__": "Posterize",
-                "always_apply": false,
                 "p": 0.5,
                 "num_bits": [
                     4,
@@ -256,7 +230,6 @@
             },
             {
                 "__class_fullname__": "RGBShift",
-                "always_apply": false,
                 "p": 0.5,
                 "r_shift_limit": [
                     -20,
@@ -273,7 +246,6 @@
             },
             {
                 "__class_fullname__": "RandomBrightnessContrast",
-                "always_apply": false,
                 "p": 0.5,
                 "brightness_limit": [
                     -0.2,
@@ -287,7 +259,6 @@
             },
             {
                 "__class_fullname__": "RandomFog",
-                "always_apply": false,
                 "p": 0.5,
                 "fog_coef_lower": 0.3,
                 "fog_coef_upper": 1,
@@ -295,7 +266,6 @@
             },
             {
                 "__class_fullname__": "RandomGamma",
-                "always_apply": false,
                 "p": 0.5,
                 "gamma_limit": [
                     80,
@@ -304,7 +274,6 @@
             },
             {
                 "__class_fullname__": "RandomGridShuffle",
-                "always_apply": false,
                 "p": 0.5,
                 "grid": [
                     2,
@@ -313,7 +282,6 @@
             },
             {
                 "__class_fullname__": "RandomRain",
-                "always_apply": false,
                 "p": 0.5,
                 "slant_lower": -10,
                 "slant_upper": 10,
@@ -330,12 +298,10 @@
             },
             {
                 "__class_fullname__": "RandomRotate90",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "RandomScale",
-                "always_apply": false,
                 "p": 0.5,
                 "interpolation": 1,
                 "scale_limit": [
@@ -345,7 +311,6 @@
             },
             {
                 "__class_fullname__": "RandomShadow",
-                "always_apply": false,
                 "p": 0.5,
                 "shadow_roi": [
                     0,
@@ -361,7 +326,6 @@
             },
             {
                 "__class_fullname__": "RandomSnow",
-                "always_apply": false,
                 "p": 0.5,
                 "snow_point_lower": 0.1,
                 "snow_point_upper": 0.3,
@@ -369,7 +333,6 @@
             },
             {
                 "__class_fullname__": "RandomSunFlare",
-                "always_apply": false,
                 "p": 0.5,
                 "flare_roi": [
                     0,
@@ -390,7 +353,6 @@
             },
             {
                 "__class_fullname__": "Rotate",
-                "always_apply": false,
                 "p": 0.5,
                 "limit": [
                     -90,
@@ -403,7 +365,6 @@
             },
             {
                 "__class_fullname__": "ShiftScaleRotate",
-                "always_apply": false,
                 "p": 0.5,
                 "shift_limit_x": [
                     -0.0625,
@@ -428,14 +389,12 @@
             },
             {
                 "__class_fullname__": "SmallestMaxSize",
-                "always_apply": false,
                 "p": 1,
                 "max_size": 1024,
                 "interpolation": 1
             },
             {
                 "__class_fullname__": "Solarize",
-                "always_apply": false,
                 "p": 0.5,
                 "threshold": [
                     128,
@@ -444,34 +403,28 @@
             },
             {
                 "__class_fullname__": "ToGray",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "ToSepia",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "Transpose",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "VerticalFlip",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "RandomCrop",
-                "always_apply": false,
                 "p": 1.0,
                 "height": 32,
                 "width": 32
             },
             {
                 "__class_fullname__": "Normalize",
-                "always_apply": false,
                 "p": 1.0,
                 "mean": [
                     0.485,

--- a/tests/files/transform_v1.1.0_with_totensor.json
+++ b/tests/files/transform_v1.1.0_with_totensor.json
@@ -6,7 +6,6 @@
         "transforms": [
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Blur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -15,7 +14,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.CLAHE",
-                "always_apply": false,
                 "p": 0.5,
                 "clip_limit": [
                     1,
@@ -28,7 +26,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ChannelDropout",
-                "always_apply": false,
                 "p": 0.5,
                 "channel_drop_range": [
                     1,
@@ -38,12 +35,10 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ChannelShuffle",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.CoarseDropout",
-                "always_apply": false,
                 "p": 0.5,
                 "max_holes": 8,
                 "max_height": 8,
@@ -54,7 +49,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Downscale",
-                "always_apply": false,
                 "p": 0.5,
                 "scale_min": 0.25,
                 "scale_max": 0.25,
@@ -62,7 +56,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ElasticTransform",
-                "always_apply": false,
                 "p": 0.5,
                 "alpha": 1,
                 "sigma": 50,
@@ -74,20 +67,17 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Equalize",
-                "always_apply": false,
                 "p": 0.5,
                 "mode": "cv",
                 "by_channels": true
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.FancyPCA",
-                "always_apply": false,
                 "p": 0.5,
                 "alpha": 0.1
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.GaussNoise",
-                "always_apply": false,
                 "p": 0.5,
                 "var_limit": [
                     10.0,
@@ -96,7 +86,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.GaussianBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -105,7 +94,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.GlassBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "sigma": 0.7,
                 "max_delta": 4,
@@ -113,7 +101,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.GridDistortion",
-                "always_apply": false,
                 "p": 0.5,
                 "num_steps": 5,
                 "distort_limit": [
@@ -127,12 +114,10 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.HorizontalFlip",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.HueSaturationValue",
-                "always_apply": false,
                 "p": 0.5,
                 "hue_shift_limit": [
                     -20,
@@ -149,7 +134,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ISONoise",
-                "always_apply": false,
                 "p": 0.5,
                 "intensity": [
                     0.1,
@@ -162,7 +146,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ImageCompression",
-                "always_apply": false,
                 "p": 0.5,
                 "quality_lower": 99,
                 "quality_upper": 100,
@@ -170,19 +153,16 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.InvertImg",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.LongestMaxSize",
-                "always_apply": false,
                 "p": 1,
                 "max_size": 1024,
                 "interpolation": 1
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.MedianBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -191,7 +171,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.MotionBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -200,7 +179,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.MultiplicativeNoise",
-                "always_apply": false,
                 "p": 0.5,
                 "multiplier": [
                     0.9,
@@ -211,12 +189,10 @@
             },
             {
                 "__class_fullname__": "albumentations.core.transforms_interface.NoOp",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.OpticalDistortion",
-                "always_apply": false,
                 "p": 0.5,
                 "distort_limit": [
                     -0.05,
@@ -227,7 +203,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.PadIfNeeded",
-                "always_apply": false,
                 "p": 1.0,
                 "min_height": 1024,
                 "min_width": 1024,
@@ -237,7 +212,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Posterize",
-                "always_apply": false,
                 "p": 0.5,
                 "num_bits": [
                     4,
@@ -246,7 +220,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RGBShift",
-                "always_apply": false,
                 "p": 0.5,
                 "r_shift_limit": [
                     -20,
@@ -263,7 +236,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomBrightnessContrast",
-                "always_apply": false,
                 "p": 0.5,
                 "brightness_limit": [
                     -0.2,
@@ -277,7 +249,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomFog",
-                "always_apply": false,
                 "p": 0.5,
                 "fog_coef_lower": 0.3,
                 "fog_coef_upper": 1,
@@ -285,7 +256,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomGamma",
-                "always_apply": false,
                 "p": 0.5,
                 "gamma_limit": [
                     80,
@@ -294,7 +264,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomGridShuffle",
-                "always_apply": false,
                 "p": 0.5,
                 "grid": [
                     2,
@@ -303,7 +272,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomRain",
-                "always_apply": false,
                 "p": 0.5,
                 "slant_lower": -10,
                 "slant_upper": 10,
@@ -320,12 +288,10 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomRotate90",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomScale",
-                "always_apply": false,
                 "p": 0.5,
                 "interpolation": 1,
                 "scale_limit": [
@@ -335,7 +301,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomShadow",
-                "always_apply": false,
                 "p": 0.5,
                 "shadow_roi": [
                     0,
@@ -351,7 +316,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomSnow",
-                "always_apply": false,
                 "p": 0.5,
                 "snow_point_lower": 0.1,
                 "snow_point_upper": 0.3,
@@ -359,7 +323,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomSunFlare",
-                "always_apply": false,
                 "p": 0.5,
                 "flare_roi": [
                     0,
@@ -380,7 +343,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Rotate",
-                "always_apply": false,
                 "p": 0.5,
                 "limit": [
                     -90,
@@ -393,7 +355,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ShiftScaleRotate",
-                "always_apply": false,
                 "p": 0.5,
                 "shift_limit": [
                     -0.0625,
@@ -414,14 +375,12 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.SmallestMaxSize",
-                "always_apply": false,
                 "p": 1,
                 "max_size": 1024,
                 "interpolation": 1
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Solarize",
-                "always_apply": false,
                 "p": 0.5,
                 "threshold": [
                     128,
@@ -430,34 +389,28 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ToGray",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ToSepia",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Transpose",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.VerticalFlip",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomCrop",
-                "always_apply": false,
                 "p": 1.0,
                 "height": 32,
                 "width": 32
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Normalize",
-                "always_apply": false,
                 "p": 1.0,
                 "mean": [
                     0.485,
@@ -473,7 +426,6 @@
             },
             {
                 "__class_fullname__": "albumentations.pytorch.transforms.ToTensorV2",
-                "always_apply": true,
                 "p": 1.0
             }
         ],

--- a/tests/files/transform_v1.1.0_without_totensor.json
+++ b/tests/files/transform_v1.1.0_without_totensor.json
@@ -6,7 +6,6 @@
         "transforms": [
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Blur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -15,7 +14,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.CLAHE",
-                "always_apply": false,
                 "p": 0.5,
                 "clip_limit": [
                     1,
@@ -28,7 +26,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ChannelDropout",
-                "always_apply": false,
                 "p": 0.5,
                 "channel_drop_range": [
                     1,
@@ -38,12 +35,10 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ChannelShuffle",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.CoarseDropout",
-                "always_apply": false,
                 "p": 0.5,
                 "max_holes": 8,
                 "max_height": 8,
@@ -54,7 +49,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Downscale",
-                "always_apply": false,
                 "p": 0.5,
                 "scale_min": 0.25,
                 "scale_max": 0.25,
@@ -62,7 +56,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ElasticTransform",
-                "always_apply": false,
                 "p": 0.5,
                 "alpha": 1,
                 "sigma": 50,
@@ -74,20 +67,17 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Equalize",
-                "always_apply": false,
                 "p": 0.5,
                 "mode": "cv",
                 "by_channels": true
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.FancyPCA",
-                "always_apply": false,
                 "p": 0.5,
                 "alpha": 0.1
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.GaussNoise",
-                "always_apply": false,
                 "p": 0.5,
                 "var_limit": [
                     10.0,
@@ -96,7 +86,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.GaussianBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -105,7 +94,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.GlassBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "sigma": 0.7,
                 "max_delta": 4,
@@ -113,7 +101,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.GridDistortion",
-                "always_apply": false,
                 "p": 0.5,
                 "num_steps": 5,
                 "distort_limit": [
@@ -127,12 +114,10 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.HorizontalFlip",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.HueSaturationValue",
-                "always_apply": false,
                 "p": 0.5,
                 "hue_shift_limit": [
                     -20,
@@ -149,7 +134,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ISONoise",
-                "always_apply": false,
                 "p": 0.5,
                 "intensity": [
                     0.1,
@@ -162,7 +146,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ImageCompression",
-                "always_apply": false,
                 "p": 0.5,
                 "quality_lower": 99,
                 "quality_upper": 100,
@@ -170,19 +153,16 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.InvertImg",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.LongestMaxSize",
-                "always_apply": false,
                 "p": 1,
                 "max_size": 1024,
                 "interpolation": 1
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.MedianBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -191,7 +171,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.MotionBlur",
-                "always_apply": false,
                 "p": 0.5,
                 "blur_limit": [
                     3,
@@ -200,7 +179,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.MultiplicativeNoise",
-                "always_apply": false,
                 "p": 0.5,
                 "multiplier": [
                     0.9,
@@ -211,12 +189,10 @@
             },
             {
                 "__class_fullname__": "albumentations.core.transforms_interface.NoOp",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.OpticalDistortion",
-                "always_apply": false,
                 "p": 0.5,
                 "distort_limit": [
                     -0.05,
@@ -227,7 +203,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.PadIfNeeded",
-                "always_apply": false,
                 "p": 1.0,
                 "min_height": 1024,
                 "min_width": 1024,
@@ -237,7 +212,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Posterize",
-                "always_apply": false,
                 "p": 0.5,
                 "num_bits": [
                     4,
@@ -246,7 +220,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RGBShift",
-                "always_apply": false,
                 "p": 0.5,
                 "r_shift_limit": [
                     -20,
@@ -263,7 +236,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomBrightnessContrast",
-                "always_apply": false,
                 "p": 0.5,
                 "brightness_limit": [
                     -0.2,
@@ -277,7 +249,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomFog",
-                "always_apply": false,
                 "p": 0.5,
                 "fog_coef_lower": 0.3,
                 "fog_coef_upper": 1,
@@ -285,7 +256,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomGamma",
-                "always_apply": false,
                 "p": 0.5,
                 "gamma_limit": [
                     80,
@@ -294,7 +264,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomGridShuffle",
-                "always_apply": false,
                 "p": 0.5,
                 "grid": [
                     2,
@@ -303,7 +272,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomRain",
-                "always_apply": false,
                 "p": 0.5,
                 "slant_lower": -10,
                 "slant_upper": 10,
@@ -320,12 +288,10 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomRotate90",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomScale",
-                "always_apply": false,
                 "p": 0.5,
                 "interpolation": 1,
                 "scale_limit": [
@@ -335,7 +301,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomShadow",
-                "always_apply": false,
                 "p": 0.5,
                 "shadow_roi": [
                     0,
@@ -351,7 +316,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomSnow",
-                "always_apply": false,
                 "p": 0.5,
                 "snow_point_lower": 0.1,
                 "snow_point_upper": 0.3,
@@ -359,7 +323,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomSunFlare",
-                "always_apply": false,
                 "p": 0.5,
                 "flare_roi": [
                     0,
@@ -380,7 +343,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Rotate",
-                "always_apply": false,
                 "p": 0.5,
                 "limit": [
                     -90,
@@ -393,7 +355,6 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ShiftScaleRotate",
-                "always_apply": false,
                 "p": 0.5,
                 "shift_limit": [
                     -0.0625,
@@ -414,14 +375,12 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.SmallestMaxSize",
-                "always_apply": false,
                 "p": 1,
                 "max_size": 1024,
                 "interpolation": 1
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Solarize",
-                "always_apply": false,
                 "p": 0.5,
                 "threshold": [
                     128,
@@ -430,34 +389,28 @@
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ToGray",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.ToSepia",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Transpose",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.VerticalFlip",
-                "always_apply": false,
                 "p": 0.5
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.RandomCrop",
-                "always_apply": false,
                 "p": 1.0,
                 "height": 32,
                 "width": 32
             },
             {
                 "__class_fullname__": "albumentations.augmentations.transforms.Normalize",
-                "always_apply": false,
                 "p": 1.0,
                 "mean": [
                     0.485,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -50,13 +50,6 @@ def test_compose():
     assert second.called
 
 
-def oneof_always_apply_crash():
-    aug = Compose([A.HorizontalFlip(p=1), A.Rotate(p=1), A.OneOf([A.Blur(p=1), A.MedianBlur(p=1)], p=1)], p=1)
-    image = np.ones((8, 8))
-    data = aug(image=image)
-    assert data
-
-
 @pytest.mark.parametrize("target_as_params", ([], ["image"], ["image", "mask"], ["image", "mask", "keypoints"]))
 def test_one_of(target_as_params):
     # Create a simple transform-like class for testing
@@ -996,46 +989,6 @@ def test_compose_additional_targets_in_available_keys() -> None:
     augmentation = Compose([], p=1, strict=False)
     augmentation(image=image, additional_target_1=image, additional_target_2=image)
 
-
-def test_transform_always_apply_warning() -> None:
-    """Check that warning is raised if always_apply argument is used"""
-    warning_expected = (
-        "always_apply is deprecated. Use `p=1` if you want to always apply the transform. self.p will be set to 1."
-    )
-
-    with pytest.warns(DeprecationWarning) as record:
-        transform = A.NoOp(always_apply=True, p=0.5)
-
-    assert len(record) == 1
-
-    assert record[0].message.args[0] == warning_expected
-    assert transform.p == 1
-
-    with pytest.warns(DeprecationWarning) as record:
-        aug = A.Compose([A.NoOp(always_apply=True, p=0.5)], p=1)
-
-    assert len(record) == 1
-
-    assert record[0].message.args[0] == warning_expected
-    assert aug.transforms[0].p == 1
-
-    warning_expected_2 = "always_apply is deprecated."
-
-    with pytest.warns(DeprecationWarning) as record:
-        transform = A.NoOp(always_apply=False, p=0.5)
-
-    assert len(record) == 1
-
-    assert record[0].message.args[0] == warning_expected_2
-    assert transform.p == 0.5
-
-    with pytest.warns(DeprecationWarning) as record:
-        aug = A.Compose([A.NoOp(always_apply=False, p=0.5)], p=1)
-
-    assert len(record) == 1
-
-    assert record[0].message.args[0] == warning_expected_2
-    assert aug.transforms[0].p == 0.5
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -305,8 +305,8 @@ def test_transform_without_schema() -> None:
 
 
 class CustomImageTransform(ImageOnlyTransform):
-    def __init__(self, custom_param: int, p: float = 0.5, always_apply: Optional[bool] = None):
-        super().__init__(p=p, always_apply=always_apply)
+    def __init__(self, custom_param: int, p: float = 0.5):
+        super().__init__(p=p)
         self.custom_param = custom_param
 
 
@@ -322,14 +322,6 @@ def test_custom_image_transform_signature() -> None:
         annotation=int,
     )
 
-    assert "always_apply" in expected_params
-    assert expected_params["always_apply"] == Parameter(
-        "always_apply",
-        kind=Parameter.POSITIONAL_OR_KEYWORD,
-        default=None,
-        annotation=Optional[bool],
-    )
-
     assert "p" in expected_params
     assert expected_params["p"] == Parameter(
         "p",
@@ -339,7 +331,6 @@ def test_custom_image_transform_signature() -> None:
     )
 
     # Ensure the correct defaults and types
-    assert expected_params["always_apply"].default is None
     assert expected_params["p"].default == 0.5
     assert expected_params["custom_param"].annotation is int
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -883,7 +883,7 @@ def test_augmentations_serialization(
 
     model_fields = get_all_init_schema_fields(augmentation_cls)
     # Note: You might want to adjust this based on how you handle default fields in your models
-    expected_args = model_fields - {"__class_fullname__", "always_apply"}
+    expected_args = model_fields - {"__class_fullname__"}
 
     achieved_args = set(instance.to_dict()["transform"].keys())
     reported_args = achieved_args - {"__class_fullname__"}


### PR DESCRIPTION
## Summary by Sourcery

Remove the deprecated 'always_apply' parameter from the codebase, including its usage in transform classes and related tests. Update the pre-commit configuration to the latest Ruff version.

Enhancements:
- Remove the deprecated 'always_apply' parameter from various transform classes across the codebase.

Tests:
- Remove tests related to the 'always_apply' parameter, including those checking for deprecation warnings.

Chores:
- Update the pre-commit configuration to use Ruff version 0.8.6.