### PR TITLE
Add typing badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ https://anaconda.org/conda-forge/albumentations)
 https://stackoverflow.com/questions/tagged/albumentations)
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Albumentations%20Guru-006BFF)](https://gurubase.io/g/albumentations)
+![PyPI - Types](https://img.shields.io/pypi/types/albumentations)
 
 [Docs](https://albumentations.ai/docs/) | [Discord](https://discord.gg/AKPrrDYNAt) | [Twitter](https://twitter.com/albumentations) | [LinkedIn](https://www.linkedin.com/company/100504475/)
 


### PR DESCRIPTION
The [typing badge](https://shields.io/badges/py-pi-types) is designed to be a visible marker for python packages that provide static types.

Since this package has good type coverage & has the `Typing :: Typed` classifier, it's a good candidate for the badge.

This PR adds the badge to your README, at the very end of the list of badges. It looks like this:

![PyPI - Types](https://img.shields.io/pypi/types/albumentations)

Feel free to close it if you don't want this in the README.

## Summary by Sourcery

Documentation:
- Add a typing badge to visually indicate that the project provides static types.