### PR TITLE
Add stain augment

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [GaussNoise](https://explore.albumentations.ai/transform/GaussNoise)
 - [GaussianBlur](https://explore.albumentations.ai/transform/GaussianBlur)
 - [GlassBlur](https://explore.albumentations.ai/transform/GlassBlur)
+- [HEStain](https://explore.albumentations.ai/transform/HEStain)
 - [HistogramMatching](https://explore.albumentations.ai/transform/HistogramMatching)
 - [HueSaturationValue](https://explore.albumentations.ai/transform/HueSaturationValue)
 - [ISONoise](https://explore.albumentations.ai/transform/ISONoise)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ pytest_cov>=5.0.0
 pytest_mock>=3.14.0
 requests>=2.31.0
 scikit-image
+scikit-learn
 tomli>=2.0.1
 torch>=2.3.1
 torchvision>=0.18.1

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -432,5 +432,10 @@ AUGMENTATION_CLS_PARAMS = [
     [A.AtLeastOneBBoxRandomCrop, {"height": 80, "width": 80, "erosion_factor": 0.2}],
     [A.ConstrainedCoarseDropout, {"num_holes_range": (1, 3), "hole_height_range": (0.1, 0.2), "hole_width_range": (0.1, 0.2), "fill": 0, "fill_mask": 0, "mask_indices": [1]}],
     [A.RandomSizedBBoxSafeCrop, {"height": 80, "width": 80, "erosion_rate": 0.2}],
-    [A.HEStain, {"method": "vahadane", "intensity_scale_range": (0.5, 1.5), "intensity_shift_range": (-0.1, 0.1), "augment_background": True}],
+    [A.HEStain, [
+        {"method": "vahadane", "intensity_scale_range": (0.5, 1.5), "intensity_shift_range": (-0.1, 0.1), "augment_background": True},
+        {"method": "macenko", "intensity_scale_range": (0.5, 1.5), "intensity_shift_range": (-0.1, 0.1), "augment_background": True},
+        {"method": "random_preset",
+         "intensity_scale_range": (0.5, 1.5), "intensity_shift_range": (-0.1, 0.1), "augment_background": True},
+    ]],
 ]

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -433,7 +433,7 @@ AUGMENTATION_CLS_PARAMS = [
     [A.ConstrainedCoarseDropout, {"num_holes_range": (1, 3), "hole_height_range": (0.1, 0.2), "hole_width_range": (0.1, 0.2), "fill": 0, "fill_mask": 0, "mask_indices": [1]}],
     [A.RandomSizedBBoxSafeCrop, {"height": 80, "width": 80, "erosion_rate": 0.2}],
     [A.HEStain, [
-        {"method": "vahadane", "intensity_scale_range": (0.5, 1.5), "intensity_shift_range": (-0.1, 0.1), "augment_background": True},
+        {"method": "vahadane", "intensity_scale_range": (0.5, 1.5), "intensity_shift_range": (-0.1, 0.1), "augment_background": False},
         {"method": "macenko", "intensity_scale_range": (0.5, 1.5), "intensity_shift_range": (-0.1, 0.1), "augment_background": True},
         {"method": "random_preset",
          "intensity_scale_range": (0.5, 1.5), "intensity_shift_range": (-0.1, 0.1), "augment_background": True},

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -432,4 +432,5 @@ AUGMENTATION_CLS_PARAMS = [
     [A.AtLeastOneBBoxRandomCrop, {"height": 80, "width": 80, "erosion_factor": 0.2}],
     [A.ConstrainedCoarseDropout, {"num_holes_range": (1, 3), "hole_height_range": (0.1, 0.2), "hole_width_range": (0.1, 0.2), "fill": 0, "fill_mask": 0, "mask_indices": [1]}],
     [A.RandomSizedBBoxSafeCrop, {"height": 80, "width": 80, "erosion_rate": 0.2}],
+    [A.HEStain, {"method": "vahadane", "intensity_scale_range": (0.5, 1.5), "intensity_shift_range": (-0.1, 0.1), "augment_background": True}],
 ]

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -319,7 +319,8 @@ def test_augmentations_wont_change_float_input(augmentation_cls, params):
             A.RandomGravel,
             A.RandomSunFlare,
             A.RandomFog,
-            A.Pad
+            A.Pad,
+            A.HEStain,
         },
     ),
 )
@@ -515,6 +516,7 @@ def test_mask_fill_value(augmentation_cls, params):
             A.RandomFog,
             A.Equalize,
             A.GridElasticDeform,
+            A.HEStain,
         },
     ),
 )
@@ -591,6 +593,7 @@ def test_multichannel_image_augmentations(augmentation_cls, params):
             A.RandomSunFlare,
             A.RandomFog,
             A.GridElasticDeform,
+            A.HEStain,
         },
     ),
 )
@@ -664,6 +667,7 @@ def test_float_multichannel_image_augmentations(augmentation_cls, params):
             A.RandomFog,
             A.Equalize,
             A.GridElasticDeform,
+            A.HEStain,
         },
     ),
 )
@@ -740,6 +744,7 @@ def test_multichannel_image_augmentations_diff_channels(augmentation_cls, params
             A.RandomSunFlare,
             A.RandomFog,
             A.GridElasticDeform,
+            A.HEStain,
         },
     ),
 )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1038,7 +1038,7 @@ def test_images_as_target(augmentation_cls, params, as_array, shape):
         if augmentation_cls in {A.ChannelDropout, A.Spatter, A.ISONoise,
                                 A.RandomGravel, A.ChromaticAberration, A.PlanckianJitter, A.PixelDistributionAdaptation,
                                 A.MaskDropout, A.ConstrainedCoarseDropout, A.ChannelShuffle, A.ToRGB, A.RandomSunFlare,
-                                A.RandomFog, A.RandomSnow, A.RandomRain}:
+                                A.RandomFog, A.RandomSnow, A.RandomRain, A.HEStain}:
             pytest.skip("ChannelDropout is not applicable to grayscale images")
 
 


### PR DESCRIPTION
## Summary by Sourcery

Add an H&E stain augmentation to simulate different staining conditions in histopathology images.  The augmentation supports predefined stain matrices, Vahadane and Macenko stain extraction methods, and custom matrices. Control the intensity variations with `intensity_scale_range` and `intensity_shift_range`, and choose whether to augment background regions with `augment_background`.

New Features:
- Added HEStain augmentation for histopathology images.

Tests:
- Added tests for the new HEStain augmentation, including shape validation, comparison with scikit-learn NMF, stain separation accuracy, and background augmentation behavior.