### PR TITLE
Updated GaussNoise

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -42,7 +42,6 @@ from albumentations.core.types import (
     MONO_CHANNEL_DIMENSIONS,
     NUM_MULTI_CHANNEL_DIMENSIONS,
     NUM_RGB_CHANNELS,
-    ImageMode,
     SpatterMode,
 )
 
@@ -301,7 +300,7 @@ def _handle_mask(
 def equalize(
     img: np.ndarray,
     mask: np.ndarray | None = None,
-    mode: ImageMode = "cv",
+    mode: Literal["cv", "pil"] = "cv",
     by_channels: bool = True,
 ) -> np.ndarray:
     """Apply histogram equalization to the input image.

--- a/albumentations/core/types.py
+++ b/albumentations/core/types.py
@@ -24,7 +24,6 @@ ScaleType = Union[ScaleIntType, ScaleFloatType]
 IntNumType = Union[np.integer, NDArray[np.integer]]
 FloatNumType = Union[np.floating, NDArray[np.floating]]
 
-ImageMode = Literal["cv", "pil"]
 SpatterMode = Literal["rain", "mud"]
 ChromaticAberrationMode = Literal["green_purple", "red_blue", "random"]
 RainMode = Literal["drizzle", "heavy", "torrential", "default"]


### PR DESCRIPTION
## Summary by Sourcery

Refactor the `GaussNoise`, `Solarize`, and `Equalize` augmentations to use standard deviation instead of variance, and to normalize parameters to the range [0, 1]. Additionally, deprecate legacy parameters in favor of more consistent alternatives.

Enhancements:
- Replace variance-based noise generation with standard deviation-based noise generation in `GaussNoise`.
- Normalize parameters to the range [0, 1] for `Solarize` and `GaussNoise`.
- Deprecate legacy parameters `var_limit` and `mean` in `GaussNoise`, and `threshold` in `Solarize`.