### PR TITLE
Added filtering on accept ratio

### DIFF
--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -653,8 +653,10 @@ def filter_bboxes(
 
     # Calculate aspect ratios if needed
     if max_accept_ratio is not None:
-        with np.errstate(divide="ignore", invalid="ignore"):
-            aspect_ratios = np.maximum(clipped_widths / clipped_heights, clipped_heights / clipped_widths)
+        aspect_ratios = np.maximum(
+            clipped_widths / (clipped_heights + epsilon),
+            clipped_heights / (clipped_widths + epsilon),
+        )
         valid_ratios = aspect_ratios <= max_accept_ratio
     else:
         valid_ratios = np.ones_like(denormalized_box_areas, dtype=bool)

--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -118,6 +118,10 @@ class BboxParams(Params):
         self.check_each_transform = check_each_transform
         self.clip = clip
         self.filter_invalid_bboxes = filter_invalid_bboxes
+        if max_accept_ratio is not None and max_accept_ratio < 1.0:
+            raise ValueError(
+                "max_accept_ratio must be >= 1.0 when provided, as aspect ratio is calculated as max(w/h, h/w)",
+            )
         self.max_accept_ratio = max_accept_ratio  # e.g., 5.0
 
     def to_dict_private(self) -> dict[str, Any]:


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2308

## Summary by Sourcery

Add filtering of bounding boxes by aspect ratio.

New Features:
- Added `max_accept_ratio` parameter to `BboxParams` to control the filtering of bounding boxes based on their aspect ratio.

Tests:
- Added tests for the new aspect ratio filtering functionality.