### PR TITLE
Added bounding box pre filtering

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -371,11 +371,12 @@ def test_check_each_transform(targets, bbox_params, keypoint_params, expected):
         [A.Crop(0, 0, 50, 50), A.PadIfNeeded(100, 100, border_mode=cv2.BORDER_CONSTANT, fill=0)],
         bbox_params=bbox_params,
         keypoint_params=keypoint_params,
+        seed=137
     )
     res = augs(image=image, **targets)
 
     for key, item in expected.items():
-        assert np.all(np.array(item) == np.array(res[key]))
+        np.testing.assert_allclose(np.array(item), np.array(res[key]), rtol=1e-6, atol=1e-6)
 
 
 @pytest.mark.parametrize(
@@ -460,11 +461,12 @@ def test_check_each_transform_compose(targets, bbox_params, keypoint_params, exp
         [Compose([A.Crop(0, 0, 50, 50), A.PadIfNeeded(100, 100, border_mode=cv2.BORDER_CONSTANT, value=0)])],
         bbox_params=bbox_params,
         keypoint_params=keypoint_params,
+        seed=137
     )
     res = augs(image=image, **targets)
 
     for key, item in expected.items():
-        assert np.all(np.array(item) == np.array(res[key]))
+        np.testing.assert_allclose(np.array(item), np.array(res[key]), rtol=1e-6, atol=1e-6)
 
 
 @pytest.mark.parametrize(
@@ -553,7 +555,7 @@ def test_check_each_transform_sequential(targets, bbox_params, keypoint_params, 
     res = augs(image=image, **targets)
 
     for key, item in expected.items():
-        assert np.all(np.array(item) == np.array(res[key]))
+        np.testing.assert_allclose(np.array(item), np.array(res[key]), rtol=1e-6, atol=1e-6)
 
 
 @pytest.mark.parametrize(
@@ -645,7 +647,7 @@ def test_check_each_transform_someof(targets, bbox_params, keypoint_params, expe
     res = augs(image=image, **targets)
 
     for key, item in expected.items():
-        assert np.all(np.array(item) == np.array(res[key]))
+        np.testing.assert_allclose(np.array(item), np.array(res[key]), rtol=1e-6, atol=1e-6)
 
 
 @pytest.mark.parametrize("image", IMAGES)

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -137,7 +137,8 @@ def test_bbox_params_edges(
     )
     res = aug(image=image, bboxes=bboxes)["bboxes"]
 
-    np.testing.assert_array_equal(res, expected_bboxes)
+    # Use assert_allclose instead of assert_array_equal to handle floating point precision
+    np.testing.assert_allclose(res, expected_bboxes, rtol=1e-6, atol=1e-6)
 
 POSITIONS: list[PositionType] = ["center", "top_left", "top_right", "bottom_left", "bottom_right"]
 

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -202,13 +202,14 @@ def test_post_data_check():
         ],
         keypoint_params=A.KeypointParams("xy"),
         bbox_params=A.BboxParams("pascal_voc"),
-        seed=42,
+        seed=137,
     )
 
     res = transform(image=img, keypoints=keypoints, bboxes=bboxes)
     assert len(res["keypoints"]) != 0 and len(res["bboxes"]) != 0
     np.testing.assert_array_equal(res["keypoints"], [(45, 45), (25, 25)])
-    np.testing.assert_array_equal(res["bboxes"], [(0, 0, 45, 45, 0)])
+    # Use assert_allclose instead of assert_array_equal
+    np.testing.assert_allclose(res["bboxes"], [(0, 0, 45, 45, 0)], rtol=1e-5, atol=1e-5)
 
 
 def test_to_tensor_v2_on_non_contiguous_array():


### PR DESCRIPTION
## Summary by Sourcery

Add pre-filtering of bounding boxes to remove invalid boxes before applying transformations.

Bug Fixes:
- Fix: Bounding box clipping now correctly handles edge cases and floating-point precision.

Enhancements:
- Improve bounding box processing by adding options to filter invalid bounding boxes and clip boxes to image boundaries.

Tests:
- Add tests for invalid bounding box filtering and clipping.