### PR TITLE
Fix pixel dropout

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -2911,11 +2911,11 @@ def prepare_drop_values(
     else:
         values = np.array(value, dtype=array.dtype).reshape(-1)
 
-    # For 2D input, return single value
+    # For monochannel input, return single value
     if array.ndim == 2:
         return np.full(array.shape, values[0], dtype=array.dtype)
 
-    # For 3D input, broadcast values to full shape
+    # For multichannel input, broadcast values to full shape
     return np.full(array.shape[:2] + (len(values),), values, dtype=array.dtype)
 
 

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -4307,8 +4307,7 @@ class PixelDropout(DualTransform):
         mask_drop_value (ColorType | None): Value to assign to dropped pixels in the mask.
             If None, the mask will remain unchanged.
             If a single number, that value will be used for all dropped pixels in the mask.
-            If a sequence, it should contain one value per channel of the mask.
-            Note: Only applicable when per_channel=False.
+            If a sequence, it should contain one value per channel.
             Default: None
 
         p (float): Probability of applying the transform. Should be in the range [0, 1].
@@ -4325,9 +4324,6 @@ class PixelDropout(DualTransform):
           if all pixels within the box are dropped. Such boxes will be removed.
         - When applied to keypoints, keypoints that fall on dropped pixels will be removed if
           the keypoint processor is configured to remove invisible keypoints.
-        - The 'per_channel' option is not supported for mask dropout. If you need to drop pixels
-          in a multi-channel mask independently, consider applying this transform multiple times
-          with per_channel=False.
 
     Example:
         >>> import numpy as np
@@ -4342,15 +4338,8 @@ class PixelDropout(DualTransform):
     class InitSchema(BaseTransformInitSchema):
         dropout_prob: ProbabilityType
         per_channel: bool
-        drop_value: ScaleFloatType | None
-        mask_drop_value: ScaleFloatType | None
-
-        @model_validator(mode="after")
-        def validate_mask_drop_value(self) -> Self:
-            if self.mask_drop_value is not None and self.per_channel:
-                msg = "PixelDropout supports mask only with per_channel=False."
-                raise ValueError(msg)
-            return self
+        drop_value: ColorType | None
+        mask_drop_value: ColorType | None
 
     _targets = ALL_TARGETS
 

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -4296,7 +4296,7 @@ class PixelDropout(DualTransform):
             If False, the same dropout mask will be applied to all channels.
             Default: False
 
-        drop_value (float | Sequence[float] | None): Value to assign to the dropped pixels.
+        drop_value (ColorType | None): Value to assign to the dropped pixels.
             If None, the value will be randomly sampled for each application:
                 - For uint8 images: Random integer in [0, 255]
                 - For float32 images: Random float in [0, 1]
@@ -4304,7 +4304,7 @@ class PixelDropout(DualTransform):
             If a sequence, it should contain one value per channel.
             Default: 0
 
-        mask_drop_value (float | Sequence[float] | None): Value to assign to dropped pixels in the mask.
+        mask_drop_value (ColorType | None): Value to assign to dropped pixels in the mask.
             If None, the mask will remain unchanged.
             If a single number, that value will be used for all dropped pixels in the mask.
             If a sequence, it should contain one value per channel of the mask.
@@ -4358,8 +4358,8 @@ class PixelDropout(DualTransform):
         self,
         dropout_prob: float = 0.01,
         per_channel: bool = False,
-        drop_value: ScaleFloatType | None = 0,
-        mask_drop_value: ScaleFloatType | None = None,
+        drop_value: ColorType | None = 0,
+        mask_drop_value: ColorType | None = None,
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -4372,7 +4372,7 @@ class PixelDropout(DualTransform):
         self,
         img: np.ndarray,
         drop_mask: np.ndarray,
-        drop_values: float | Sequence[float],
+        drop_values: np.ndarray,
         **params: Any,
     ) -> np.ndarray:
         return fmain.pixel_dropout(img, drop_mask, drop_values)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -4296,7 +4296,7 @@ class PixelDropout(DualTransform):
             If False, the same dropout mask will be applied to all channels.
             Default: False
 
-        drop_value (ColorType | None): Value to assign to the dropped pixels.
+        drop_value (float | Sequence[float] | None): Value to assign to the dropped pixels.
             If None, the value will be randomly sampled for each application:
                 - For uint8 images: Random integer in [0, 255]
                 - For float32 images: Random float in [0, 1]
@@ -4304,7 +4304,7 @@ class PixelDropout(DualTransform):
             If a sequence, it should contain one value per channel.
             Default: 0
 
-        mask_drop_value (ColorType | None): Value to assign to dropped pixels in the mask.
+        mask_drop_value (float | Sequence[float] | None): Value to assign to dropped pixels in the mask.
             If None, the mask will remain unchanged.
             If a single number, that value will be used for all dropped pixels in the mask.
             If a sequence, it should contain one value per channel.

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -1500,6 +1500,34 @@ def test_get_drop_mask_reproducibility():
     assert not np.array_equal(mask1, mask3)
 
 
+def test_pixel_dropout_sequence_per_channel():
+    """Test pixel dropout with sequence values and per_channel=True"""
+    # Setup
+    image = np.ones((10, 10, 3), dtype=np.uint8) * 255
+    drop_values = (1, 2, 3)
+
+    # With dropout_prob=1.0, drop_mask will be all True
+    drop_mask = np.ones((10, 10, 3), dtype=bool)
+
+    # Verify drop_mask is all True
+    assert np.all(drop_mask)
+    assert drop_mask.shape == image.shape
+
+    # Prepare drop values
+    prepared_values = fmain.prepare_drop_values(image, drop_values, np.random.default_rng(42))
+
+    # Verify prepared_values shape matches image
+    assert prepared_values.shape == image.shape
+
+    # Apply dropout
+    result = fmain.pixel_dropout(image, drop_mask, prepared_values)
+
+    # Each channel should be entirely filled with its corresponding value
+    for channel_idx, expected_value in enumerate(drop_values):
+        assert np.all(result[:, :, channel_idx] == expected_value), \
+            f"Channel {channel_idx} should be filled with value {expected_value}"
+
+
 def test_prepare_drop_values_random_two_channels():
     """Test random value generation for 2-channel images."""
     rng = np.random.default_rng(42)


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2279

## Summary by Sourcery

Fix bugs related to the PixelDropout transform, including incorrect drop value handling for multi-channel images and per-channel dropout with sequence values.

Bug Fixes:
- Fix incorrect drop value handling for multi-channel images in PixelDropout.
- Fix per-channel dropout with sequence values in PixelDropout.

Tests:
- Add tests for PixelDropout to verify correct drop value handling and per-channel dropout behavior.