### PR TITLE
Update random snow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: albumentations-team/albumentations
         files: ./coverage.xml
+        flags: ubuntu-py3.12
+        fail_ci_if_error: true  # Optional: fails CI if upload fails
         verbose: true  # Optional: helps with debugging
 
   check_code_formatting_types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,6 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: albumentations-team/albumentations
         files: ./coverage.xml
-        flags: ubuntu-py3.12
-        fail_ci_if_error: true  # Optional: fails CI if upload fails
         verbose: true  # Optional: helps with debugging
 
   check_code_formatting_types:

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -456,52 +456,11 @@ class RandomSnow(ImageOnlyTransform):
             AfterValidator(nondecreasing),
         ]
 
-        snow_point_lower: float | None = Field(
-            gt=0,
-            lt=1,
-        )
-        snow_point_upper: float | None = Field(
-            gt=0,
-            lt=1,
-        )
         brightness_coeff: float = Field(gt=0)
         method: Literal["bleach", "texture"]
 
-        @model_validator(mode="after")
-        def validate_ranges(self) -> Self:
-            if self.snow_point_lower is not None or self.snow_point_upper is not None:
-                if self.snow_point_lower is not None:
-                    warn(
-                        "`snow_point_lower` deprecated. Use `snow_point_range` as tuple"
-                        " (snow_point_lower, snow_point_upper) instead.",
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-                if self.snow_point_upper is not None:
-                    warn(
-                        "`snow_point_upper` deprecated. Use `snow_point_range` as tuple"
-                        "(snow_point_lower, snow_point_upper) instead.",
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-                lower = self.snow_point_lower if self.snow_point_lower is not None else self.snow_point_range[0]
-                upper = self.snow_point_upper if self.snow_point_upper is not None else self.snow_point_range[1]
-                self.snow_point_range = (lower, upper)
-                self.snow_point_lower = None
-                self.snow_point_upper = None
-
-            # Validate the snow_point_range
-            if not (0 < self.snow_point_range[0] <= self.snow_point_range[1] < 1):
-                raise ValueError(
-                    "snow_point_range values should be increasing within (0, 1) range.",
-                )
-
-            return self
-
     def __init__(
         self,
-        snow_point_lower: float | None = None,
-        snow_point_upper: float | None = None,
         brightness_coeff: float = 2.5,
         snow_point_range: tuple[float, float] = (0.1, 0.3),
         method: Literal["bleach", "texture"] = "bleach",

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1509,24 +1509,6 @@ def test_random_rain_invalid_input(params):
 
 
 @pytest.mark.parametrize(
-    "params, expected",
-    [
-        # Test default initialization values
-        ({}, {"snow_point_range": (0.1, 0.3)}),
-        # Test snow point range
-        ({"snow_point_range": (0.2, 0.6)}, {"snow_point_range": (0.2, 0.6)}),
-        # Deprecated quality values handling
-        ({"snow_point_lower": 0.15}, {"snow_point_range": (0.15, 0.3)}),
-        ({"snow_point_upper": 0.4}, {"snow_point_range": (0.1, 0.4)}),
-    ],
-)
-def test_random_snow_initialization(params, expected):
-    img_comp = A.RandomSnow(**params)
-    for key, value in expected.items():
-        assert getattr(img_comp, key) == value, f"Failed on {key} with value {value}"
-
-
-@pytest.mark.parametrize(
     "params",
     [
         ({"snow_point_range": (1.2, 1.5)}),  # Invalid quality range -> upper bound


### PR DESCRIPTION
## Summary by Sourcery

Replace deprecated `snow_point_lower` and `snow_point_upper` parameters with `snow_point_range` in `RandomSnow` transform.

Enhancements:
- Simplified the `RandomSnow` transform initialization by removing deprecated parameters.

Tests:
- Removed tests for deprecated `snow_point_lower` and `snow_point_upper` parameters.