### PR TITLE
Deleted update_params

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -2199,10 +2199,6 @@ class GaussNoise(ImageOnlyTransform):
         mean_range (tuple[float, float]): Range for noise mean as a fraction
             of the maximum value (255 for uint8 images or 1.0 for float images).
             Values should be in range [-1, 1]. Default: (0.0, 0.0).
-        var_limit (tuple[float, float] | float): [Deprecated] Variance range for noise.
-            If var_limit is a single float value, the range will be (0, var_limit).
-            Default: (10.0, 50.0).
-        mean (float): [Deprecated] Mean of the noise. Default: 0.
         per_channel (bool): If True, noise will be sampled for each channel independently.
             Otherwise, the noise will be sampled once for all channels. Default: True.
         noise_scale_factor (float): Scaling factor for noise generation. Value should be in the range (0, 1].

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -770,7 +770,7 @@ def test_affine_scale_ratio(params):
 
     data = {"image": image}
     call_params = aug.get_params()
-    call_params = aug.update_params_shape(call_params, data)
+    call_params = aug.update_transform_params(call_params, data)
 
     apply_params = aug.get_params_dependent_on_data(params=call_params, data=data)
 


### PR DESCRIPTION
## Summary by Sourcery

Renamed `update_params_shape` to `update_transform_params` and updated its docstring to reflect that it now updates parameters with both input shape and transform-specific parameters. Removed the deprecated `update_params` method and the `var_limit` and `mean` parameters from `GaussNoise`.

Enhancements:
- Updated `update_transform_params` to include transform-specific parameters like `interpolation`, `fill`, and `fill_mask`.

Tests:
- Updated tests to use `update_transform_params` instead of `update_params_shape`.