### PR TITLE
Updated RandomCropNearBbox

### DIFF
--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -1088,7 +1088,6 @@ class RandomCropNearBBox(BaseCrop):
             If max_part_shift is a single float, the range will be (0, max_part_shift).
             Default (0, 0.3).
         cropping_bbox_key (str): Additional target key for cropping box. Default `cropping_bbox`.
-        cropping_box_key (str): [Deprecated] Use `cropping_bbox_key` instead.
         p (float): probability of applying the transform. Default: 1.
 
     Targets:
@@ -1114,21 +1113,9 @@ class RandomCropNearBBox(BaseCrop):
         self,
         max_part_shift: ScaleFloatType = (0, 0.3),
         cropping_bbox_key: str = "cropping_bbox",
-        cropping_box_key: str | None = None,  # Deprecated
         p: float = 1.0,
     ):
         super().__init__(p=p)
-        # Check for deprecated parameter and issue warning
-        if cropping_box_key is not None:
-            warn(
-                "The parameter 'cropping_box_key' is deprecated and will be removed in future versions. "
-                "Use 'cropping_bbox_key' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            # Ensure the new parameter is used even if the old one is passed
-            cropping_bbox_key = cropping_box_key
-
         self.max_part_shift = cast(tuple[float, float], max_part_shift)
         self.cropping_bbox_key = cropping_bbox_key
 


### PR DESCRIPTION
## Summary by Sourcery

Remove the deprecated `cropping_box_key` parameter from the `RandomCropNearBBox` transform.