### PR TITLE
Update from float

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -3015,7 +3015,7 @@ class FromFloat(ImageOnlyTransform):
     """
 
     class InitSchema(BaseTransformInitSchema):
-        dtype: Literal["uint8", "uint16", "float32"]
+        dtype: Literal["uint8", "uint16", "uint32"]
         max_value: float | None
 
         @model_validator(mode="after")
@@ -3032,7 +3032,7 @@ class FromFloat(ImageOnlyTransform):
 
     def __init__(
         self,
-        dtype: Literal["uint8", "uint16", "float32"] = "uint8",
+        dtype: Literal["uint8", "uint16", "uint32"] = "uint8",
         max_value: float | None = None,
         p: float = 1.0,
     ):

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -3020,13 +3020,8 @@ class FromFloat(ImageOnlyTransform):
 
         @model_validator(mode="after")
         def update_max_value(self) -> Self:
-            dtype2npdtype = {
-                "uint8": np.uint8,
-                "uint16": np.uint16,
-                "uint32": np.uint32,
-            }
             if self.max_value is None:
-                self.max_value = get_max_value(dtype2npdtype[self.dtype])
+                self.max_value = get_max_value(np.dtype(self.dtype))
 
             return self
 


### PR DESCRIPTION
## Summary by Sourcery

Update `FromFloat` to support uint32.  Set maximum value automatically if not provided.

New Features:
- Add support for `uint32` dtype in `FromFloat` transform.

Tests:
- Update tests for `FromFloat` to cover the new `uint32` dtype and automatic maximum value setting.