### PR TITLE
Fix input types

### DIFF
--- a/albumentations/augmentations/blur/functional.py
+++ b/albumentations/augmentations/blur/functional.py
@@ -14,7 +14,7 @@ from pydantic import ValidationInfo
 
 from albumentations.augmentations.functional import convolve
 from albumentations.augmentations.geometric.functional import scale
-from albumentations.core.type_definitions import EIGHT, ScaleIntType
+from albumentations.core.type_definitions import EIGHT
 
 __all__ = ["blur", "central_zoom", "defocus", "glass_blur", "median_blur", "zoom_blur"]
 
@@ -134,7 +134,7 @@ def _ensure_odd_values(result: tuple[int, int], field_name: str | None = None) -
     return new_result
 
 
-def process_blur_limit(value: ScaleIntType, info: ValidationInfo, min_value: int = 0) -> tuple[int, int]:
+def process_blur_limit(value: int | tuple[int, int], info: ValidationInfo, min_value: int = 0) -> tuple[int, int]:
     """Process blur limit to ensure valid kernel sizes."""
     # Convert value to tuple[int, int]
     if isinstance(value, Sequence):

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -27,7 +27,6 @@ from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     ImageOnlyTransform,
 )
-from albumentations.core.type_definitions import ScaleFloatType, ScaleIntType
 from albumentations.core.utils import to_tuple
 
 from . import functional as fblur
@@ -49,11 +48,11 @@ TWO = 2
 
 
 class BlurInitSchema(BaseTransformInitSchema):
-    blur_limit: ScaleIntType
+    blur_limit: tuple[int, int] | int
 
     @field_validator("blur_limit")
     @classmethod
-    def process_blur(cls, value: ScaleIntType, info: ValidationInfo) -> tuple[int, int]:
+    def process_blur(cls, value: tuple[int, int] | int, info: ValidationInfo) -> tuple[int, int]:
         return fblur.process_blur_limit(value, info, min_value=3)
 
 
@@ -103,7 +102,7 @@ class Blur(ImageOnlyTransform):
 
     def __init__(
         self,
-        blur_limit: ScaleIntType = (3, 7),
+        blur_limit: tuple[int, int] | int = (3, 7),
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -249,7 +248,7 @@ class MotionBlur(Blur):
 
     def __init__(
         self,
-        blur_limit: ScaleIntType = 7,
+        blur_limit: tuple[int, int] | int = (3, 7),
         allow_shifted: bool = True,
         angle_range: tuple[float, float] = (0, 360),
         direction_range: tuple[float, float] = (-1.0, 1.0),
@@ -348,7 +347,7 @@ class MedianBlur(Blur):
 
     def __init__(
         self,
-        blur_limit: ScaleIntType = 7,
+        blur_limit: tuple[int, int] | int = (3, 7),
         p: float = 0.5,
     ):
         super().__init__(blur_limit=blur_limit, p=p)
@@ -423,16 +422,20 @@ class GaussianBlur(ImageOnlyTransform):
 
     class InitSchema(BaseTransformInitSchema):
         sigma_limit: Annotated[
-            ScaleFloatType,
+            tuple[float, float] | float,
             AfterValidator(process_non_negative_range),
             AfterValidator(nondecreasing),
         ]
-        blur_limit: Annotated[ScaleIntType, AfterValidator(convert_to_0plus_range), AfterValidator(nondecreasing)]
+        blur_limit: Annotated[
+            tuple[int, int] | int,
+            AfterValidator(convert_to_0plus_range),
+            AfterValidator(nondecreasing),
+        ]
 
     def __init__(
         self,
-        blur_limit: ScaleIntType = 0,
-        sigma_limit: ScaleFloatType = (0.5, 3.0),
+        blur_limit: tuple[int, int] | int = 0,
+        sigma_limit: tuple[float, float] | float = (0.5, 3.0),
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -670,7 +673,7 @@ class AdvancedBlur(ImageOnlyTransform):
 
         @field_validator("beta_limit")
         @classmethod
-        def check_beta_limit(cls, value: ScaleFloatType) -> tuple[float, float]:
+        def check_beta_limit(cls, value: tuple[float, float] | float) -> tuple[float, float]:
             result = to_tuple(value, low=0)
             if not (result[0] < 1.0 < result[1]):
                 msg = "beta_limit is expected to include 1.0."
@@ -691,12 +694,12 @@ class AdvancedBlur(ImageOnlyTransform):
 
     def __init__(
         self,
-        blur_limit: ScaleIntType = (3, 7),
-        sigma_x_limit: ScaleFloatType = (0.2, 1.0),
-        sigma_y_limit: ScaleFloatType = (0.2, 1.0),
-        rotate_limit: ScaleIntType = (-90, 90),
-        beta_limit: ScaleFloatType = (0.5, 8.0),
-        noise_limit: ScaleFloatType = (0.9, 1.1),
+        blur_limit: tuple[int, int] | int = (3, 7),
+        sigma_x_limit: tuple[float, float] | float = (0.2, 1.0),
+        sigma_y_limit: tuple[float, float] | float = (0.2, 1.0),
+        rotate_limit: tuple[int, int] | int = (-90, 90),
+        beta_limit: tuple[float, float] | float = (0.5, 8.0),
+        noise_limit: tuple[float, float] | float = (0.9, 1.1),
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -823,8 +826,8 @@ class Defocus(ImageOnlyTransform):
 
     def __init__(
         self,
-        radius: ScaleIntType = (3, 10),
-        alias_blur: ScaleFloatType = (0.1, 0.5),
+        radius: tuple[int, int] | int = (3, 10),
+        alias_blur: tuple[float, float] | float = (0.1, 0.5),
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -878,8 +881,8 @@ class ZoomBlur(ImageOnlyTransform):
 
     def __init__(
         self,
-        max_factor: ScaleFloatType = (1, 1.31),
-        step_factor: ScaleFloatType = (0.01, 0.03),
+        max_factor: tuple[float, float] | float = (1, 1.31),
+        step_factor: tuple[float, float] | float = (0.01, 0.03),
         p: float = 0.5,
     ):
         super().__init__(p=p)

--- a/albumentations/augmentations/crops/functional.py
+++ b/albumentations/augmentations/crops/functional.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-
 import cv2
 import numpy as np
 from albucore import maybe_process_in_chunks, preserve_channel_dim
@@ -156,9 +154,9 @@ def crop(img: np.ndarray, x_min: int, y_min: int, x_max: int, y_max: int) -> np.
 @preserve_channel_dim
 def crop_and_pad(
     img: np.ndarray,
-    crop_params: Sequence[int] | None,
-    pad_params: Sequence[int] | None,
-    pad_value: Sequence[float] | float | None,
+    crop_params: tuple[int, int, int, int] | None,
+    pad_params: tuple[int, int, int, int] | None,
+    pad_value: tuple[float, ...] | float | None,
     image_shape: tuple[int, int],
     interpolation: int,
     pad_mode: int,

--- a/albumentations/augmentations/crops/functional.py
+++ b/albumentations/augmentations/crops/functional.py
@@ -9,7 +9,6 @@ from albucore import maybe_process_in_chunks, preserve_channel_dim
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.utils import handle_empty_array
 from albumentations.core.bbox_utils import denormalize_bboxes, normalize_bboxes
-from albumentations.core.type_definitions import ColorType
 
 __all__ = [
     "crop",
@@ -159,7 +158,7 @@ def crop_and_pad(
     img: np.ndarray,
     crop_params: Sequence[int] | None,
     pad_params: Sequence[int] | None,
-    pad_value: ColorType | None,
+    pad_value: Sequence[float] | float | None,
     image_shape: tuple[int, int],
     interpolation: int,
     pad_mode: int,

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Sequence
-from typing import Annotated, Any, cast
+from typing import Annotated, Any, Literal, Union, cast
 
 import cv2
 import numpy as np
@@ -24,11 +24,8 @@ from albumentations.core.type_definitions import (
     ALL_TARGETS,
     NUM_MULTI_CHANNEL_DIMENSIONS,
     PAIR,
-    ColorType,
     PercentType,
-    PositionType,
     PxType,
-    ScaleFloatType,
 )
 
 from . import functional as fcrops
@@ -101,17 +98,17 @@ class BaseCropAndPad(BaseCrop):
     class InitSchema(BaseTransformInitSchema):
         pad_if_needed: bool
         border_mode: BorderModeType
-        fill: ColorType
-        fill_mask: ColorType
-        pad_position: PositionType
+        fill: tuple[float, ...] | float
+        fill_mask: tuple[float, ...] | float
+        pad_position: Literal["center", "top_left", "top_right", "bottom_left", "bottom_right", "random"]
 
     def __init__(
         self,
         pad_if_needed: bool,
         border_mode: int,
-        fill: ColorType,
-        fill_mask: ColorType,
-        pad_position: PositionType,
+        fill: tuple[float, ...] | float,
+        fill_mask: tuple[float, ...] | float,
+        pad_position: Literal["center", "top_left", "top_right", "bottom_left", "bottom_right", "random"],
         p: float,
     ):
         super().__init__(p=p)
@@ -269,9 +266,9 @@ class RandomCrop(BaseCropAndPad):
         width: width of the crop.
         pad_if_needed (bool): Whether to pad if crop size exceeds image size. Default: False.
         border_mode (OpenCV flag): OpenCV border mode used for padding. Default: cv2.BORDER_CONSTANT.
-        fill (ColorType): Padding value for images if border_mode is
+        fill (Sequence[float] | float): Padding value for images if border_mode is
             cv2.BORDER_CONSTANT. Default: 0.
-        fill_mask (ColorType): Padding value for masks if border_mode is
+        fill_mask (Sequence[float] | float): Padding value for masks if border_mode is
             cv2.BORDER_CONSTANT. Default: 0.
         pad_position (Literal['center', 'top_left', 'top_right', 'bottom_left', 'bottom_right', 'random']):
             Position of padding. Default: 'center'.
@@ -292,18 +289,18 @@ class RandomCrop(BaseCropAndPad):
         height: Annotated[int, Field(ge=1)]
         width: Annotated[int, Field(ge=1)]
         border_mode: BorderModeType
-        fill: ColorType
-        fill_mask: ColorType
+        fill: tuple[float, ...] | float
+        fill_mask: tuple[float, ...] | float
 
     def __init__(
         self,
         height: int,
         width: int,
         pad_if_needed: bool = False,
-        pad_position: PositionType = "center",
+        pad_position: Literal["center", "top_left", "top_right", "bottom_left", "bottom_right", "random"] = "center",
         border_mode: int = cv2.BORDER_CONSTANT,
-        fill: ColorType = 0.0,
-        fill_mask: ColorType = 0.0,
+        fill: tuple[float, ...] | float = 0.0,
+        fill_mask: tuple[float, ...] | float = 0.0,
         p: float = 1.0,
     ):
         super().__init__(
@@ -383,9 +380,9 @@ class CenterCrop(BaseCropAndPad):
         width (int): The width of the crop. Must be greater than 0.
         pad_if_needed (bool): Whether to pad if crop size exceeds image size. Default: False.
         border_mode (OpenCV flag): OpenCV border mode used for padding. Default: cv2.BORDER_CONSTANT.
-        fill (ColorType): Padding value for images if border_mode is
+        fill (tuple[float, ...] | float): Padding value for images if border_mode is
             cv2.BORDER_CONSTANT. Default: 0.
-        fill_mask (ColorType): Padding value for masks if border_mode is
+        fill_mask (tuple[float, ...] | float): Padding value for masks if border_mode is
             cv2.BORDER_CONSTANT. Default: 0.
         pad_position (Literal['center', 'top_left', 'top_right', 'bottom_left', 'bottom_right', 'random']):
             Position of padding. Default: 'center'.
@@ -407,18 +404,18 @@ class CenterCrop(BaseCropAndPad):
         height: Annotated[int, Field(ge=1)]
         width: Annotated[int, Field(ge=1)]
         border_mode: BorderModeType
-        fill: ColorType
-        fill_mask: ColorType
+        fill: tuple[float, ...] | float
+        fill_mask: tuple[float, ...] | float
 
     def __init__(
         self,
         height: int,
         width: int,
         pad_if_needed: bool = False,
-        pad_position: PositionType = "center",
+        pad_position: Literal["center", "top_left", "top_right", "bottom_left", "bottom_right", "random"] = "center",
         border_mode: int = cv2.BORDER_CONSTANT,
-        fill: ColorType = 0.0,
-        fill_mask: ColorType = 0.0,
+        fill: tuple[float, ...] | float = 0.0,
+        fill_mask: tuple[float, ...] | float = 0.0,
         p: float = 1.0,
     ):
         super().__init__(
@@ -497,8 +494,8 @@ class Crop(BaseCropAndPad):
         y_max (int): Maximum y-coordinate of the crop region (bottom edge). Must be > y_min. Default: 1024.
         pad_if_needed (bool): Whether to pad if crop coordinates exceed image dimensions. Default: False.
         border_mode (OpenCV flag): OpenCV border mode used for padding. Default: cv2.BORDER_CONSTANT.
-        fill (ColorType): Padding value if border_mode is cv2.BORDER_CONSTANT. Default: 0.
-        fill_mask (ColorType): Padding value for masks. Default: 0.
+        fill (tuple[float, ...] | float): Padding value if border_mode is cv2.BORDER_CONSTANT. Default: 0.
+        fill_mask (tuple[float, ...] | float): Padding value for masks. Default: 0.
         pad_position (Literal['center', 'top_left', 'top_right', 'bottom_left', 'bottom_right', 'random']):
             Position of padding. Default: 'center'.
         p (float): Probability of applying the transform. Default: 1.0.
@@ -522,8 +519,8 @@ class Crop(BaseCropAndPad):
         x_max: Annotated[int, Field(gt=0)]
         y_max: Annotated[int, Field(gt=0)]
         border_mode: BorderModeType
-        fill: ColorType
-        fill_mask: ColorType
+        fill: tuple[float, ...] | float
+        fill_mask: tuple[float, ...] | float
 
         @model_validator(mode="after")
         def validate_coordinates(self) -> Self:
@@ -543,10 +540,10 @@ class Crop(BaseCropAndPad):
         x_max: int = 1024,
         y_max: int = 1024,
         pad_if_needed: bool = False,
-        pad_position: PositionType = "center",
+        pad_position: Literal["center", "top_left", "top_right", "bottom_left", "bottom_right", "random"] = "center",
         border_mode: int = cv2.BORDER_CONSTANT,
-        fill: ColorType = 0,
-        fill_mask: ColorType = 0,
+        fill: tuple[float, ...] | float = 0,
+        fill_mask: tuple[float, ...] | float = 0,
         p: float = 1.0,
     ):
         super().__init__(
@@ -1109,7 +1106,7 @@ class RandomCropNearBBox(BaseCrop):
 
     def __init__(
         self,
-        max_part_shift: ScaleFloatType = (0, 0.3),
+        max_part_shift: tuple[float, float] | float = (0, 0.3),
         cropping_bbox_key: str = "cropping_bbox",
         p: float = 1.0,
     ):
@@ -1431,11 +1428,11 @@ class CropAndPad(DualTransform):
         border_mode (int):
             OpenCV border mode used for padding. Default: cv2.BORDER_CONSTANT.
 
-        fill (ColorType):
+        fill (tuple[float, ...] | float):
             The constant value to use for padding if border_mode is cv2.BORDER_CONSTANT.
             Default: 0.
 
-        fill_mask (ColorType):
+        fill_mask (tuple[float, ...] | float):
             Same as fill but used for mask padding. Default: 0.
 
         keep_size (bool):
@@ -1492,8 +1489,8 @@ class CropAndPad(DualTransform):
         sample_independently: bool
         interpolation: InterpolationType
         mask_interpolation: InterpolationType
-        fill: ColorType
-        fill_mask: ColorType
+        fill: tuple[float, ...] | float
+        fill_mask: tuple[float, ...] | float
         border_mode: BorderModeType
 
         @model_validator(mode="after")
@@ -1516,8 +1513,8 @@ class CropAndPad(DualTransform):
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
         border_mode: BorderModeType = cv2.BORDER_CONSTANT,
-        fill: ColorType = 0,
-        fill_mask: ColorType = 0,
+        fill: tuple[float, ...] | float = 0,
+        fill_mask: tuple[float, ...] | float = 0,
         p: float = 1.0,
     ):
         super().__init__(p=p)
@@ -1540,7 +1537,7 @@ class CropAndPad(DualTransform):
         img: np.ndarray,
         crop_params: Sequence[int],
         pad_params: Sequence[int],
-        fill: ColorType,
+        fill: tuple[float, ...] | float,
         **params: Any,
     ) -> np.ndarray:
         return fcrops.crop_and_pad(
@@ -1559,7 +1556,7 @@ class CropAndPad(DualTransform):
         mask: np.ndarray,
         crop_params: Sequence[int],
         pad_params: Sequence[int],
-        fill_mask: ColorType,
+        fill_mask: tuple[float, ...] | float,
         **params: Any,
     ) -> np.ndarray:
         return fcrops.crop_and_pad(
@@ -1669,8 +1666,10 @@ class CropAndPad(DualTransform):
         return {
             "crop_params": crop_params or None,
             "pad_params": pad_params or None,
-            "fill": None if pad_params is None else self._get_pad_value(cast(ColorType, self.fill)),
-            "fill_mask": None if pad_params is None else self._get_pad_value(cast(ColorType, self.fill_mask)),
+            "fill": None if pad_params is None else self._get_pad_value(self.fill),
+            "fill_mask": None
+            if pad_params is None
+            else self._get_pad_value(cast(Union[tuple[float, ...], float], self.fill_mask)),
             "result_shape": (result_rows, result_cols),
         }
 
@@ -1717,7 +1716,7 @@ class CropAndPad(DualTransform):
 
     def _get_pad_value(
         self,
-        fill: ColorType,
+        fill: Sequence[float] | float,
     ) -> int | float:
         if isinstance(fill, (list, tuple)):
             if len(fill) == PAIR:

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -266,9 +266,9 @@ class RandomCrop(BaseCropAndPad):
         width: width of the crop.
         pad_if_needed (bool): Whether to pad if crop size exceeds image size. Default: False.
         border_mode (OpenCV flag): OpenCV border mode used for padding. Default: cv2.BORDER_CONSTANT.
-        fill (Sequence[float] | float): Padding value for images if border_mode is
+        fill (tuple[float, ...] | float): Padding value for images if border_mode is
             cv2.BORDER_CONSTANT. Default: 0.
-        fill_mask (Sequence[float] | float): Padding value for masks if border_mode is
+        fill_mask (tuple[float, ...] | float): Padding value for masks if border_mode is
             cv2.BORDER_CONSTANT. Default: 0.
         pad_position (Literal['center', 'top_left', 'top_right', 'bottom_left', 'bottom_right', 'random']):
             Position of padding. Default: 'center'.

--- a/albumentations/augmentations/domain_adaptation/transforms.py
+++ b/albumentations/augmentations/domain_adaptation/transforms.py
@@ -18,7 +18,6 @@ from albumentations.augmentations.utils import read_rgb_image
 from albumentations.core.composition import Compose
 from albumentations.core.pydantic import ZeroOneRangeType, check_range_bounds, nondecreasing
 from albumentations.core.transforms_interface import BaseTransformInitSchema, BasicTransform, ImageOnlyTransform
-from albumentations.core.type_definitions import ScaleFloatType
 
 __all__ = [
     "FDA",
@@ -199,7 +198,7 @@ class FDA(ImageOnlyTransform):
     def __init__(
         self,
         reference_images: Sequence[Any],
-        beta_limit: ScaleFloatType = (0, 0.1),
+        beta_limit: tuple[float, float] | float = (0, 0.1),
         read_fn: Callable[[Any], np.ndarray] = read_rgb_image,
         p: float = 0.5,
     ):
@@ -458,7 +457,7 @@ class TemplateTransform(ImageOnlyTransform):
     def __init__(
         self,
         templates: np.ndarray | list[np.ndarray],
-        img_weight: ScaleFloatType = (0.5, 0.5),
+        img_weight: tuple[float, float] | float = (0.5, 0.5),
         template_transform: Compose | BasicTransform | None = None,
         name: str | None = None,
         p: float = 0.5,

--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -25,12 +25,12 @@ class CoarseDropout(BaseDropout):
     Args:
         num_holes_range (tuple[int, int]): Range (min, max) for the number of rectangular
             regions to drop out. Default: (1, 1)
-        hole_height_range (tuple[Real, Real]): Range (min, max) for the height
+        hole_height_range (tuple[int, int] | tuple[float, float]): Range (min, max) for the height
             of dropout regions. If int, specifies absolute pixel values. If float,
-            interpreted as a fraction of the image height. Default: (8, 8)
-        hole_width_range (tuple[Real, Real]): Range (min, max) for the width
+            interpreted as a fraction of the image height. Default: (0.1, 0.2)
+        hole_width_range (tuple[int, int] | tuple[float, float]): Range (min, max) for the width
             of dropout regions. If int, specifies absolute pixel values. If float,
-            interpreted as a fraction of the image width. Default: (8, 8)
+            interpreted as a fraction of the image width. Default: (0.1, 0.2)
         fill (tuple[float, float] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"]):
             Value for the dropped pixels. Can be:
             - int or float: all channels are filled with this value
@@ -125,14 +125,14 @@ class CoarseDropout(BaseDropout):
     def calculate_hole_dimensions(
         self,
         image_shape: tuple[int, int],
-        height_range: tuple[float, float],
-        width_range: tuple[float, float],
+        height_range: tuple[float, float] | tuple[int, int],
+        width_range: tuple[float, float] | tuple[int, int],
         size: int,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Calculate random hole dimensions based on the provided ranges."""
         height, width = image_shape[:2]
 
-        if isinstance(height_range[0], int):
+        if height_range[1] >= 1:
             min_height = height_range[0]
             max_height = min(height_range[1], height)
 

--- a/albumentations/augmentations/dropout/functional.py
+++ b/albumentations/augmentations/dropout/functional.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import Literal, cast
 
 import cv2
 import numpy as np
@@ -15,7 +15,7 @@ from albucore import (
 
 from albumentations.augmentations.geometric.functional import split_uniform_grid
 from albumentations.augmentations.utils import handle_empty_array
-from albumentations.core.type_definitions import MONO_CHANNEL_DIMENSIONS, ColorType, DropoutFillValue, InpaintMethod
+from albumentations.core.type_definitions import MONO_CHANNEL_DIMENSIONS
 
 __all__ = [
     "calculate_grid_dimensions",
@@ -32,7 +32,7 @@ __all__ = [
 def channel_dropout(
     img: np.ndarray,
     channels_to_drop: int | tuple[int, ...] | np.ndarray,
-    fill_value: ColorType = 0,
+    fill_value: tuple[float, ...] | float = 0,
 ) -> np.ndarray:
     if is_grayscale_image(img):
         msg = "Only one channel. ChannelDropout is not defined."
@@ -83,7 +83,7 @@ def generate_random_fill(
 
 
 @uint8_io
-def apply_inpainting(img: np.ndarray, holes: np.ndarray, method: InpaintMethod) -> np.ndarray:
+def apply_inpainting(img: np.ndarray, holes: np.ndarray, method: Literal["inpaint_telea", "inpaint_ns"]) -> np.ndarray:
     """Apply OpenCV inpainting to fill the holes in the image.
 
     Args:
@@ -160,7 +160,7 @@ def fill_holes_with_random(
 def cutout(
     img: np.ndarray,
     holes: np.ndarray,
-    fill_value: DropoutFillValue,
+    fill_value: tuple[float, ...] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"],
     random_generator: np.random.Generator,
 ) -> np.ndarray:
     """Apply cutout augmentation to the image by cutting out holes and filling them.
@@ -184,7 +184,7 @@ def cutout(
     # Handle inpainting methods
     if isinstance(fill_value, str):
         if fill_value in {"inpaint_telea", "inpaint_ns"}:
-            return apply_inpainting(img, holes, cast(InpaintMethod, fill_value))
+            return apply_inpainting(img, holes, cast(Literal["inpaint_telea", "inpaint_ns"], fill_value))
         if fill_value == "random":
             return fill_holes_with_random(img, holes, random_generator, uniform=False)
         if fill_value == "random_uniform":

--- a/albumentations/augmentations/dropout/grid_dropout.py
+++ b/albumentations/augmentations/dropout/grid_dropout.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from pydantic import AfterValidator, Field
 
 import albumentations.augmentations.dropout.functional as fdropout
 from albumentations.augmentations.dropout.transforms import BaseDropout
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
-from albumentations.core.type_definitions import ColorType, DropoutFillValue
 
 __all__ = ["GridDropout"]
 
@@ -30,7 +29,7 @@ class GridDropout(BaseDropout):
             Default: None. If provided, overrides unit_size_range.
         random_offset (bool): Whether to offset the grid randomly between 0 and (grid unit size - hole size).
             If True, entered shift_xy is ignored and set randomly. Default: True.
-        fill (ColorType | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"]):
+        fill (tuple[float, float] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"]):
             Value for the dropped pixels. Can be:
             - int or float: all channels are filled with this value
             - tuple: tuple of values for each channel
@@ -39,7 +38,7 @@ class GridDropout(BaseDropout):
             - 'inpaint_telea': uses OpenCV Telea inpainting method
             - 'inpaint_ns': uses OpenCV Navier-Stokes inpainting method
             Default: 0
-        fill_mask (ColorType | None): Value for the dropped pixels in mask.
+        fill_mask (tuple[float, float] | float | None): Value for the dropped pixels in mask.
             If None, the mask is not modified. Default: None.
         shift_xy (tuple[int, int]): Offsets of the grid start in x and y directions from (0,0) coordinate.
             Only used when random_offset is False. Default: (0, 0).
@@ -112,8 +111,8 @@ class GridDropout(BaseDropout):
         unit_size_range: tuple[int, int] | None = None,
         holes_number_xy: tuple[int, int] | None = None,
         shift_xy: tuple[int, int] = (0, 0),
-        fill: DropoutFillValue = 0,
-        fill_mask: ColorType | None = None,
+        fill: tuple[float, ...] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"] = 0,
+        fill_mask: tuple[float, ...] | float | None = None,
         p: float = 0.5,
     ):
         super().__init__(fill=fill, fill_mask=fill_mask, p=p)

--- a/albumentations/augmentations/dropout/mask_dropout.py
+++ b/albumentations/augmentations/dropout/mask_dropout.py
@@ -10,7 +10,7 @@ from albumentations.core.bbox_utils import BboxProcessor, denormalize_bboxes, no
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.pydantic import OnePlusIntRangeType
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
-from albumentations.core.type_definitions import ALL_TARGETS, ScaleIntType
+from albumentations.core.type_definitions import ALL_TARGETS
 
 __all__ = ["MaskDropout"]
 
@@ -25,8 +25,11 @@ class MaskDropout(DualTransform):
     Args:
         max_objects (int | tuple[int, int]): Maximum number of objects to dropout. If a single int is provided,
             it's treated as the upper bound. If a tuple of two ints is provided, it's treated as a range [min, max].
-        fill (float | str | Literal["inpaint"]): Value to fill the dropped out regions in the image.
-            If set to 'inpaint', it applies inpainting to the dropped out regions (works only for 3-channel images).
+        fill (float | Literal["inpaint_telea", "inpaint_ns"]): Value to fill dropped out regions in the image.
+            Can be one of:
+            - float: Constant value to fill the regions (e.g., 0 for black, 255 for white)
+            - "inpaint_telea": Use Telea inpainting algorithm (for 3-channel images only)
+            - "inpaint_ns": Use Navier-Stokes inpainting algorithm (for 3-channel images only)
         fill_mask (float | int): Value to fill the dropped out regions in the mask.
         min_area (float): Minimum area (in pixels) of a bounding box that must remain visible after dropout to be kept.
             Only applicable if bounding box augmentation is enabled. Default: 0.0
@@ -78,9 +81,9 @@ class MaskDropout(DualTransform):
 
     def __init__(
         self,
-        max_objects: ScaleIntType = (1, 1),
-        fill: float | Literal["inpaint"] = 0,
-        fill_mask: float = 0,
+        max_objects: tuple[int, int] | int = (1, 1),
+        fill: tuple[float, ...] | float | Literal["inpaint_telea", "inpaint_ns"] = 0,
+        fill_mask: tuple[float, ...] | float | None = None,
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -117,11 +120,11 @@ class MaskDropout(DualTransform):
         if dropout_mask is None:
             return img
 
-        if self.fill == "inpaint":
+        if self.fill in {"inpaint_telea", "inpaint_ns"}:
             dropout_mask = dropout_mask.astype(np.uint8)
             _, _, width, height = cv2.boundingRect(dropout_mask)
             radius = min(3, max(width, height) // 2)
-            return cv2.inpaint(img, dropout_mask, radius, cv2.INPAINT_NS)
+            return cv2.inpaint(img, dropout_mask, radius, cast(Literal["inpaint_telea", "inpaint_ns"], self.fill))
 
         img = img.copy()
         img[dropout_mask] = self.fill

--- a/albumentations/augmentations/dropout/mask_dropout.py
+++ b/albumentations/augmentations/dropout/mask_dropout.py
@@ -76,7 +76,7 @@ class MaskDropout(DualTransform):
     class InitSchema(BaseTransformInitSchema):
         max_objects: OnePlusIntRangeType
 
-        fill: float | Literal["inpaint"]
+        fill: float | Literal["inpaint_telea", "inpaint_ns"]
         fill_mask: float
 
     def __init__(

--- a/albumentations/augmentations/dropout/mask_dropout.py
+++ b/albumentations/augmentations/dropout/mask_dropout.py
@@ -30,7 +30,7 @@ class MaskDropout(DualTransform):
             - float: Constant value to fill the regions (e.g., 0 for black, 255 for white)
             - "inpaint_telea": Use Telea inpainting algorithm (for 3-channel images only)
             - "inpaint_ns": Use Navier-Stokes inpainting algorithm (for 3-channel images only)
-        fill_mask (float | int): Value to fill the dropped out regions in the mask.
+        fill_mask (float): Value to fill the dropped out regions in the mask.
         min_area (float): Minimum area (in pixels) of a bounding box that must remain visible after dropout to be kept.
             Only applicable if bounding box augmentation is enabled. Default: 0.0
         min_visibility (float): Minimum visibility ratio (visible area / total area) of a bounding box after dropout
@@ -82,8 +82,8 @@ class MaskDropout(DualTransform):
     def __init__(
         self,
         max_objects: tuple[int, int] | int = (1, 1),
-        fill: tuple[float, ...] | float | Literal["inpaint_telea", "inpaint_ns"] = 0,
-        fill_mask: tuple[float, ...] | float | None = None,
+        fill: float | Literal["inpaint_telea", "inpaint_ns"] = 0,
+        fill_mask: float | None = None,
         p: float = 0.5,
     ):
         super().__init__(p=p)

--- a/albumentations/augmentations/dropout/mask_dropout.py
+++ b/albumentations/augmentations/dropout/mask_dropout.py
@@ -83,7 +83,7 @@ class MaskDropout(DualTransform):
         self,
         max_objects: tuple[int, int] | int = (1, 1),
         fill: float | Literal["inpaint_telea", "inpaint_ns"] = 0,
-        fill_mask: float | None = None,
+        fill_mask: float = 0,
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -132,7 +132,7 @@ class MaskDropout(DualTransform):
         return img
 
     def apply_to_mask(self, mask: np.ndarray, dropout_mask: np.ndarray | None, **params: Any) -> np.ndarray:
-        if dropout_mask is None:
+        if dropout_mask is None or self.fill_mask is None:
             return mask
 
         mask = mask.copy()

--- a/albumentations/augmentations/dropout/transforms.py
+++ b/albumentations/augmentations/dropout/transforms.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import numpy as np
 from albucore import get_num_channels
@@ -13,7 +13,7 @@ from albumentations.augmentations.dropout.functional import (
 from albumentations.core.bbox_utils import BboxProcessor, denormalize_bboxes, normalize_bboxes
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
-from albumentations.core.type_definitions import ALL_TARGETS, ColorType, DropoutFillValue, Targets
+from albumentations.core.type_definitions import ALL_TARGETS, Targets
 
 
 class BaseDropout(DualTransform):
@@ -23,9 +23,9 @@ class BaseDropout(DualTransform):
     including applying cutouts to images and masks.
 
     Args:
-        fill (ColorType | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"]):
+        fill (tuple[float, ...] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"]):
             Value to fill dropped regions.
-        fill_mask (ColorType | None): Value to fill
+        fill_mask (tuple[float, ...] | float | None): Value to fill
             dropped regions in the mask. If None, the mask is not modified.
         p (float): Probability of applying the transform.
 
@@ -39,17 +39,17 @@ class BaseDropout(DualTransform):
     _targets: tuple[Targets, ...] | Targets = ALL_TARGETS
 
     class InitSchema(BaseTransformInitSchema):
-        fill: DropoutFillValue
-        fill_mask: ColorType | None
+        fill: tuple[float, ...] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"]
+        fill_mask: tuple[float, ...] | float | None
 
     def __init__(
         self,
-        fill: DropoutFillValue,
-        fill_mask: ColorType | None,
+        fill: tuple[float, ...] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"],
+        fill_mask: tuple[float, ...] | float | None,
         p: float,
     ):
         super().__init__(p=p)
-        self.fill = fill
+        self.fill = fill  # type: ignore[assignment]
         self.fill_mask = fill_mask
 
     def apply(self, img: np.ndarray, holes: np.ndarray, seed: int, **params: Any) -> np.ndarray:

--- a/albumentations/augmentations/dropout/xy_masking.py
+++ b/albumentations/augmentations/dropout/xy_masking.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import numpy as np
 from pydantic import model_validator
@@ -9,7 +9,6 @@ from typing_extensions import Self
 from albumentations.augmentations.dropout.transforms import BaseDropout
 from albumentations.core.pydantic import NonNegativeIntRangeType
 from albumentations.core.transforms_interface import BaseTransformInitSchema
-from albumentations.core.type_definitions import ColorType, DropoutFillValue, ScaleIntType
 
 __all__ = ["XYMasking"]
 
@@ -36,7 +35,7 @@ class XYMasking(BaseDropout):
             while a tuple (min, max) allows for variable-height masks, chosen randomly
             within the specified range for each mask. This flexibility facilitates creating masks of various
             sizes in the vertical direction.
-        fill (ColorType | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"]):
+        fill (tuple[float, float] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"]):
             Value for the dropped pixels. Can be:
             - int or float: all channels are filled with this value
             - tuple: tuple of values for each channel
@@ -45,7 +44,7 @@ class XYMasking(BaseDropout):
             - 'inpaint_telea': uses OpenCV Telea inpainting method
             - 'inpaint_ns': uses OpenCV Navier-Stokes inpainting method
             Default: 0
-        fill_mask (ColorType | None): Fill value for dropout regions in the mask.
+        fill_mask (tuple[float, float] | float | None): Fill value for dropout regions in the mask.
             If None, mask regions corresponding to image dropouts are unchanged. Default: None
         p (float): Probability of applying the transform. Defaults to 0.5.
 
@@ -64,8 +63,8 @@ class XYMasking(BaseDropout):
         mask_x_length: NonNegativeIntRangeType
         mask_y_length: NonNegativeIntRangeType
 
-        fill: DropoutFillValue
-        fill_mask: ColorType | None
+        fill: tuple[float, ...] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"]
+        fill_mask: tuple[float, ...] | float | None
 
         @model_validator(mode="after")
         def check_mask_length(self) -> Self:
@@ -82,12 +81,12 @@ class XYMasking(BaseDropout):
 
     def __init__(
         self,
-        num_masks_x: ScaleIntType = 0,
-        num_masks_y: ScaleIntType = 0,
-        mask_x_length: ScaleIntType = 0,
-        mask_y_length: ScaleIntType = 0,
-        fill: DropoutFillValue = 0,
-        fill_mask: ColorType | None = None,
+        num_masks_x: tuple[int, int] | int = 0,
+        num_masks_y: tuple[int, int] | int = 0,
+        mask_x_length: tuple[int, int] | int = 0,
+        mask_y_length: tuple[int, int] | int = 0,
+        fill: tuple[float, ...] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"] = 0,
+        fill_mask: tuple[float, ...] | float | None = None,
         p: float = 0.5,
     ):
         super().__init__(p=p, fill=fill, fill_mask=fill_mask)

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -11,7 +11,7 @@ from typing_extensions import Self
 
 from albumentations.core.pydantic import InterpolationType
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
-from albumentations.core.type_definitions import ALL_TARGETS, ScaleFloatType
+from albumentations.core.type_definitions import ALL_TARGETS
 from albumentations.core.utils import to_tuple
 
 from . import functional as fgeometric
@@ -67,18 +67,18 @@ class RandomScale(DualTransform):
     _targets = ALL_TARGETS
 
     class InitSchema(BaseTransformInitSchema):
-        scale_limit: ScaleFloatType
+        scale_limit: tuple[float, float] | float
         interpolation: InterpolationType
         mask_interpolation: InterpolationType
 
         @field_validator("scale_limit")
         @classmethod
-        def check_scale_limit(cls, v: ScaleFloatType) -> tuple[float, float]:
+        def check_scale_limit(cls, v: tuple[float, float] | float) -> tuple[float, float]:
             return to_tuple(v, bias=1.0)
 
     def __init__(
         self,
-        scale_limit: ScaleFloatType = (-0.1, 0.1),
+        scale_limit: tuple[float, float] | float = (-0.1, 0.1),
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
         p: float = 0.5,

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -18,11 +18,7 @@ from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     DualTransform,
 )
-from albumentations.core.type_definitions import (
-    ALL_TARGETS,
-    ColorType,
-    ScaleFloatType,
-)
+from albumentations.core.type_definitions import ALL_TARGETS
 
 from . import functional as fgeometric
 
@@ -121,8 +117,8 @@ class RotateInitSchema(BaseTransformInitSchema):
 
     border_mode: BorderModeType
 
-    fill: ColorType | None
-    fill_mask: ColorType | None
+    fill: tuple[float, ...] | float
+    fill_mask: tuple[float, ...] | float | None
 
 
 class Rotate(DualTransform):
@@ -137,10 +133,10 @@ class Rotate(DualTransform):
         border_mode (OpenCV flag): Flag that is used to specify the pixel extrapolation method. Should be one of:
             cv2.BORDER_CONSTANT, cv2.BORDER_REPLICATE, cv2.BORDER_REFLECT, cv2.BORDER_WRAP, cv2.BORDER_REFLECT_101.
             Default: cv2.BORDER_CONSTANT
-        fill (ColorType): Padding value if border_mode is cv2.BORDER_CONSTANT.
-        fill_mask (ColorType): Padding value if border_mode is cv2.BORDER_CONSTANT applied for masks.
-        rotate_method (str): Method to rotate bounding boxes. Should be 'largest_box' or 'ellipse'.
-            Default: 'largest_box'
+        fill (tuple[float, ...] | float): Padding value if border_mode is cv2.BORDER_CONSTANT.
+        fill_mask (tuple[float, ...] | float): Padding value if border_mode is cv2.BORDER_CONSTANT applied for masks.
+        rotate_method (Literal["largest_box", "ellipse"]): Method to rotate bounding boxes.
+            Should be 'largest_box' or 'ellipse'. Default: 'largest_box'
         crop_border (bool): Whether to crop border after rotation. If True, the output image size might differ
             from the input. Default: False
         mask_interpolation (OpenCV flag): flag that is used to specify the interpolation algorithm for mask.
@@ -191,19 +187,19 @@ class Rotate(DualTransform):
         rotate_method: Literal["largest_box", "ellipse"]
         crop_border: bool
 
-        fill: ColorType
-        fill_mask: ColorType
+        fill: tuple[float, ...] | float
+        fill_mask: tuple[float, ...] | float
 
     def __init__(
         self,
-        limit: ScaleFloatType = (-90, 90),
+        limit: tuple[float, float] | float = (-90, 90),
         interpolation: int = cv2.INTER_LINEAR,
         border_mode: int = cv2.BORDER_CONSTANT,
         rotate_method: Literal["largest_box", "ellipse"] = "largest_box",
         crop_border: bool = False,
         mask_interpolation: int = cv2.INTER_NEAREST,
-        fill: ColorType = 0,
-        fill_mask: ColorType = 0,
+        fill: tuple[float, ...] | float = 0,
+        fill_mask: tuple[float, ...] | float = 0,
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -367,9 +363,9 @@ class Rotate(DualTransform):
         center = fgeometric.center(params["shape"][:2])
         bbox_center = fgeometric.center_bbox(params["shape"][:2])
 
-        translate: fgeometric.XYInt = {"x": 0, "y": 0}
-        shear: fgeometric.XYFloat = {"x": 0, "y": 0}
-        scale: fgeometric.XYFloat = {"x": 1, "y": 1}
+        translate: dict[str, int] = {"x": 0, "y": 0}
+        shear: dict[str, float] = {"x": 0, "y": 0}
+        scale: dict[str, float] = {"x": 1, "y": 1}
         rotate = angle
 
         matrix = fgeometric.create_affine_transformation_matrix(
@@ -420,8 +416,8 @@ class SafeRotate(Affine):
         border_mode (OpenCV flag): Flag that is used to specify the pixel extrapolation method. Should be one of:
             cv2.BORDER_CONSTANT, cv2.BORDER_REPLICATE, cv2.BORDER_REFLECT, cv2.BORDER_WRAP, cv2.BORDER_REFLECT_101.
             Default: cv2.BORDER_REFLECT_101
-        fill (ColorType): Padding value if border_mode is cv2.BORDER_CONSTANT.
-        fill_mask (ColorType): Padding value if border_mode is cv2.BORDER_CONSTANT applied
+        fill (tuple[float, float] | float): Padding value if border_mode is cv2.BORDER_CONSTANT.
+        fill_mask (tuple[float, float] | float): Padding value if border_mode is cv2.BORDER_CONSTANT applied
             for masks.
         rotate_method (Literal["largest_box", "ellipse"]): Method to rotate bounding boxes.
             Should be 'largest_box' or 'ellipse'. Default: 'largest_box'
@@ -478,13 +474,13 @@ class SafeRotate(Affine):
 
     def __init__(
         self,
-        limit: ScaleFloatType = (-90, 90),
+        limit: tuple[float, float] | float = (-90, 90),
         interpolation: int = cv2.INTER_LINEAR,
         border_mode: int = cv2.BORDER_CONSTANT,
         rotate_method: Literal["largest_box", "ellipse"] = "largest_box",
         mask_interpolation: int = cv2.INTER_NEAREST,
-        fill: ColorType = 0,
-        fill_mask: ColorType = 0,
+        fill: tuple[float, ...] | float = 0,
+        fill_mask: tuple[float, ...] | float = 0,
         p: float = 0.5,
     ):
         super().__init__(

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -766,7 +766,7 @@ class Affine(DualTransform):
         self,
         scale: tuple[float, float] | float | dict[str, float | tuple[float, float]] = (1.0, 1.0),
         translate_percent: tuple[float, float] | float | dict[str, float | tuple[float, float]] | None = None,
-        translate_px: tuple[float, float] | float | dict[str, float | tuple[float, float]] | None = None,
+        translate_px: tuple[int, int] | int | dict[str, int | tuple[int, int]] | None = None,
         rotate: tuple[float, float] | float = 0.0,
         shear: tuple[float, float] | float | dict[str, float | tuple[float, float]] = (0.0, 0.0),
         interpolation: int = cv2.INTER_LINEAR,

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -999,8 +999,8 @@ class Affine(DualTransform):
         height, width = image_shape[:2]
         if self.translate_px is not None:
             return {
-                "x": self.py_random.randint(*self.translate_px["x"]),
-                "y": self.py_random.randint(*self.translate_px["y"]),
+                "x": self.py_random.randint(int(self.translate_px["x"][0]), int(self.translate_px["x"][1])),
+                "y": self.py_random.randint(int(self.translate_px["y"][0]), int(self.translate_px["y"][1])),
             }
         if self.translate_percent is not None:
             translate = {key: self.py_random.uniform(*value) for key, value in self.translate_percent.items()}

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -37,12 +37,6 @@ from albumentations.core.transforms_interface import (
 from albumentations.core.type_definitions import (
     ALL_TARGETS,
     BIG_INTEGER,
-    ColorType,
-    D4Type,
-    PositionType,
-    ScaleFloatType,
-    ScaleIntType,
-    ScaleType,
     d4_group_elements,
 )
 from albumentations.core.utils import to_tuple
@@ -366,9 +360,9 @@ class Perspective(DualTransform):
             Default: True.
         border_mode (OpenCV flag): OpenCV border mode used for padding.
             Default: cv2.BORDER_CONSTANT.
-        fill (ColorType): Padding value if border_mode is cv2.BORDER_CONSTANT.
+        fill (tuple[float, ...] | float): Padding value if border_mode is cv2.BORDER_CONSTANT.
             Default: 0.
-        fill_mask (ColorType): Padding value for mask if border_mode is
+        fill_mask (tuple[float, ...] | float): Padding value for mask if border_mode is
             cv2.BORDER_CONSTANT. Default: 0.
         fit_output (bool): If True, the image plane size and position will be adjusted to still capture
             the whole image after perspective transformation. This is followed by image resizing if keep_size is set
@@ -417,20 +411,20 @@ class Perspective(DualTransform):
         fit_output: bool
         interpolation: InterpolationType
         mask_interpolation: InterpolationType
-        fill: ColorType
-        fill_mask: ColorType
+        fill: tuple[float, ...] | float
+        fill_mask: tuple[float, ...] | float
         border_mode: BorderModeType
 
     def __init__(
         self,
-        scale: ScaleFloatType = (0.05, 0.1),
+        scale: tuple[float, float] | float = (0.05, 0.1),
         keep_size: bool = True,
         fit_output: bool = False,
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
         border_mode: int = cv2.BORDER_CONSTANT,
-        fill: ColorType = 0,
-        fill_mask: ColorType = 0,
+        fill: tuple[float, ...] | float = 0,
+        fill_mask: tuple[float, ...] | float = 0,
         p: float = 0.5,
     ):
         super().__init__(p)
@@ -647,11 +641,11 @@ class Affine(DualTransform):
                   *independently* per axis, resulting in samples that differ between the axes.
         interpolation (int): OpenCV interpolation flag.
         mask_interpolation (int): OpenCV interpolation flag.
-        fill (ColorType): The constant value to use when filling in newly created pixels.
+        fill (tuple[float, ...] | float): The constant value to use when filling in newly created pixels.
             (E.g. translating by 1px to the right will create a new 1px-wide column of pixels
             on the left of the image).
             The value is only used when `mode=constant`. The expected value range is ``[0, 255]`` for ``uint8`` images.
-        fill_mask (ColorType): Same as fill but only for masks.
+        fill_mask (tuple[float, ...] | float): Same as fill but only for masks.
         border_mode (int): OpenCV border flag.
         fit_output (bool): If True, the image plane size and position will be adjusted to tightly capture
             the whole image after affine transformation (`translate_percent` and `translate_px` are ignored).
@@ -687,16 +681,16 @@ class Affine(DualTransform):
     _targets = ALL_TARGETS
 
     class InitSchema(BaseTransformInitSchema):
-        scale: ScaleFloatType | fgeometric.XYFloatScale
-        translate_percent: ScaleFloatType | fgeometric.XYFloatScale | None
-        translate_px: ScaleIntType | fgeometric.XYIntScale | None
-        rotate: ScaleFloatType
-        shear: ScaleFloatType | fgeometric.XYFloatScale
+        scale: tuple[float, float] | float | dict[str, float | tuple[float, float]]
+        translate_percent: tuple[float, float] | float | dict[str, float | tuple[float, float]] | None
+        translate_px: tuple[float, float] | float | dict[str, float | tuple[float, float]] | None
+        rotate: tuple[float, float] | float
+        shear: tuple[float, float] | float | dict[str, float | tuple[float, float]]
         interpolation: InterpolationType
         mask_interpolation: InterpolationType
 
-        fill: ColorType
-        fill_mask: ColorType
+        fill: tuple[float, ...] | float
+        fill_mask: tuple[float, ...] | float
         border_mode: BorderModeType
 
         fit_output: bool
@@ -708,19 +702,16 @@ class Affine(DualTransform):
         @classmethod
         def process_shear(
             cls,
-            value: ScaleFloatType | fgeometric.XYFloatScale,
+            value: tuple[float, float] | float | dict[str, float | tuple[float, float]],
             info: ValidationInfo,
-        ) -> fgeometric.XYFloatDict:
-            return cast(
-                fgeometric.XYFloatDict,
-                cls._handle_dict_arg(value, info.field_name),
-            )
+        ) -> dict[str, tuple[float, float]]:
+            return cls._handle_dict_arg(value, info.field_name)
 
         @field_validator("rotate")
         @classmethod
         def process_rotate(
             cls,
-            value: ScaleFloatType,
+            value: tuple[float, float] | float,
         ) -> tuple[float, float]:
             return to_tuple(value, value)
 
@@ -751,10 +742,16 @@ class Affine(DualTransform):
 
         @staticmethod
         def _handle_dict_arg(
-            val: ScaleType | fgeometric.XYFloatScale | fgeometric.XYIntScale,
+            val: tuple[float, float]
+            | dict[str, float | tuple[float, float]]
+            | float
+            | tuple[int, int]
+            | dict[str, int | tuple[int, int]],
             name: str | None,
             default: float = 1.0,
-        ) -> dict[str, Any]:
+        ) -> dict[str, tuple[float, float]]:
+            if isinstance(val, float):
+                return {"x": (val, val), "y": (val, val)}
             if isinstance(val, dict):
                 if "x" not in val and "y" not in val:
                     raise ValueError(
@@ -762,16 +759,16 @@ class Affine(DualTransform):
                     )
                 x = val.get("x", default)
                 y = val.get("y", default)
-                return {"x": to_tuple(x, x), "y": to_tuple(y, y)}  # type: ignore[arg-type]
+                return {"x": to_tuple(x, x), "y": to_tuple(y, y)}
             return {"x": to_tuple(val, val), "y": to_tuple(val, val)}
 
     def __init__(
         self,
-        scale: ScaleFloatType | fgeometric.XYFloatScale = 1,
-        translate_percent: ScaleFloatType | fgeometric.XYFloatScale | None = None,
-        translate_px: ScaleIntType | fgeometric.XYIntScale | None = None,
-        rotate: ScaleFloatType = 0,
-        shear: ScaleFloatType | fgeometric.XYFloatScale = 0,
+        scale: tuple[float, float] | float | dict[str, float | tuple[float, float]] = (1.0, 1.0),
+        translate_percent: tuple[float, float] | float | dict[str, float | tuple[float, float]] | None = None,
+        translate_px: tuple[float, float] | float | dict[str, float | tuple[float, float]] | None = None,
+        rotate: tuple[float, float] | float = 0.0,
+        shear: tuple[float, float] | float | dict[str, float | tuple[float, float]] = (0.0, 0.0),
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
         fit_output: bool = False,
@@ -779,8 +776,8 @@ class Affine(DualTransform):
         rotate_method: Literal["largest_box", "ellipse"] = "largest_box",
         balanced_scale: bool = False,
         border_mode: int = cv2.BORDER_CONSTANT,
-        fill: ColorType = 0,
-        fill_mask: ColorType = 0,
+        fill: tuple[float, ...] | float = 0,
+        fill_mask: tuple[float, ...] | float = 0,
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -790,12 +787,12 @@ class Affine(DualTransform):
         self.fill = fill
         self.fill_mask = fill_mask
         self.border_mode = border_mode
-        self.scale = cast(fgeometric.XYFloatDict, scale)
-        self.translate_percent = cast(fgeometric.XYFloatDict, translate_percent)
-        self.translate_px = cast(fgeometric.XYIntDict, translate_px)
+        self.scale = cast(dict[str, tuple[float, float]], scale)
+        self.translate_percent = cast(dict[str, tuple[float, float]], translate_percent)
+        self.translate_px = cast(dict[str, tuple[int, int]], translate_px)
         self.rotate = cast(tuple[float, float], rotate)
         self.fit_output = fit_output
-        self.shear = cast(fgeometric.XYFloatDict, shear)
+        self.shear = cast(dict[str, tuple[float, float]], shear)
         self.keep_ratio = keep_ratio
         self.rotate_method = rotate_method
         self.balanced_scale = balanced_scale
@@ -875,7 +872,7 @@ class Affine(DualTransform):
         self,
         keypoints: np.ndarray,
         matrix: np.ndarray,
-        scale: fgeometric.XYFloat,
+        scale: dict[str, float],
         **params: Any,
     ) -> np.ndarray:
         return fgeometric.keypoints_affine(
@@ -904,11 +901,11 @@ class Affine(DualTransform):
 
     @staticmethod
     def get_scale(
-        scale: fgeometric.XYFloatDict,
+        scale: dict[str, tuple[float, float]],
         keep_ratio: bool,
         balanced_scale: bool,
         random_state: random.Random,
-    ) -> fgeometric.XYFloat:
+    ) -> dict[str, float]:
         result_scale = {}
         for key, value in scale.items():
             if isinstance(value, (int, float)):
@@ -941,7 +938,7 @@ class Affine(DualTransform):
         if keep_ratio:
             result_scale["y"] = result_scale["x"]
 
-        return cast(fgeometric.XYFloat, result_scale)
+        return result_scale
 
     def get_params_dependent_on_data(
         self,
@@ -998,7 +995,7 @@ class Affine(DualTransform):
             "output_shape": output_shape,
         }
 
-    def _get_translate_params(self, image_shape: tuple[int, int]) -> fgeometric.XYInt:
+    def _get_translate_params(self, image_shape: tuple[int, int]) -> dict[str, int]:
         height, width = image_shape[:2]
         if self.translate_px is not None:
             return {
@@ -1008,12 +1005,12 @@ class Affine(DualTransform):
         if self.translate_percent is not None:
             translate = {key: self.py_random.uniform(*value) for key, value in self.translate_percent.items()}
             return cast(
-                fgeometric.XYInt,
+                dict[str, int],
                 {"x": int(translate["x"] * width), "y": int(translate["y"] * height)},
             )
-        return cast(fgeometric.XYInt, {"x": 0, "y": 0})
+        return cast(dict[str, int], {"x": 0, "y": 0})
 
-    def _get_shear_params(self) -> fgeometric.XYFloat:
+    def _get_shear_params(self) -> dict[str, float]:
         return {
             "x": -self.py_random.uniform(*self.shear["x"]),
             "y": -self.py_random.uniform(*self.shear["y"]),
@@ -1039,8 +1036,8 @@ class ShiftScaleRotate(Affine):
         border_mode (OpenCV flag): flag that is used to specify the pixel extrapolation method. Should be one of:
             cv2.BORDER_CONSTANT, cv2.BORDER_REPLICATE, cv2.BORDER_REFLECT, cv2.BORDER_WRAP, cv2.BORDER_REFLECT_101.
             Default: cv2.BORDER_CONSTANT
-        fill (ColorType): padding value if border_mode is cv2.BORDER_CONSTANT.
-        fill_mask (ColorType): padding value if border_mode is cv2.BORDER_CONSTANT applied for masks.
+        fill (tuple[float, ...] | float): padding value if border_mode is cv2.BORDER_CONSTANT.
+        fill_mask (tuple[float, ...] | float): padding value if border_mode is cv2.BORDER_CONSTANT applied for masks.
         shift_limit_x ((float, float) or float): shift factor range for width. If it is set then this value
             instead of shift_limit will be used for shifting width.  If shift_limit_x is a single float value,
             the range will be (-shift_limit_x, shift_limit_x). Absolute values for lower and upper bounds should lie in
@@ -1073,11 +1070,11 @@ class ShiftScaleRotate(Affine):
         interpolation: InterpolationType
         border_mode: BorderModeType
 
-        fill: ColorType = 0
-        fill_mask: ColorType = 0
+        fill: tuple[float, ...] | float = 0
+        fill_mask: tuple[float, ...] | float = 0
 
-        shift_limit_x: ScaleFloatType | None
-        shift_limit_y: ScaleFloatType | None
+        shift_limit_x: tuple[float, float] | float | None
+        shift_limit_y: tuple[float, float] | float | None
         rotate_method: Literal["largest_box", "ellipse"]
         mask_interpolation: InterpolationType
 
@@ -1099,9 +1096,9 @@ class ShiftScaleRotate(Affine):
         @classmethod
         def check_scale_limit(
             cls,
-            value: ScaleFloatType,
+            value: tuple[float, float] | float,
             info: ValidationInfo,
-        ) -> ScaleFloatType:
+        ) -> tuple[float, float]:
             bounds = 0, float("inf")
             result = to_tuple(value, bias=1.0)
             check_range(result, *bounds, str(info.field_name))
@@ -1109,17 +1106,17 @@ class ShiftScaleRotate(Affine):
 
     def __init__(
         self,
-        shift_limit: ScaleFloatType = (-0.0625, 0.0625),
-        scale_limit: ScaleFloatType = (-0.1, 0.1),
-        rotate_limit: ScaleFloatType = (-45, 45),
+        shift_limit: tuple[float, float] | float = (-0.0625, 0.0625),
+        scale_limit: tuple[float, float] | float = (-0.1, 0.1),
+        rotate_limit: tuple[float, float] | float = (-45, 45),
         interpolation: int = cv2.INTER_LINEAR,
         border_mode: int = cv2.BORDER_CONSTANT,
-        shift_limit_x: ScaleFloatType | None = None,
-        shift_limit_y: ScaleFloatType | None = None,
+        shift_limit_x: tuple[float, float] | float | None = None,
+        shift_limit_y: tuple[float, float] | float | None = None,
         rotate_method: Literal["largest_box", "ellipse"] = "largest_box",
         mask_interpolation: InterpolationType = cv2.INTER_NEAREST,
-        fill: ColorType = 0,
-        fill_mask: ColorType = 0,
+        fill: tuple[float, ...] | float = 0,
+        fill_mask: tuple[float, ...] | float = 0,
         p: float = 0.5,
     ):
         shift_limit_x = cast(tuple[float, float], shift_limit_x)
@@ -1231,8 +1228,8 @@ class PiecewiseAffine(BaseDistortion):
 
     class InitSchema(BaseTransformInitSchema):
         scale: NonNegativeFloatRangeType
-        nb_rows: ScaleIntType
-        nb_cols: ScaleIntType
+        nb_rows: tuple[int, int] | int
+        nb_cols: tuple[int, int] | int
         interpolation: InterpolationType
         mask_interpolation: InterpolationType
         absolute_scale: bool
@@ -1242,9 +1239,9 @@ class PiecewiseAffine(BaseDistortion):
         @classmethod
         def process_range(
             cls,
-            value: ScaleFloatType,
+            value: tuple[int, int] | int,
             info: ValidationInfo,
-        ) -> tuple[float, float]:
+        ) -> tuple[int, int]:
             bounds = 2, BIG_INTEGER
             result = to_tuple(value, value)
             check_range(result, *bounds, info.field_name)
@@ -1252,9 +1249,9 @@ class PiecewiseAffine(BaseDistortion):
 
     def __init__(
         self,
-        scale: ScaleFloatType = (0.03, 0.05),
-        nb_rows: ScaleIntType = (4, 4),
-        nb_cols: ScaleIntType = (4, 4),
+        scale: tuple[float, float] | float = (0.03, 0.05),
+        nb_rows: tuple[int, int] | int = (4, 4),
+        nb_cols: tuple[int, int] | int = (4, 4),
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
         absolute_scale: bool = False,
@@ -1569,7 +1566,7 @@ class OpticalDistortion(BaseDistortion):
 
     def __init__(
         self,
-        distort_limit: ScaleFloatType = (-0.05, 0.05),
+        distort_limit: tuple[float, float] | float = (-0.05, 0.05),
         interpolation: int = cv2.INTER_LINEAR,
         mask_interpolation: int = cv2.INTER_NEAREST,
         mode: Literal["camera", "fisheye"] = "camera",
@@ -1693,7 +1690,7 @@ class GridDistortion(BaseDistortion):
     def __init__(
         self,
         num_steps: int = 5,
-        distort_limit: ScaleFloatType = (-0.3, 0.3),
+        distort_limit: tuple[float, float] | float = (-0.3, 0.3),
         interpolation: int = cv2.INTER_LINEAR,
         normalized: bool = True,
         mask_interpolation: int = cv2.INTER_NEAREST,
@@ -1811,7 +1808,7 @@ class D4(DualTransform):
     def apply(
         self,
         img: np.ndarray,
-        group_element: D4Type,
+        group_element: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"],
         **params: Any,
     ) -> np.ndarray:
         return fgeometric.d4(img, group_element)
@@ -1819,7 +1816,7 @@ class D4(DualTransform):
     def apply_to_bboxes(
         self,
         bboxes: np.ndarray,
-        group_element: D4Type,
+        group_element: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"],
         **params: Any,
     ) -> np.ndarray:
         return fgeometric.bboxes_d4(bboxes, group_element)
@@ -1827,7 +1824,7 @@ class D4(DualTransform):
     def apply_to_keypoints(
         self,
         keypoints: np.ndarray,
-        group_element: D4Type,
+        group_element: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"],
         **params: Any,
     ) -> np.ndarray:
         return fgeometric.keypoints_d4(keypoints, group_element, params["shape"])
@@ -1848,7 +1845,7 @@ class D4(DualTransform):
     def apply_to_mask3d(self, mask3d: np.ndarray, **params: Any) -> np.ndarray:
         return self.apply(mask3d, **params)
 
-    def get_params(self) -> dict[str, D4Type]:
+    def get_params(self) -> dict[str, Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]]:
         return {
             "group_element": self.random_generator.choice(d4_group_elements),
         }
@@ -2171,8 +2168,8 @@ class Pad(DualTransform):
             * int - pad all sides by this value
             * tuple[int, int] - (pad_x, pad_y) to pad left/right by pad_x and top/bottom by pad_y
             * tuple[int, int, int, int] - (left, top, right, bottom) specific padding per side
-        fill (ColorType): Padding value if border_mode is cv2.BORDER_CONSTANT
-        fill_mask (ColorType): Padding value for mask if border_mode is cv2.BORDER_CONSTANT
+        fill (tuple[float, ...] | float): Padding value if border_mode is cv2.BORDER_CONSTANT
+        fill_mask (tuple[float, ...] | float): Padding value for mask if border_mode is cv2.BORDER_CONSTANT
         border_mode (OpenCV flag): OpenCV border mode
         p (float): probability of applying the transform. Default: 1.0.
 
@@ -2190,15 +2187,15 @@ class Pad(DualTransform):
 
     class InitSchema(BaseTransformInitSchema):
         padding: int | tuple[int, int] | tuple[int, int, int, int]
-        fill: ColorType
-        fill_mask: ColorType
+        fill: tuple[float, ...] | float
+        fill_mask: tuple[float, ...] | float
         border_mode: BorderModeType
 
     def __init__(
         self,
         padding: int | tuple[int, int] | tuple[int, int, int, int] = 0,
-        fill: ColorType = 0,
-        fill_mask: ColorType = 0,
+        fill: tuple[float, ...] | float = 0,
+        fill_mask: tuple[float, ...] | float = 0,
         border_mode: BorderModeType = cv2.BORDER_CONSTANT,
         p: float = 1.0,
     ):
@@ -2349,9 +2346,9 @@ class PadIfNeeded(Pad):
             Position where the image is to be placed after padding. Default is 'center'.
         border_mode (int): Specifies the border mode to use if padding is required.
             The default is `cv2.BORDER_CONSTANT`.
-        fill (ColorType | None): Value to fill the border pixels if the border mode is `cv2.BORDER_CONSTANT`.
-            Default is None.
-        fill_mask (ColorType | None): Similar to `fill` but used for padding masks. Default is None.
+        fill (tuple[float, ...] | float | None): Value to fill the border pixels if the border mode
+            is `cv2.BORDER_CONSTANT`. Default is None.
+        fill_mask (tuple[float, ...] | float | None): Similar to `fill` but used for padding masks. Default is None.
         p (float): Probability of applying the transform. Default is 1.0.
 
     Targets:
@@ -2385,11 +2382,11 @@ class PadIfNeeded(Pad):
         min_width: int | None = Field(ge=1)
         pad_height_divisor: int | None = Field(ge=1)
         pad_width_divisor: int | None = Field(ge=1)
-        position: PositionType
+        position: Literal["center", "top_left", "top_right", "bottom_left", "bottom_right", "random"]
         border_mode: BorderModeType
 
-        fill: ColorType
-        fill_mask: ColorType
+        fill: tuple[float, ...] | float
+        fill_mask: tuple[float, ...] | float
 
         @model_validator(mode="after")
         def validate_divisibility(self) -> Self:
@@ -2412,10 +2409,10 @@ class PadIfNeeded(Pad):
         min_width: int | None = 1024,
         pad_height_divisor: int | None = None,
         pad_width_divisor: int | None = None,
-        position: PositionType = "center",
+        position: Literal["center", "top_left", "top_right", "bottom_left", "bottom_right", "random"] = "center",
         border_mode: int = cv2.BORDER_CONSTANT,
-        fill: ColorType = 0,
-        fill_mask: ColorType = 0,
+        fill: tuple[float, ...] | float = 0,
+        fill_mask: tuple[float, ...] | float = 0,
         p: float = 1.0,
     ):
         # Initialize with dummy padding that will be calculated later

--- a/albumentations/augmentations/text/transforms.py
+++ b/albumentations/augmentations/text/transforms.py
@@ -11,7 +11,6 @@ import albumentations.augmentations.text.functional as ftext
 from albumentations.core.bbox_utils import check_bboxes, denormalize_bboxes
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
-from albumentations.core.type_definitions import ColorType
 
 __all__ = ["TextImage"]
 
@@ -81,7 +80,7 @@ class TextImage(ImageOnlyTransform):
             AfterValidator(nondecreasing),
             AfterValidator(check_range_bounds(0, 1)),
         ]
-        font_color: list[ColorType | str] | ColorType | str
+        font_color: list[tuple[float, ...] | float | str] | tuple[float, ...] | float | str
         clear_bg: bool
         metadata_key: str
 
@@ -92,7 +91,7 @@ class TextImage(ImageOnlyTransform):
         augmentations: tuple[Literal["insertion", "swap", "deletion"] | None] = (None,),
         fraction_range: tuple[float, float] = (1.0, 1.0),
         font_size_fraction_range: tuple[float, float] = (0.8, 0.9),
-        font_color: list[ColorType | str] | ColorType | str = "black",
+        font_color: list[tuple[float, ...] | float | str] | tuple[float, ...] | float | str = "black",
         clear_bg: bool = False,
         metadata_key: str = "textimage_metadata",
         p: float = 0.5,

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -70,12 +70,6 @@ from albumentations.core.type_definitions import (
     NUM_RGB_CHANNELS,
     PAIR,
     SEVEN,
-    ChromaticAberrationMode,
-    ColorType,
-    MorphologyMode,
-    RainMode,
-    ScaleFloatType,
-    ScaleIntType,
 )
 from albumentations.core.utils import format_args, to_tuple
 
@@ -147,9 +141,9 @@ class Normalize(ImageOnlyTransform):
         or scale pixel values to a specified range.
 
     Args:
-        mean (ColorType | None): Mean values for standard normalization.
+        mean (tuple[float, float] | float | None): Mean values for standard normalization.
             For "standard" normalization, the default values are ImageNet mean values: (0.485, 0.456, 0.406).
-        std (ColorType | None): Standard deviation values for standard normalization.
+        std (tuple[float, float] | float | None): Standard deviation values for standard normalization.
             For "standard" normalization, the default values are ImageNet standard deviation :(0.229, 0.224, 0.225).
         max_pixel_value (float | None): Maximum possible pixel value, used for scaling in standard normalization.
             Defaults to 255.0.
@@ -204,8 +198,8 @@ class Normalize(ImageOnlyTransform):
     """
 
     class InitSchema(BaseTransformInitSchema):
-        mean: ColorType | None
-        std: ColorType | None
+        mean: tuple[float, ...] | float | None
+        std: tuple[float, ...] | float | None
         max_pixel_value: float | None
         normalization: Literal[
             "standard",
@@ -229,8 +223,8 @@ class Normalize(ImageOnlyTransform):
 
     def __init__(
         self,
-        mean: ColorType | None = (0.485, 0.456, 0.406),
-        std: ColorType | None = (0.229, 0.224, 0.225),
+        mean: tuple[float, ...] | float | None = (0.485, 0.456, 0.406),
+        std: tuple[float, ...] | float | None = (0.229, 0.224, 0.225),
         max_pixel_value: float | None = 255.0,
         normalization: Literal[
             "standard",
@@ -768,7 +762,7 @@ class RandomRain(ImageOnlyTransform):
         drop_color: tuple[int, int, int]
         blur_value: int = Field(ge=1)
         brightness_coefficient: float = Field(gt=0, le=1)
-        rain_type: RainMode
+        rain_type: Literal["drizzle", "heavy", "torrential", "default"]
 
     def __init__(
         self,
@@ -778,7 +772,7 @@ class RandomRain(ImageOnlyTransform):
         drop_color: tuple[int, int, int] = (200, 200, 200),
         blur_value: int = 7,
         brightness_coefficient: float = 0.7,
-        rain_type: RainMode = "default",
+        rain_type: Literal["drizzle", "heavy", "torrential", "default"] = "default",
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -1661,9 +1655,9 @@ class HueSaturationValue(ImageOnlyTransform):
 
     def __init__(
         self,
-        hue_shift_limit: ScaleFloatType = (-20, 20),
-        sat_shift_limit: ScaleFloatType = (-30, 30),
-        val_shift_limit: ScaleFloatType = (-20, 20),
+        hue_shift_limit: tuple[float, float] | float = (-20, 20),
+        sat_shift_limit: tuple[float, float] | float = (-30, 30),
+        val_shift_limit: tuple[float, float] | float = (-20, 20),
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -2135,8 +2129,8 @@ class RandomBrightnessContrast(ImageOnlyTransform):
 
     def __init__(
         self,
-        brightness_limit: ScaleFloatType = (-0.2, 0.2),
-        contrast_limit: ScaleFloatType = (-0.2, 0.2),
+        brightness_limit: tuple[float, float] | float = (-0.2, 0.2),
+        contrast_limit: tuple[float, float] | float = (-0.2, 0.2),
         brightness_by_max: bool = True,
         ensure_safe_range: bool = False,
         p: float = 0.5,
@@ -2461,7 +2455,7 @@ class CLAHE(ImageOnlyTransform):
 
     def __init__(
         self,
-        clip_limit: ScaleFloatType = 4.0,
+        clip_limit: tuple[float, float] | float = 4.0,
         tile_grid_size: tuple[int, int] = (8, 8),
         p: float = 0.5,
     ):
@@ -2627,7 +2621,7 @@ class RandomGamma(ImageOnlyTransform):
 
     def __init__(
         self,
-        gamma_limit: ScaleFloatType = (80, 120),
+        gamma_limit: tuple[float, float] | float = (80, 120),
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -3331,7 +3325,7 @@ class MultiplicativeNoise(ImageOnlyTransform):
 
     def __init__(
         self,
-        multiplier: ScaleFloatType = (0.9, 1.1),
+        multiplier: tuple[float, float] | float = (0.9, 1.1),
         per_channel: bool = False,
         elementwise: bool = False,
         p: float = 0.5,
@@ -3541,16 +3535,16 @@ class ColorJitter(ImageOnlyTransform):
     """
 
     class InitSchema(BaseTransformInitSchema):
-        brightness: ScaleFloatType
-        contrast: ScaleFloatType
-        saturation: ScaleFloatType
-        hue: ScaleFloatType
+        brightness: tuple[float, float] | float
+        contrast: tuple[float, float] | float
+        saturation: tuple[float, float] | float
+        hue: tuple[float, float] | float
 
         @field_validator("brightness", "contrast", "saturation", "hue")
         @classmethod
         def check_ranges(
             cls,
-            value: ScaleFloatType,
+            value: tuple[float, float] | float,
             info: ValidationInfo,
         ) -> tuple[float, float]:
             if info.field_name == "hue":
@@ -3578,10 +3572,10 @@ class ColorJitter(ImageOnlyTransform):
 
     def __init__(
         self,
-        brightness: ScaleFloatType = (0.8, 1.2),
-        contrast: ScaleFloatType = (0.8, 1.2),
-        saturation: ScaleFloatType = (0.8, 1.2),
-        hue: ScaleFloatType = (-0.5, 0.5),
+        brightness: tuple[float, float] | float = (0.8, 1.2),
+        contrast: tuple[float, float] | float = (0.8, 1.2),
+        saturation: tuple[float, float] | float = (0.8, 1.2),
+        hue: tuple[float, float] | float = (-0.5, 0.5),
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -4025,8 +4019,8 @@ class Superpixels(ImageOnlyTransform):
 
     def __init__(
         self,
-        p_replace: ScaleFloatType = (0, 0.1),
-        n_segments: ScaleIntType = (100, 100),
+        p_replace: tuple[float, float] | float = (0, 0.1),
+        n_segments: tuple[int, int] | int = (100, 100),
         max_size: int | None = 128,
         interpolation: int = cv2.INTER_LINEAR,
         p: float = 0.5,
@@ -4148,7 +4142,7 @@ class RingingOvershoot(ImageOnlyTransform):
     """
 
     class InitSchema(BlurInitSchema):
-        blur_limit: ScaleIntType
+        blur_limit: tuple[int, int] | int
         cutoff: Annotated[
             tuple[float, float],
             AfterValidator(check_range_bounds(0, np.pi)),
@@ -4157,7 +4151,7 @@ class RingingOvershoot(ImageOnlyTransform):
 
     def __init__(
         self,
-        blur_limit: ScaleIntType = (7, 15),
+        blur_limit: tuple[int, int] | int = (7, 15),
         cutoff: tuple[float, float] = (np.pi / 4, np.pi / 2),
         p: float = 0.5,
     ):
@@ -4263,22 +4257,22 @@ class UnsharpMask(ImageOnlyTransform):
         sigma_limit: NonNegativeFloatRangeType
         alpha: ZeroOneRangeType
         threshold: int = Field(ge=0, le=255)
-        blur_limit: ScaleIntType
+        blur_limit: tuple[int, int] | int
 
         @field_validator("blur_limit")
         @classmethod
         def process_blur(
             cls,
-            value: ScaleIntType,
+            value: tuple[int, int] | int,
             info: ValidationInfo,
         ) -> tuple[int, int]:
             return fblur.process_blur_limit(value, info, min_value=3)
 
     def __init__(
         self,
-        blur_limit: ScaleIntType = (3, 7),
-        sigma_limit: ScaleFloatType = 0.0,
-        alpha: ScaleFloatType = (0.2, 0.5),
+        blur_limit: tuple[int, int] | int = (3, 7),
+        sigma_limit: tuple[float, float] | float = 0.0,
+        alpha: tuple[float, float] | float = (0.2, 0.5),
         threshold: int = 10,
         p: float = 0.5,
     ):
@@ -4379,8 +4373,8 @@ class PixelDropout(DualTransform):
     class InitSchema(BaseTransformInitSchema):
         dropout_prob: ProbabilityType
         per_channel: bool
-        drop_value: ColorType | None
-        mask_drop_value: ColorType | None
+        drop_value: tuple[float, float] | float | None
+        mask_drop_value: tuple[float, float] | float | None
 
     _targets = ALL_TARGETS
 
@@ -4388,8 +4382,8 @@ class PixelDropout(DualTransform):
         self,
         dropout_prob: float = 0.01,
         per_channel: bool = False,
-        drop_value: ColorType | None = 0,
-        mask_drop_value: ColorType | None = None,
+        drop_value: tuple[float, float] | float | None = 0,
+        mask_drop_value: tuple[float, float] | float | None = None,
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -4607,11 +4601,11 @@ class Spatter(ImageOnlyTransform):
 
     def __init__(
         self,
-        mean: ScaleFloatType = (0.65, 0.65),
-        std: ScaleFloatType = (0.3, 0.3),
-        gauss_sigma: ScaleFloatType = (2, 2),
-        cutout_threshold: ScaleFloatType = (0.68, 0.68),
-        intensity: ScaleFloatType = (0.6, 0.6),
+        mean: tuple[float, float] | float = (0.65, 0.65),
+        std: tuple[float, float] | float = (0.3, 0.3),
+        gauss_sigma: tuple[float, float] | float = (2, 2),
+        cutout_threshold: tuple[float, float] | float = (0.68, 0.68),
+        intensity: tuple[float, float] | float = (0.6, 0.6),
         mode: Literal["rain", "mud"] | Sequence[Literal["rain", "mud"]] = "rain",
         color: Sequence[int] | dict[str, Sequence[int]] | None = None,
         p: float = 0.5,
@@ -4774,14 +4768,14 @@ class ChromaticAberration(ImageOnlyTransform):
     class InitSchema(BaseTransformInitSchema):
         primary_distortion_limit: SymmetricRangeType
         secondary_distortion_limit: SymmetricRangeType
-        mode: ChromaticAberrationMode
+        mode: Literal["green_purple", "red_blue", "random"]
         interpolation: InterpolationType
 
     def __init__(
         self,
-        primary_distortion_limit: ScaleFloatType = (-0.02, 0.02),
-        secondary_distortion_limit: ScaleFloatType = (-0.05, 0.05),
-        mode: ChromaticAberrationMode = "green_purple",
+        primary_distortion_limit: tuple[float, float] | float = (-0.02, 0.02),
+        secondary_distortion_limit: tuple[float, float] | float = (-0.05, 0.05),
+        mode: Literal["green_purple", "red_blue", "random"] = "green_purple",
         interpolation: InterpolationType = cv2.INTER_LINEAR,
         p: float = 0.5,
     ):
@@ -4928,12 +4922,12 @@ class Morphological(DualTransform):
 
     class InitSchema(BaseTransformInitSchema):
         scale: OnePlusIntRangeType
-        operation: MorphologyMode
+        operation: Literal["erosion", "dilation"]
 
     def __init__(
         self,
-        scale: ScaleIntType = (2, 3),
-        operation: MorphologyMode = "dilation",
+        scale: tuple[int, int] | int = (2, 3),
+        operation: Literal["erosion", "dilation"] = "dilation",
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -5632,9 +5626,9 @@ class RGBShift(AdditiveNoise):
 
     def __init__(
         self,
-        r_shift_limit: ScaleFloatType = (-20, 20),
-        g_shift_limit: ScaleFloatType = (-20, 20),
-        b_shift_limit: ScaleFloatType = (-20, 20),
+        r_shift_limit: tuple[float, float] | float = (-20, 20),
+        g_shift_limit: tuple[float, float] | float = (-20, 20),
+        b_shift_limit: tuple[float, float] | float = (-20, 20),
         p: float = 0.5,
     ):
         # Convert RGB shift limits to normalized ranges if needed

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -4331,7 +4331,7 @@ class PixelDropout(DualTransform):
             If False, the same dropout mask will be applied to all channels.
             Default: False
 
-        drop_value (float | Sequence[float] | None): Value to assign to the dropped pixels.
+        drop_value (float | tuple[float, ...] | None): Value to assign to the dropped pixels.
             If None, the value will be randomly sampled for each application:
                 - For uint8 images: Random integer in [0, 255]
                 - For float32 images: Random float in [0, 1]
@@ -4339,7 +4339,7 @@ class PixelDropout(DualTransform):
             If a sequence, it should contain one value per channel.
             Default: 0
 
-        mask_drop_value (float | Sequence[float] | None): Value to assign to dropped pixels in the mask.
+        mask_drop_value (float | tuple[float, ...] | None): Value to assign to dropped pixels in the mask.
             If None, the mask will remain unchanged.
             If a single number, that value will be used for all dropped pixels in the mask.
             If a sequence, it should contain one value per channel.
@@ -4373,8 +4373,8 @@ class PixelDropout(DualTransform):
     class InitSchema(BaseTransformInitSchema):
         dropout_prob: ProbabilityType
         per_channel: bool
-        drop_value: tuple[float, float] | float | None
-        mask_drop_value: tuple[float, float] | float | None
+        drop_value: tuple[float, ...] | float | None
+        mask_drop_value: tuple[float, ...] | float | None
 
     _targets = ALL_TARGETS
 
@@ -4382,8 +4382,8 @@ class PixelDropout(DualTransform):
         self,
         dropout_prob: float = 0.01,
         per_channel: bool = False,
-        drop_value: tuple[float, float] | float | None = 0,
-        mask_drop_value: tuple[float, float] | float | None = None,
+        drop_value: tuple[float, ...] | float | None = 0,
+        mask_drop_value: tuple[float, ...] | float | None = None,
         p: float = 0.5,
     ):
         super().__init__(p=p)

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import random
 from typing import Literal
 
 import numpy as np
 
 from albumentations.augmentations.utils import handle_empty_array
-from albumentations.core.type_definitions import NUM_VOLUME_DIMENSIONS, ColorType
+from albumentations.core.type_definitions import NUM_VOLUME_DIMENSIONS
 
 
 def adjust_padding_by_position3d(
@@ -50,7 +52,7 @@ def adjust_padding_by_position3d(
 def pad_3d_with_params(
     volume: np.ndarray,
     padding: tuple[int, int, int, int, int, int],
-    value: ColorType,
+    value: tuple[float, ...] | float,
 ) -> np.ndarray:
     """Pad 3D volume with given parameters.
 
@@ -115,7 +117,7 @@ def crop3d(
     return volume[z_min:z_max, y_min:y_max, x_min:x_max]
 
 
-def cutout3d(volume: np.ndarray, holes: np.ndarray, fill_value: ColorType) -> np.ndarray:
+def cutout3d(volume: np.ndarray, holes: np.ndarray, fill_value: tuple[float, ...] | float) -> np.ndarray:
     """Cut out holes in 3D volume and fill them with a given value."""
     volume = volume.copy()
     for z1, y1, x1, z2, y2, x2 in holes:

--- a/albumentations/core/pydantic.py
+++ b/albumentations/core/pydantic.py
@@ -79,6 +79,7 @@ NonNegativeFloatRangeType = Annotated[
 NonNegativeIntRangeType = Annotated[
     Union[tuple[int, int], int],
     AfterValidator(process_non_negative_range),
+    AfterValidator(nondecreasing),
     AfterValidator(float2int),
 ]
 

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -16,12 +16,7 @@ from albumentations.core.pydantic import ProbabilityType
 from albumentations.core.validation import ValidatedTransformMeta
 
 from .serialization import Serializable, SerializableMeta, get_shortest_class_fullname
-from .type_definitions import (
-    ALL_TARGETS,
-    ColorType,
-    DropoutFillValue,
-    Targets,
-)
+from .type_definitions import ALL_TARGETS, Targets
 from .utils import ensure_contiguous_output, format_args
 
 __all__ = ["BasicTransform", "DualTransform", "ImageOnlyTransform", "NoOp", "Transform3D"]
@@ -52,8 +47,8 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
     ]  # mapping for targets (plus additional targets) and methods for which they depend
     call_backup = None
     interpolation: int
-    fill: DropoutFillValue
-    fill_mask: ColorType | None
+    fill: tuple[float, ...] | float
+    fill_mask: tuple[float, ...] | float | None
     # replay mode params
     deterministic: bool = False
     save_key = "replay"

--- a/albumentations/core/type_definitions.py
+++ b/albumentations/core/type_definitions.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from enum import Enum
-from typing import Literal, TypeVar, Union
+from typing import TypeVar, Union
 
 import cv2
 import numpy as np
@@ -10,27 +9,12 @@ from albucore.utils import MAX_VALUES_BY_DTYPE
 from numpy.typing import NDArray
 from typing_extensions import NotRequired, TypedDict
 
-ColorType = Union[float, Sequence[float]]
-
 Number = TypeVar("Number", float, int)
-
-ScalarType = Union[float, int]
-
-ScaleIntType = Union[int, tuple[int, int]]
-ScaleFloatType = Union[float, tuple[float, float]]
-
-ScaleType = Union[ScaleIntType, ScaleFloatType]
 
 IntNumType = Union[np.integer, NDArray[np.integer]]
 FloatNumType = Union[np.floating, NDArray[np.floating]]
 
-ChromaticAberrationMode = Literal["green_purple", "red_blue", "random"]
-RainMode = Literal["drizzle", "heavy", "torrential", "default"]
-
-MorphologyMode = Literal["erosion", "dilation"]
-
 d4_group_elements = ["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]
-D4Type = Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]
 
 
 class ReferenceImage(TypedDict):
@@ -104,10 +88,3 @@ REFLECT_BORDER_MODES = {
 
 NUM_KEYPOINTS_COLUMNS_IN_ALBUMENTATIONS = 5
 NUM_BBOXES_COLUMNS_IN_ALBUMENTATIONS = 4
-
-
-PositionType = Literal["center", "top_left", "top_right", "bottom_left", "bottom_right", "random"]
-
-InpaintMethod = Literal["inpaint_telea", "inpaint_ns"]
-
-DropoutFillValue = Union[ColorType, Literal["random", "random_uniform"], InpaintMethod]

--- a/albumentations/core/utils.py
+++ b/albumentations/core/utils.py
@@ -294,40 +294,40 @@ def ensure_contiguous_output(arg: np.ndarray | Sequence[np.ndarray]) -> np.ndarr
 
 @overload
 def to_tuple(
-    param: int | Sequence[int],
-    low: int | Sequence[int] | None = None,
+    param: int | tuple[int, int],
+    low: int | tuple[int, int] | None = None,
     bias: float | None = None,
 ) -> tuple[int, int]: ...
 
 
 @overload
 def to_tuple(
-    param: float | Sequence[float],
-    low: float | Sequence[float] | None = None,
+    param: float | tuple[float, float],
+    low: float | tuple[float, float] | None = None,
     bias: float | None = None,
 ) -> tuple[float, float]: ...
 
 
 def to_tuple(
-    param: float | Sequence[int] | Sequence[float],
-    low: float | Sequence[int] | Sequence[float] | None = None,
+    param: float | tuple[float, float] | tuple[int, int],
+    low: float | tuple[float, float] | tuple[int, int] | None = None,
     bias: float | None = None,
-) -> tuple[int, int] | tuple[float, float]:
+) -> tuple[float, float] | tuple[int, int]:
     """Convert input argument to a min-max tuple.
 
     This function processes various input types and returns a tuple representing a range.
     It handles single values, sequences, and can apply optional low bounds or biases.
 
     Args:
-        param (ScaleType): The primary input value. Can be:
+        param (tuple[float, float] | float | tuple[int, int] | int): The primary input value. Can be:
             - A single int or float: Converted to a symmetric range around zero.
             - A tuple of two ints or two floats: Used directly as min and max values.
 
-        low (ScaleType | None, optional): A lower bound value. Used when param is a single value.
+        low (tuple[float, float] | float | None, optional): A lower bound value. Used when param is a single value.
             If provided, the result will be (low, param) or (param, low), depending on which is smaller.
             Cannot be used together with 'bias'. Defaults to None.
 
-        bias (ScalarType | None, optional): A value to be added to both elements of the resulting tuple.
+        bias (float | int | None, optional): A value to be added to both elements of the resulting tuple.
             Cannot be used together with 'low'. Defaults to None.
 
     Returns:

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -304,7 +304,7 @@ AUGMENTATION_CLS_PARAMS = [
                          {
                             "dropout_prob": 0.1,
                             "per_channel": False,
-                            "drop_value": None,
+                            "drop_value": 2,
                             "mask_drop_value": 15,
         },
                       ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,18 +3,22 @@ import sys
 
 import numpy as np
 import pytest
+import cv2
 
-from tests.utils import set_seed
+cv2.setRNGSeed(137)
 
-set_seed(42)
+np.random.seed(137)
 
 @pytest.fixture
 def mask():
-    return np.random.randint(low=0, high=2, size=(100, 100), dtype=np.uint8)
+    return cv2.randu(np.empty((100, 100), dtype=np.uint8), 0, 2)
 
 @pytest.fixture
 def image():
-    return np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
+    return cv2.randu(np.zeros((100, 100, 3), dtype=np.uint8),
+                       low=np.array([0, 0, 0]),
+                       high=np.array([255, 255, 255]))
+
 
 @pytest.fixture
 def bboxes():
@@ -29,7 +33,6 @@ def mask3d():
     return np.random.randint(0, 2, (10, 100, 100), dtype=np.uint8)
 
 
-
 @pytest.fixture
 def albumentations_bboxes():
     return np.array([[0.15, 0.12, 0.75, 0.30, 1], [0.55, 0.25, 0.90, 0.90, 2]])
@@ -42,12 +45,12 @@ def keypoints():
 
 @pytest.fixture
 def template():
-    return np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
+    return cv2.randu(np.zeros((100, 100, 3), dtype=np.uint8), 0, 255)
 
 
 @pytest.fixture
 def float_template():
-    return np.random.uniform(low=0.0, high=1.0, size=(100, 100, 3)).astype("float32")
+    return cv2.randu(np.zeros((100, 100, 3), dtype=np.float32), 0, 1)
 
 
 @pytest.fixture(scope="package")
@@ -61,12 +64,11 @@ def mp_pool():
         method = None
     return multiprocessing.get_context(method).Pool(4)
 
+SQUARE_UINT8_IMAGE = cv2.randu(np.zeros((100, 100, 3), dtype=np.uint8), 0, 255)
+RECTANGULAR_UINT8_IMAGE = cv2.randu(np.zeros((101, 99, 3), dtype=np.uint8), 0, 255)
 
-SQUARE_UINT8_IMAGE = np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
-RECTANGULAR_UINT8_IMAGE = np.random.randint(low=0, high=256, size=(101, 99, 3), dtype=np.uint8)
-
-SQUARE_FLOAT_IMAGE = np.random.uniform(low=0.0, high=1.0, size=(100, 100, 3)).astype(np.float32)
-RECTANGULAR_FLOAT_IMAGE = np.random.uniform(low=0.0, high=1.0, size=(101, 99, 3)).astype(np.float32)
+SQUARE_FLOAT_IMAGE = cv2.randu(np.zeros((100, 100, 3), dtype=np.float32), 0, 1)
+RECTANGULAR_FLOAT_IMAGE = cv2.randu(np.zeros((101, 99, 3), dtype=np.float32), 0, 1)
 
 UINT8_IMAGES = [SQUARE_UINT8_IMAGE, RECTANGULAR_UINT8_IMAGE]
 
@@ -79,3 +81,5 @@ RECTANGULAR_IMAGES = [RECTANGULAR_UINT8_IMAGE, RECTANGULAR_FLOAT_IMAGE]
 
 SQUARE_MULTI_UINT8_IMAGE = np.random.randint(low=0, high=256, size=(100, 100, 5), dtype=np.uint8)
 SQUARE_MULTI_FLOAT_IMAGE = np.random.uniform(low=0.0, high=1.0, size=(100, 100, 5)).astype(np.float32)
+
+MULTI_IMAGES = [SQUARE_MULTI_UINT8_IMAGE, SQUARE_MULTI_FLOAT_IMAGE]

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -1,8 +1,9 @@
+from typing import Literal
 import numpy as np
 import pytest
 
 import albumentations as A
-from albumentations.core.type_definitions import PositionType
+
 import cv2
 
 from .conftest import IMAGES, RECTANGULAR_UINT8_IMAGE
@@ -147,7 +148,7 @@ def test_bbox_params_edges(
     # Use assert_allclose instead of assert_array_equal to handle floating point precision
     np.testing.assert_allclose(res, expected_bboxes, rtol=1e-6, atol=1e-6)
 
-POSITIONS: list[PositionType] = ["center", "top_left", "top_right", "bottom_left", "bottom_right"]
+POSITIONS = ["center", "top_left", "top_right", "bottom_left", "bottom_right"]
 
 @pytest.mark.parametrize(
     ["crop_cls", "crop_params"],
@@ -162,7 +163,7 @@ def test_pad_position_equivalence(
     image: np.ndarray,
     crop_cls: type[A.DualTransform],
     crop_params: dict[str, int],
-    pad_position: PositionType,
+    pad_position: Literal["center", "top_left", "top_right", "bottom_left", "bottom_right"],
     border_mode: int,
     mask: np.ndarray,
     bboxes: np.ndarray,

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1324,13 +1324,13 @@ def test_selective_channel(
             {"border_mode": cv2.BORDER_CONSTANT, "fill": 255},
         ),
         (
-            {"border_mode": cv2.BORDER_CONSTANT, "fill": [0, 0, 0]},
-            {"border_mode": cv2.BORDER_CONSTANT, "fill": [0, 0, 0]},
+            {"border_mode": cv2.BORDER_CONSTANT, "fill": (0, 0, 0)},
+            {"border_mode": cv2.BORDER_CONSTANT, "fill": (0, 0, 0)},
         ),
         # Mask value handling
         (
-            {"border_mode": cv2.BORDER_CONSTANT, "fill": [0, 0, 0], "fill_mask": 128},
-            {"border_mode": cv2.BORDER_CONSTANT, "fill": [0, 0, 0], "fill_mask": 128},
+            {"border_mode": cv2.BORDER_CONSTANT, "fill": (0, 0, 0), "fill_mask": 128},
+            {"border_mode": cv2.BORDER_CONSTANT, "fill": (0, 0, 0), "fill_mask": 128},
         ),
     ],
 )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,11 +11,6 @@ import albumentations
 from tests.aug_definitions import AUGMENTATION_CLS_PARAMS
 
 
-def set_seed(seed: int = 0):
-    random.seed(seed)
-    np.random.seed(seed)
-
-
 def convert_2d_to_3d(arrays, num_channels=3):
     # Converts a 2D numpy array with shape (H, W) into a 3D array with shape (H, W, num_channels)
     # by repeating the existing values along the new axis.


### PR DESCRIPTION
## Summary by Sourcery

Refine type hints across various augmentations, functions, and schemas for enhanced type safety and clarity. Update tests accordingly to maintain type consistency.

Bug Fixes:
- Correct type hints for parameters `fill`, `fill_mask`, `scale`, `translate_percent`, `translate_px`, `rotate`, `shear`, `shift_limit`, `shift_limit_x`, `shift_limit_y`, `scale_limit`, `rotate_limit`, `nb_rows`, `nb_cols`, `mean`, `std`, `p_replace`, `n_segments`, `distort_limit`, `multiplier`, `brightness`, `contrast`, `saturation`, `hue`, `gamma_limit`, `r_shift_limit`, `g_shift_limit`, `b_shift_limit`, `max_part_shift`, `clip_limit`, `quality_range`, `img_weight`, `beta_limit`, `radius`, `alias_blur`, `max_factor`, `step_factor`, `scale_limit`, `padding`, `rain_type`, `drop_color`, `blur_value`, `brightness_coefficient`, `hue_shift_limit`, `sat_shift_limit`, `val_shift_limit`, `brightness_limit`, `contrast_limit`, `position`, `font_color`, `operation`, `group_element` across multiple augmentations and schemas.
- Remove unnecessary cast operations and correct type annotations for improved type safety.
- Update tests to reflect the type hint changes and ensure type consistency.
- Fix type annotations in `Perspective`, `Affine`, `ShiftScaleRotate`, `PiecewiseAffine`, `Pad`, `PadIfNeeded`, `Normalize`, `RandomRain`, `RandomCropFromBorders`, `CLAHE`, `RandomBrightnessContrast`, `ImageCompression`, `ColorJitter`, `TemplateTransform`, `RingingOvershoot`, `UnsharpMask`, `PixelDropout`, `AdvancedBlur`, `RandomFog`, `ChromaticAberration`, `Morphological`, `ChannelShuffle`, `Pad3D`, `PadIfNeeded3D`, `CenterCrop3D`, `RandomCrop3D`, `CoarseDropout3D`, `BaseCropAndPad`, `RandomCrop`, `CenterCrop`, `Crop`, `CropAndPad`, `RandomScale`, `FDA`, `SafeRotate`, `Rotate`, `TextImage`, `Erasing`, `CoarseDropout`, `ConstrainedCoarseDropout`, `Blur`, `MotionBlur`, `MedianBlur`, `GaussianBlur`, `GlassBlur`, `ZoomBlur`, `MaskDropout`, `GridDropout`, `XYMasking` classes and their respective schemas.
- Correct type annotations for `d4`, `bboxes_d4`, `keypoints_d4`, `warp_affine_with_value_extension`, `warp_affine`, `keypoints_affine`, `create_affine_transformation_matrix`, `pad`, `extend_value`, `copy_make_border_with_value_extension`, `pad_with_params`, `remap`, `validate_rotate_method`, `is_rgb_image`, `is_grayscale_image`, `is_multispectral_image`, `_maybe_process_in_chunks`, `clip`, `clip_image`, `clip_bboxes_v2`, `get_random_crop_coords`, `random_crop`, `center_crop`, `crop_bbox_by_coords`, `bbox_rot90`, `keypoint_rot90`, `try_add_depth`, `adjust_rotation_matrix`, `safe_rotate`, `keypoints_rotation_matrix`, `affine`, `adjust_keypoint_by_scale`, `flip_keypoints`, `from_distance_maps`, `get_num_channels`, `get_center_crop_coords`, `get_random_crop_coords3d`, `center_crop3d`, `random_crop3d`, `generate_holes`, `cutout3d`, `generate_binary_mask`, `get_multichannel_color`, `cutout`, `generate_gaussian_noise_xy`, `generate_grid_dropout_mask`, `grid_dropout`, `channel_dropout`, `random_shadow` functions to ensure accurate type information and prevent potential runtime errors.