### PR TITLE
Updated RandomSunFlare

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1153,15 +1153,6 @@ class RandomSunFlare(ImageOnlyTransform):
 
     class InitSchema(BaseTransformInitSchema):
         flare_roi: tuple[float, float, float, float]
-        angle_lower: float | None = Field(ge=0, le=1)
-        angle_upper: float | None = Field(ge=0, le=1)
-
-        num_flare_circles_lower: int | None = Field(
-            ge=0,
-        )
-        num_flare_circles_upper: int | None = Field(
-            gt=0,
-        )
         src_radius: int = Field(gt=1)
         src_color: tuple[int, ...]
 
@@ -1192,59 +1183,11 @@ class RandomSunFlare(ImageOnlyTransform):
             ):
                 raise ValueError(f"Invalid flare_roi. Got: {self.flare_roi}")
 
-            if self.angle_lower is not None or self.angle_upper is not None:
-                if self.angle_lower is not None:
-                    warn(
-                        "`angle_lower` deprecated. Use `angle_range` as tuple (angle_lower, angle_upper) instead.",
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-                if self.angle_upper is not None:
-                    warn(
-                        "`angle_upper` deprecated. Use `angle_range` as tuple(angle_lower, angle_upper) instead.",
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-                lower = self.angle_lower if self.angle_lower is not None else self.angle_range[0]
-                upper = self.angle_upper if self.angle_upper is not None else self.angle_range[1]
-                self.angle_range = (lower, upper)
-
-            if self.num_flare_circles_lower is not None or self.num_flare_circles_upper is not None:
-                if self.num_flare_circles_lower is not None:
-                    warn(
-                        "`num_flare_circles_lower` deprecated. Use `num_flare_circles_range` as tuple"
-                        " (num_flare_circles_lower, num_flare_circles_upper) instead.",
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-                if self.num_flare_circles_upper is not None:
-                    warn(
-                        "`num_flare_circles_upper` deprecated. Use `num_flare_circles_range` as tuple"
-                        " (num_flare_circles_lower, num_flare_circles_upper) instead.",
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-                lower = (
-                    self.num_flare_circles_lower
-                    if self.num_flare_circles_lower is not None
-                    else self.num_flare_circles_range[0]
-                )
-                upper = (
-                    self.num_flare_circles_upper
-                    if self.num_flare_circles_upper is not None
-                    else self.num_flare_circles_range[1]
-                )
-                self.num_flare_circles_range = (lower, upper)
-
             return self
 
     def __init__(
         self,
         flare_roi: tuple[float, float, float, float] = (0, 0, 1, 0.5),
-        angle_lower: float | None = None,
-        angle_upper: float | None = None,
-        num_flare_circles_lower: int | None = None,
-        num_flare_circles_upper: int | None = None,
         src_radius: int = 400,
         src_color: tuple[int, ...] = (255, 255, 255),
         angle_range: tuple[float, float] = (0, 1),

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1771,43 +1771,6 @@ def test_gauss_noise(mean, image):
 
 
 @pytest.mark.parametrize(
-    "params, expected",
-    [
-        # Test default initialization values
-        (
-            {},
-            {
-                "flare_roi": (0, 0, 1, 0.5),
-                "angle_range": (0, 1),
-                "num_flare_circles_range": (6, 10),
-                "src_radius": 400,
-                "src_color": (255, 255, 255),
-            },
-        ),
-        # Test custom initialization values
-        ({"flare_roi": (0.2, 0.3, 0.8, 0.9)}, {"flare_roi": (0.2, 0.3, 0.8, 0.9)}),
-        ({"angle_range": (0.3, 0.7)}, {"angle_range": (0.3, 0.7)}),
-        ({"angle_lower": 0.3, "angle_upper": 0.7}, {"angle_range": (0.3, 0.7)}),
-        ({"num_flare_circles_range": (4, 8)}, {"num_flare_circles_range": (4, 8)}),
-        (
-            {"num_flare_circles_lower": 4, "num_flare_circles_upper": 8},
-            {"num_flare_circles_range": (4, 8)},
-        ),
-        ({"src_radius": 500}, {"src_radius": 500}),
-        ({"src_color": (200, 200, 200)}, {"src_color": (200, 200, 200)}),
-        ({"angle_lower": 0.2}, {"angle_range": (0.2, 1)}),
-        ({"angle_upper": 0.8}, {"angle_range": (0, 0.8)}),
-        ({"num_flare_circles_lower": 5}, {"num_flare_circles_range": (5, 10)}),
-        ({"num_flare_circles_upper": 9}, {"num_flare_circles_range": (6, 9)}),
-    ],
-)
-def test_random_sun_flare_initialization(params, expected):
-    img_flare = A.RandomSunFlare(**params)
-    for key, value in expected.items():
-        assert getattr(img_flare, key) == value, f"Failed on {key} with value {value}"
-
-
-@pytest.mark.parametrize(
     "params",
     [
         (


### PR DESCRIPTION
## Summary by Sourcery

Remove deprecated `angle_lower`, `angle_upper`, `num_flare_circles_lower`, and `num_flare_circles_upper` parameters from `RandomSunFlare`. Use `angle_range` and `num_flare_circles_range` instead.

Enhancements:
- Refactor `RandomSunFlare` to use range parameters for angle and number of flare circles.

Tests:
- Update tests to reflect the changes in `RandomSunFlare` parameterization.