### PR TITLE
Fix hsv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ conda_build/
 .ruff_cache/
 
 data/
+
+notebooks/

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -115,15 +115,15 @@ def shift_hsv(
         hue = sz_lut(hue, lut_hue, inplace=False)
 
     if sat_shift != 0:
-        # Create a mask for pixels that should not have saturation changed
-        # White pixels have V=255 and S=0, we should keep them white
-        white_mask = (val == 255) & (sat == 0)
+        # Create a mask for all grayscale pixels (S=0)
+        # These should remain grayscale regardless of saturation change
+        grayscale_mask = sat == 0
 
         # Apply saturation shift only to non-white pixels
         sat = add_constant(sat, sat_shift, inplace=True)
 
         # Reset saturation for white pixels
-        sat[white_mask] = 0
+        sat[grayscale_mask] = 0
 
     if val_shift != 0:
         val = add_constant(val, val_shift, inplace=True)

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -115,7 +115,15 @@ def shift_hsv(
         hue = sz_lut(hue, lut_hue, inplace=False)
 
     if sat_shift != 0:
+        # Create a mask for pixels that should not have saturation changed
+        # White pixels have V=255 and S=0, we should keep them white
+        white_mask = (val == 255) & (sat == 0)
+
+        # Apply saturation shift only to non-white pixels
         sat = add_constant(sat, sat_shift, inplace=True)
+
+        # Reset saturation for white pixels
+        sat[white_mask] = 0
 
     if val_shift != 0:
         val = add_constant(val, val_shift, inplace=True)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -3027,7 +3027,7 @@ def test_white_pixels_in_mixed_images(image_type, sat_shift):
                     f"White pixel at ({y},{x}) changed color in {image_type} image"
 
     # Non-white pixels should be affected by saturation (except black which has V=0)
-    if image_type == "white_and_color" or image_type == "white_black_color":
+    if image_type in {"white_and_color", "white_black_color"}:
         colored_mask = ~white_mask & ~np.all(image == 0, axis=2)  # Not white and not black
 
         # Convert original and result to HSV to check saturation directly


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2353

## Summary by Sourcery

Fixes an issue in the `shift_hsv` function where white and gray pixels were incorrectly modified when adjusting saturation. The fix ensures that white and gray pixels remain unchanged when saturation is adjusted, while other colors are correctly modified. Comprehensive tests are added to verify the fix.

Bug Fixes:
- Fixes an issue where increasing saturation would change white and gray pixels in an image, ensuring they remain white and gray respectively after the transformation.

Tests:
- Adds comprehensive tests to verify that white and gray pixels remain unchanged when saturation is adjusted in the `shift_hsv` function, covering various scenarios with white, gray, and colored pixels in mixed images.