### PR TITLE
Fix BboxProcessor filtering on max accept ratio

### DIFF
--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -243,6 +243,7 @@ class BboxProcessor(DataProcessor):
             min_visibility=self.params.min_visibility,
             min_width=self.params.min_width,
             min_height=self.params.min_height,
+            max_accept_ratio=self.params.max_accept_ratio,
         )
 
     def check_and_convert(


### PR DESCRIPTION
# Description

## Issue
In the current implementation, the parameter `max_accept_ratio` is not explicitly passed in the `BboxProcessor.filter` function 

https://github.com/albumentations-team/albumentations/blob/8008ca2bd428ca6d015aa114c92fab082348e32f/albumentations/core/bbox_utils.py#L237-L246

This omission causes the default value (`None`) for `max_accept_ratio` to be used, making **`BboxProcessor`** effectively ignore bounding-box filtering by aspect ratio.

## Fix
The parameter `max_accept_ratio` is now explicitly passed in both **`BboxProcessor`**, ensuring the correct behavior when filtering bounding boxes based on their aspect ratio.
```diff
def filter(self, data: np.ndarray, shape: ShapeType) -> np.ndarray:
    self.params: BboxParams
    return filter_bboxes(
        data,
        shape,
        min_area=self.params.min_area,
        min_visibility=self.params.min_visibility,
        min_width=self.params.min_width,
        min_height=self.params.min_height,
+       max_accept_ratio=self.params.max_accept_ratio
    )
```
## Related
- **Issue #2308**
---

## Tests Added

New test cases have been introduced to verify that `max_accept_ratio` is used in different scenarios, including:

1. **`test_bbox_processor_max_accept_ratio`**  
   Verifies that `BboxProcessor.preprocess` and `BboxProcessor.postprocess` respect the `max_accept_ratio`.

3. **`test_compose_with_max_accept_ratio`**  
   Ensures bounding boxes are filtered correctly when using Albumentations `Compose`.

4. **`test_compose_max_accept_ratio_all_formats`**  
   Confirms `max_accept_ratio` filtering works for `coco`, `pascal_voc`, `yolo`, and `albumentations` formats.

### Test Details

- **Environment**: Python 3.12.8, Ubuntu 24.02, Docker
- **All tests have passed** successfully, validating the fix.

### Additional Notes
- This change is **backward-compatible**.
- Filtering now behaves consistently across different bounding-box operations when `max_accept_ratio` is specified.

## Summary by Sourcery

Fix filtering of bounding boxes by aspect ratio using the `max_accept_ratio` parameter in `BboxProcessor`.

Bug Fixes:
- Fixed a bug where the `max_accept_ratio` parameter was not being used in the `BboxProcessor`, resulting in incorrect filtering of bounding boxes.

Tests:
- Added tests to verify the correct behavior of `max_accept_ratio` in `BboxProcessor.preprocess`, `BboxProcessor.postprocess`, and `Compose` with different bounding box formats.