### PR TITLE
⚡️ Speed up function `mask_dropout_keypoints` by 5,854%

### DIFF
--- a/albumentations/augmentations/dropout/functional.py
+++ b/albumentations/augmentations/dropout/functional.py
@@ -531,7 +531,11 @@ def mask_dropout_keypoints(
     Returns:
         Filtered keypoints array. Keeps keypoints where not all channels are dropped.
     """
-    keep_indices = np.array([not dropout_mask[int(kp[1]), int(kp[0])].all() for kp in keypoints])
+    # Vectorized operation to check where dropout_mask is not fully true at keypoint locations
+    rows = keypoints[:, 1].astype(int)
+    cols = keypoints[:, 0].astype(int)
+    mask_values = dropout_mask[rows, cols]
+    keep_indices = ~mask_values.all(axis=-1) if dropout_mask.ndim == 3 else ~mask_values
     return keypoints[keep_indices]
 
 


### PR DESCRIPTION
### 📄 5,854% (58.54x) speedup for ***`mask_dropout_keypoints` in `albumentations/augmentations/dropout/functional.py`***

⏱️ Runtime :   **`9.70 milliseconds`**  **→** **`163 microseconds`** (best of `164` runs)
<details>
<summary> 📝 Explanation and details</summary>

The current implementation of `mask_dropout_keypoints` makes use of list comprehension and applies the `all()` method in a potentially redundant manner. This can be optimized by using NumPy's vectorized operations, which are typically faster than looping with list comprehensions when working with arrays.

Here's how we can optimize the function.



### Changes Made.
1. **Vectorization**: We use NumPy's advanced indexing to directly fetch the mask values for all keypoints in one go instead of iterating through each keypoint individually.
2. **Conditional Axis Handling**: The function now efficiently determines whether to apply `all(axis=-1)` conditionally, based on whether the `dropout_mask` is 3D or 2D, by checking its number of dimensions (`ndim`).
3. **Maintain Compatibility**: Preserved the function structure and logic, ensuring that the output remains consistent with the original implementation.

These changes should significantly enhance the performance of the function, especially when handling large arrays of keypoints and masks.

</details>

✅ **Correctness verification report:**


| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **18 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>🌀 Generated Regression Tests Details</summary>

```python
from __future__ import annotations

import numpy as np
# imports
import pytest  # used for our unit tests
from albumentations.augmentations.dropout.functional import \
    mask_dropout_keypoints
from albumentations.augmentations.utils import handle_empty_array

# unit tests

def test_single_keypoint_non_dropped():
    # Test with a single keypoint on a non-dropped pixel
    keypoints = np.array([[1, 1]])
    dropout_mask = np.array([[False, False], [False, False]])
    expected = np.array([[1, 1]])
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)

def test_multiple_keypoints_mixed():
    # Test with multiple keypoints on a mix of dropped and non-dropped pixels
    keypoints = np.array([[0, 0], [1, 1], [2, 2]])
    dropout_mask = np.array([[False, True, False], [False, False, True], [True, True, True]])
    expected = np.array([[0, 0], [1, 1]])
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)

def test_empty_keypoints():
    # Test with an empty keypoints array
    keypoints = np.array([])
    dropout_mask = np.array([[False, False], [False, False]])
    expected = np.array([])
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)

def test_keypoints_on_edges():
    # Test with keypoints on the edges of the dropout_mask
    keypoints = np.array([[0, 0], [1, 1], [0, 1]])
    dropout_mask = np.array([[True, False], [False, True]])
    expected = np.array([[1, 1], [0, 1]])
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)

def test_all_pixels_dropped():
    # Test with all pixels in the dropout_mask dropped
    keypoints = np.array([[0, 0], [1, 1]])
    dropout_mask = np.array([[True, True], [True, True]])
    expected = np.array([])
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)



def test_large_number_of_keypoints():
    # Test with a large number of keypoints
    keypoints = np.random.randint(0, 100, size=(1000, 2))
    dropout_mask = np.zeros((100, 100), dtype=bool)  # No pixels dropped
    expected = keypoints
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)


def test_identical_keypoints():
    # Test with identical keypoints, some on dropped and some on non-dropped pixels
    keypoints = np.array([[0, 0], [0, 0], [1, 1]])
    dropout_mask = np.array([[False, True], [True, False]])
    expected = np.array([[0, 0], [0, 0]])
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.

from __future__ import annotations

import numpy as np
# imports
import pytest  # used for our unit tests
from albumentations.augmentations.dropout.functional import \
    mask_dropout_keypoints
from albumentations.augmentations.utils import handle_empty_array

# unit tests

def test_single_keypoint_on_active_pixel():
    # Single keypoint on an active pixel
    keypoints = np.array([[5, 5]])
    dropout_mask = np.zeros((10, 10), dtype=bool)
    expected = np.array([[5, 5]])
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)

def test_single_keypoint_on_dropped_pixel():
    # Single keypoint on a dropped pixel
    keypoints = np.array([[5, 5]])
    dropout_mask = np.ones((10, 10), dtype=bool)
    expected = np.array([])
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)

def test_mixed_keypoints_on_active_and_dropped_pixels():
    # Mixed keypoints on active and dropped pixels
    keypoints = np.array([[1, 1], [2, 2], [3, 3]])
    dropout_mask = np.zeros((5, 5), dtype=bool)
    dropout_mask[2, 2] = True
    expected = np.array([[1, 1], [3, 3]])
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)

def test_empty_keypoints_array():
    # Empty keypoints array
    keypoints = np.array([])
    dropout_mask = np.zeros((10, 10), dtype=bool)
    expected = np.array([])
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)

def test_keypoints_on_edge_of_mask():
    # Keypoints on the edge of the mask
    keypoints = np.array([[0, 0], [9, 9]])
    dropout_mask = np.zeros((10, 10), dtype=bool)
    expected = np.array([[0, 0], [9, 9]])
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)

def test_keypoints_with_non_integer_coordinates():
    # Keypoints with non-integer coordinates
    keypoints = np.array([[5.5, 5.5]])
    dropout_mask = np.zeros((10, 10), dtype=bool)
    expected = np.array([[5.5, 5.5]])
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)

def test_2d_vs_3d_mask():
    # Test with 2D and 3D masks
    keypoints = np.array([[5, 5]])
    dropout_mask_2d = np.zeros((10, 10), dtype=bool)
    dropout_mask_3d = np.zeros((10, 10, 3), dtype=bool)
    expected = np.array([[5, 5]])
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask_2d)
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask_3d)

def test_all_pixels_dropped_in_certain_channels():
    # All pixels dropped in certain channels
    keypoints = np.array([[5, 5]])
    dropout_mask = np.zeros((10, 10, 3), dtype=bool)
    dropout_mask[:, :, 0] = True  # First channel is all dropped
    expected = np.array([[5, 5]])
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)

def test_large_number_of_keypoints():
    # Large number of keypoints
    keypoints = np.random.randint(0, 100, (10000, 2))
    dropout_mask = np.random.choice([False, True], (100, 100))
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)
    # We cannot predict the exact output, but we can ensure no errors occur

def test_large_mask_with_sparse_keypoints():
    # Large mask with sparse keypoints
    keypoints = np.array([[1000, 1000], [2000, 2000]])
    dropout_mask = np.random.choice([False, True], (3000, 3000))
    codeflash_output = mask_dropout_keypoints(keypoints, dropout_mask)
    # Ensure no errors occur, and the result is logically consistent
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>



[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)

## Summary by Sourcery

Optimise the `mask_dropout_keypoints` function for improved performance by replacing list comprehension with NumPy's vectorized operations.

Enhancements:
- Optimise `mask_dropout_keypoints` by using NumPy's vectorized operations instead of list comprehension, resulting in a significant speedup.

Tests:
- Add regression tests to verify the correctness of the optimised `mask_dropout_keypoints` function.