### PR TITLE
Better import for Pytorch functions

### DIFF
--- a/albumentations/__init__.py
+++ b/albumentations/__init__.py
@@ -11,6 +11,7 @@ except Exception:  # noqa: BLE001
     __maintainer__ = "Vladimir Iglovikov"
 
 import os
+from contextlib import suppress
 
 from albumentations.check_version import check_for_updates
 
@@ -18,6 +19,9 @@ from .augmentations import *
 from .core.composition import *
 from .core.serialization import *
 from .core.transforms_interface import *
+
+with suppress(ImportError):
+    from .pytorch import *
 
 # Perform the version check after all other initializations
 if os.getenv("NO_ALBUMENTATIONS_UPDATE", "").lower() not in {"true", "1"}:

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -149,13 +149,13 @@ POSITIONS: list[PositionType] = ["center", "top_left", "top_right", "bottom_left
     ]
 )
 @pytest.mark.parametrize("pad_position", POSITIONS)
-@pytest.mark.parametrize("pad_mode", [cv2.BORDER_CONSTANT, cv2.BORDER_REFLECT_101, cv2.BORDER_REFLECT])
+@pytest.mark.parametrize("border_mode", [cv2.BORDER_CONSTANT, cv2.BORDER_REFLECT_101, cv2.BORDER_REFLECT])
 def test_pad_position_equivalence(
     image: np.ndarray,
     crop_cls: type[A.DualTransform],
     crop_params: dict[str, int],
     pad_position: PositionType,
-    pad_mode: int,
+    border_mode: int,
     mask: np.ndarray,
     bboxes: np.ndarray,
     keypoints: np.ndarray,
@@ -167,7 +167,7 @@ def test_pad_position_equivalence(
         crop_cls(
             **crop_params,
             pad_if_needed=True,
-            border_mode=pad_mode,
+            border_mode=border_mode,
             fill=0,
             pad_position=pad_position,
         )
@@ -178,7 +178,7 @@ def test_pad_position_equivalence(
         A.PadIfNeeded(
             min_height=crop_params["height"],
             min_width=crop_params["width"],
-            border_mode=pad_mode,
+            border_mode=border_mode,
             fill=0,
             position=pad_position,
         ),

--- a/tests/test_domain_adaptation.py
+++ b/tests/test_domain_adaptation.py
@@ -234,8 +234,8 @@ def test_pca_inverse_transform(n_components, data, expected_transformed, expecte
     pca = PCA(n_components)
     transformed = pca.fit_transform(data)
     inversed = pca.inverse_transform(transformed)
-    assert np.array_equal(transformed, expected_transformed)
-    assert np.array_equal(inversed, expected_inverse)
+    np.testing.assert_array_almost_equal(transformed, expected_transformed)
+    np.testing.assert_array_almost_equal(inversed, expected_inverse)
 
 
 # Helper function to create test images

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -5,14 +5,13 @@ from PIL import Image
 from torchvision.transforms import ColorJitter
 
 import albumentations as A
-from albumentations.pytorch.transforms import ToTensorV2
 from tests.conftest import RECTANGULAR_UINT8_IMAGE, SQUARE_UINT8_IMAGE, UINT8_IMAGES
 
 
 @pytest.mark.parametrize("image", UINT8_IMAGES)
 def test_torch_to_tensor_v2_augmentations(image):
     mask = image.copy()
-    aug = ToTensorV2()
+    aug = A.ToTensorV2()
     data = aug(image=image, mask=mask, force_apply=True)
     height, width, num_channels = image.shape
     assert isinstance(data["image"], torch.Tensor) and data["image"].shape == (num_channels, height, width)
@@ -25,7 +24,7 @@ def test_torch_to_tensor_v2_augmentations(image):
 def test_torch_to_tensor_v2_augmentations_with_transpose_2d_mask(image):
     mask = image[:, :, 0].copy()
 
-    aug = ToTensorV2(transpose_mask=True)
+    aug = A.ToTensorV2(transpose_mask=True)
 
     data = aug(image=image, mask=mask, force_apply=True)
     image_height, image_width, image_num_channels = image.shape
@@ -43,7 +42,7 @@ def test_torch_to_tensor_v2_augmentations_with_transpose_2d_mask(image):
 
 @pytest.mark.parametrize("image", UINT8_IMAGES)
 def test_torch_to_tensor_v2_augmentations_with_transpose_3d_mask(image):
-    aug = ToTensorV2(transpose_mask=True)
+    aug = A.ToTensorV2(transpose_mask=True)
     mask_shape = image.shape[:2] + (4,)
     mask = np.random.randint(low=0, high=256, size=mask_shape, dtype=np.uint8)
     data = aug(image=image, mask=mask, force_apply=True)
@@ -64,7 +63,7 @@ def test_torch_to_tensor_v2_augmentations_with_transpose_3d_mask(image):
 
 
 def test_additional_targets_for_totensorv2():
-    aug = A.Compose([ToTensorV2()], additional_targets={"image2": "image", "mask2": "mask"})
+    aug = A.Compose([A.ToTensorV2()], additional_targets={"image2": "image", "mask2": "mask"})
     for _i in range(10):
         image1 = np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
         image2 = image1.copy()
@@ -89,7 +88,7 @@ def test_additional_targets_for_totensorv2():
         assert np.array_equal(res["image"], res["image2"])
         assert np.array_equal(res["mask"], res["mask2"])
 
-    aug = A.Compose([ToTensorV2()])
+    aug = A.Compose([A.ToTensorV2()])
     aug.add_targets(additional_targets={"image2": "image", "mask2": "mask"})
     for _i in range(10):
         image1 = np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
@@ -117,7 +116,7 @@ def test_additional_targets_for_totensorv2():
 
 
 def test_torch_to_tensor_v2_on_gray_scale_images():
-    aug = ToTensorV2()
+    aug = A.ToTensorV2()
     grayscale_image = np.random.randint(low=0, high=256, size=(100, 100), dtype=np.uint8)
     data = aug(image=grayscale_image)
     assert isinstance(data["image"], torch.Tensor)
@@ -127,7 +126,7 @@ def test_torch_to_tensor_v2_on_gray_scale_images():
 
 
 def test_with_replaycompose() -> None:
-    aug = A.ReplayCompose([ToTensorV2()])
+    aug = A.ReplayCompose([A.ToTensorV2()])
     kwargs = {
         "image": np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8),
         "mask": np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8),
@@ -199,7 +198,7 @@ def test_post_data_check():
         [
             A.Resize(50, 50, p=1),
             A.Normalize(p=1),
-            ToTensorV2(p=1),
+            A.ToTensorV2(p=1),
         ],
         keypoint_params=A.KeypointParams("xy"),
         bbox_params=A.BboxParams("pascal_voc"),
@@ -221,7 +220,7 @@ def test_to_tensor_v2_on_non_contiguous_array():
     non_contiguous_img = img[::2, ::2, :]
     assert not non_contiguous_img.flags["C_CONTIGUOUS"]
 
-    transform = A.Compose([ToTensorV2()])
+    transform = A.Compose([A.ToTensorV2()])
     transformed = transform(image=non_contiguous_img, masks=[non_contiguous_img] * 2)
 
     # Additional checks to ensure the transformation worked correctly
@@ -239,7 +238,7 @@ def test_to_tensor_v2_on_non_contiguous_array_with_horizontal_flip():
         [
             A.HorizontalFlip(p=1),
             A.ToFloat(max_value=255),
-            ToTensorV2(),
+            A.ToTensorV2(),
         ],
         is_check_shapes=False,
     )
@@ -255,7 +254,7 @@ def test_to_tensor_v2_on_non_contiguous_array_with_random_rotate90():
     transforms = A.Compose(
         [
             A.RandomRotate90(p=1.0),
-            ToTensorV2(),
+            A.ToTensorV2(),
         ],
     )
 
@@ -270,7 +269,7 @@ def test_to_tensor_v2_on_non_contiguous_array_with_random_rotate90():
 
 
 def test_to_tensor_v2_images_masks():
-    transform = A.Compose([ToTensorV2(p=1)])
+    transform = A.Compose([A.ToTensorV2(p=1)])
     image = SQUARE_UINT8_IMAGE
     mask = np.random.randint(0, 2, (100, 100), dtype=np.uint8)
 

--- a/tests/transforms3d/test_pytorch.py
+++ b/tests/transforms3d/test_pytorch.py
@@ -2,7 +2,6 @@ import pytest
 import numpy as np
 import torch
 import albumentations as A
-from albumentations.pytorch.transforms import ToTensor3D
 
 test_cases = [
     pytest.param(
@@ -38,7 +37,7 @@ def test_to_tensor_3d_shapes(
     expected_volume_shape,
     expected_mask_shape
 ):
-    transform = A.Compose([ToTensor3D(p=1)])
+    transform = A.Compose([A.ToTensor3D(p=1)])
     volume = np.random.randint(0, 256, volume_shape, dtype=np.uint8)
     mask3d = np.random.randint(0, 2, mask_shape, dtype=np.uint8)
 
@@ -70,7 +69,7 @@ error_test_cases = [
     error_test_cases
 )
 def test_to_tensor_3d_errors(volume_shape, expected_error, expected_message):
-    transform = A.Compose([ToTensor3D(p=1)])
+    transform = A.Compose([A.ToTensor3D(p=1)])
     volume = np.random.rand(*volume_shape)
 
     with pytest.raises(expected_error, match=expected_message):


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Simplified imports for PyTorch transforms by removing the need to import them from `albumentations.pytorch.transforms`.