### PR TITLE
Fix in pydantic validation

### DIFF
--- a/albumentations/core/validation.py
+++ b/albumentations/core/validation.py
@@ -75,9 +75,12 @@ class ValidatedTransformMeta(type):
             def custom_init(self: Any, *args: Any, **kwargs: Any) -> None:
                 full_kwargs, param_names, strict = cls._process_init_parameters(original_init, args, kwargs)
 
-                validated_kwargs = cls._validate_parameters(dct["InitSchema"], full_kwargs, param_names, strict)
-                if not validated_kwargs:
-                    validated_kwargs = cls._get_default_values(signature(original_init).parameters)
+                validated_kwargs = cls._validate_parameters(
+                    dct["InitSchema"],
+                    full_kwargs,
+                    param_names,
+                    strict,
+                ) or cls._get_default_values(signature(original_init).parameters)
 
                 # Store and check invalid args
                 invalid_args = [name_arg for name_arg in kwargs if name_arg not in param_names and name_arg != "strict"]

--- a/albumentations/core/validation.py
+++ b/albumentations/core/validation.py
@@ -4,10 +4,66 @@ from inspect import Parameter, signature
 from typing import Any, Callable
 from warnings import warn
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 
 class ValidatedTransformMeta(type):
+    @staticmethod
+    def _process_init_parameters(
+        original_init: Callable[..., Any],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> tuple[dict[str, Any], list[str], bool]:
+        init_params = signature(original_init).parameters
+        param_names = list(init_params.keys())[1:]  # Exclude 'self'
+        full_kwargs: dict[str, Any] = dict(zip(param_names, args))
+        full_kwargs.update(kwargs)
+
+        # Get strict value before validation
+        strict = full_kwargs.pop("strict", False)
+
+        # Add default values if not provided
+        for parameter_name, parameter in init_params.items():
+            if (
+                parameter_name != "self"
+                and parameter_name not in full_kwargs
+                and parameter.default is not Parameter.empty
+            ):
+                full_kwargs[parameter_name] = parameter.default
+
+        return full_kwargs, param_names, strict
+
+    @staticmethod
+    def _validate_parameters(
+        schema_cls: type[BaseModel],
+        full_kwargs: dict[str, Any],
+        param_names: list[str],
+        strict: bool,
+    ) -> dict[str, Any]:
+        try:
+            config = schema_cls(**{k: v for k, v in full_kwargs.items() if k in param_names})
+            validated_kwargs = config.model_dump()
+            validated_kwargs.pop("strict", None)
+        except ValidationError as e:
+            raise ValueError(str(e)) from e
+        except Exception as e:
+            if strict:
+                raise ValueError(str(e)) from e
+            warn(str(e), stacklevel=2)
+            return {}
+        else:
+            return validated_kwargs
+
+    @staticmethod
+    def _get_default_values(init_params: dict[str, Parameter]) -> dict[str, Any]:
+        validated_kwargs = {}
+        for param_name, param in init_params.items():
+            if param_name in {"self", "strict"}:
+                continue
+            if param.default is not Parameter.empty:
+                validated_kwargs[param_name] = param.default
+        return validated_kwargs
+
     def __new__(cls: type[Any], name: str, bases: tuple[type, ...], dct: dict[str, Any]) -> type[Any]:
         if "InitSchema" in dct and issubclass(dct["InitSchema"], BaseModel):
             original_init: Callable[..., Any] | None = dct.get("__init__")
@@ -18,46 +74,15 @@ class ValidatedTransformMeta(type):
             original_sig = signature(original_init)
 
             def custom_init(self: Any, *args: Any, **kwargs: Any) -> None:
-                init_params = signature(original_init).parameters
-                param_names = list(init_params.keys())[1:]  # Exclude 'self'
-                full_kwargs: dict[str, Any] = dict(zip(param_names, args))
-                full_kwargs.update(kwargs)
+                full_kwargs, param_names, strict = cls._process_init_parameters(original_init, args, kwargs)
 
-                # Get strict value before validation
-                strict = full_kwargs.pop("strict", False)  # Remove strict from kwargs
+                validated_kwargs = cls._validate_parameters(dct["InitSchema"], full_kwargs, param_names, strict)
+                if not validated_kwargs:
+                    validated_kwargs = cls._get_default_values(signature(original_init).parameters)
 
-                for parameter_name, parameter in init_params.items():
-                    if (
-                        parameter_name != "self"
-                        and parameter_name not in full_kwargs
-                        and parameter.default is not Parameter.empty
-                    ):
-                        full_kwargs[parameter_name] = parameter.default
-
-                # Configure model validation
-                try:
-                    config = dct["InitSchema"](**{k: v for k, v in full_kwargs.items() if k in param_names})
-                    validated_kwargs = config.model_dump()
-                    # Remove strict from validated kwargs to prevent it from being passed to __init__
-                    validated_kwargs.pop("strict", None)
-                except Exception as e:
-                    if strict:
-                        raise
-                    warn(str(e), stacklevel=2)
-                    # Use default values for invalid parameters
-                    config = dct["InitSchema"]()
-                    validated_kwargs = config.model_dump()
-                    validated_kwargs.pop("strict", None)  # Also remove from default values
-
-                # Store invalid args in the instance
-                invalid_args = [
-                    name_arg for name_arg in kwargs if name_arg not in validated_kwargs and name_arg != "strict"
-                ]
-
-                # Call original init with validated kwargs (strict removed)
+                # Store and check invalid args
+                invalid_args = [name_arg for name_arg in kwargs if name_arg not in param_names and name_arg != "strict"]
                 original_init(self, **validated_kwargs)
-
-                # Store invalid args after initialization
                 self.invalid_args = invalid_args
 
                 if invalid_args:

--- a/albumentations/core/validation.py
+++ b/albumentations/core/validation.py
@@ -16,8 +16,7 @@ class ValidatedTransformMeta(type):
     ) -> tuple[dict[str, Any], list[str], bool]:
         init_params = signature(original_init).parameters
         param_names = list(init_params.keys())[1:]  # Exclude 'self'
-        full_kwargs: dict[str, Any] = dict(zip(param_names, args))
-        full_kwargs.update(kwargs)
+        full_kwargs: dict[str, Any] = dict(zip(param_names, args)) | kwargs
 
         # Get strict value before validation
         strict = full_kwargs.pop("strict", False)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,7 +4,7 @@ import typing
 from unittest import mock
 from unittest.mock import MagicMock, Mock, call, patch
 import warnings
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 import torch
 import cv2
 import numpy as np
@@ -25,7 +25,7 @@ from albumentations.core.composition import (
     Sequential,
     SomeOf,
 )
-from albumentations.core.transforms_interface import DualTransform, ImageOnlyTransform, NoOp
+from albumentations.core.transforms_interface import BasicTransform, DualTransform, ImageOnlyTransform, NoOp
 from albumentations.core.utils import to_tuple, get_shape
 from tests.conftest import (
     IMAGES,
@@ -1879,3 +1879,64 @@ def test_mask_interpolation(augmentation_cls, params, border_mode, image):
     transform = A.Compose([augmentation_cls(**params, p=1)], seed=137, strict=False)
 
     transform(image=image, mask=mask)
+
+
+@pytest.mark.parametrize(
+    "params, strict, expected_outcome, expected_error_params",
+    [
+        # Valid cases
+        ({"rotate": 45}, False, "valid", []),
+        ({"rotate": 45, "p": 0.5}, False, "valid", []),
+
+        # Invalid parameter names (affected by strict)
+        ({"rotate": 45, "invalid_param": 123}, False, "warning", []),
+        ({"rotate": 45, "invalid_param": 123}, True, "error", ["invalid_param"]),
+        ({"rotate": 45, "wrong_param": 0.5, "bad_param": 30}, False, "warning", []),
+
+        # Invalid parameter values (always error, regardless of strict)
+        ({"rotate": 45, "p": 1.5}, False, "value_error", ["p"]),
+        ({"rotate": 45, "p": -0.5}, False, "value_error", ["p"]),
+        # Multiple invalid values
+        ({"interpolation": -1, "mask_interpolation": -1, "p": 1.5}, False, "value_error",
+         ["interpolation", "mask_interpolation", "p"]),
+    ]
+)
+def test_affine_invalid_parameters(params, strict, expected_outcome, expected_error_params):
+    if expected_outcome == "valid":
+        transform = A.Affine(**params)
+        assert transform is not None
+        assert not hasattr(transform, 'invalid_args') or not transform.invalid_args
+
+    elif expected_outcome == "warning":
+        transform = A.Affine(strict=strict, **params)
+        assert hasattr(transform, 'invalid_args')
+        invalid_params = set(params.keys()) - {"rotate", "p", "scale", "translate_percent",
+                                             "translate_px", "interpolation", "mask_interpolation",
+                                             "mode", "fit_output", "keep_ratio"}
+        assert set(transform.invalid_args) == invalid_params
+
+    elif expected_outcome == "error":
+        with pytest.raises(ValueError) as excinfo:
+            A.Affine(strict=strict, **params)
+        error_msg = str(excinfo.value)
+        for param in expected_error_params:
+            assert param in error_msg
+
+    elif expected_outcome == "value_error":
+        with pytest.raises(ValueError) as excinfo:
+            A.Affine(strict=strict, **params)
+        error_msg = str(excinfo.value)
+
+        # Verify that ALL expected error parameters are in the message
+        for param in expected_error_params:
+            assert param in error_msg
+
+        if len(expected_error_params) > 1:
+            # Count unique parameters mentioned in the error
+            error_params = set()
+            for param in expected_error_params:
+                if param in error_msg:
+                    error_params.add(param)
+
+            assert len(error_params) == len(expected_error_params), \
+                f"Expected validation errors for {expected_error_params}, got errors for {error_params}"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1933,10 +1933,7 @@ def test_affine_invalid_parameters(params, strict, expected_outcome, expected_er
 
         if len(expected_error_params) > 1:
             # Count unique parameters mentioned in the error
-            error_params = set()
-            for param in expected_error_params:
-                if param in error_msg:
-                    error_params.add(param)
+            error_params = {param for param in expected_error_params if param in error_msg}
 
             assert len(error_params) == len(expected_error_params), \
                 f"Expected validation errors for {expected_error_params}, got errors for {error_params}"


### PR DESCRIPTION
## Summary by Sourcery

This pull request fixes an issue in pydantic validation where default values were not being correctly applied when invalid parameters were passed to a transform. It also improves the handling of invalid parameters in transforms by providing more informative error messages and warnings. Finally, it adds new tests to verify the correct handling of invalid parameters in transforms.

Bug Fixes:
- Fixes an issue in pydantic validation where default values were not being correctly applied when invalid parameters were passed to a transform, leading to unexpected behavior.
- Fixes an issue where invalid arguments were not being correctly handled, leading to unexpected behavior.

Enhancements:
- Improves the handling of invalid parameters in transforms by providing more informative error messages and warnings.
- Refactors the validation logic to improve readability and maintainability.

Tests:
- Adds new tests to verify the correct handling of invalid parameters in transforms.