### PR TITLE
Boosted version to 2.0.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         files: setup.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.5
+    rev: v0.9.6
     hooks:
       # Run the linter.
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [ "setuptools>=45", "wheel" ]
 [project]
 name = "albumentations"
 
-version = "2.0.3"
+version = "2.0.4"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volumes, volumetric masks) data, with optimized performance and seamless integration into ML workflows."
 readme = "README.md"


### PR DESCRIPTION
## Summary by Sourcery

Bump version to 2.0.4 and update Ruff pre-commit hook to v0.9.6.

CI:
- Update pre-commit hook for Ruff to v0.9.6.

Chores:
- Update project version to 2.0.4.