### PR TITLE
⚡️ Speed up function `clahe` by 10%

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -163,10 +163,7 @@ def solarize(img: np.ndarray, threshold: float) -> np.ndarray:
 
 @uint8_io
 @clipped
-def posterize(
-    img: np.ndarray,
-    bits: Literal[1, 2, 3, 4, 5, 6, 7] | list[Literal[1, 2, 3, 4, 5, 6, 7]],
-) -> np.ndarray:
+def posterize(img: np.ndarray, bits: Literal[1, 2, 3, 4, 5, 6, 7] | list[Literal[1, 2, 3, 4, 5, 6, 7]]) -> np.ndarray:
     """Reduce the number of bits for each color channel by keeping only the highest N bits.
 
     This transform performs bit-depth reduction by masking out lower bits, effectively
@@ -2478,14 +2475,7 @@ def generate_plasma_pattern(
         plasma_grid = one_diamond_square_step(plasma_grid, noise_scale)
 
     return np.clip(
-        cv2.normalize(
-            plasma_grid[: target_shape[0], : target_shape[1]],
-            None,
-            0,
-            1,
-            cv2.NORM_MINMAX,
-            dtype=cv2.CV_32F,
-        ),
+        cv2.normalize(plasma_grid[: target_shape[0], : target_shape[1]], None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F),
         0,
         1,
     )

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -147,7 +147,10 @@ def solarize(img: np.ndarray, threshold: float) -> np.ndarray:
     max_val = MAX_VALUES_BY_DTYPE[dtype]
 
     if dtype == np.uint8:
-        lut = [(max_val - i if i >= threshold * max_val else i) for i in range(int(max_val) + 1)]
+        lut = [
+            (max_val - i if i >= threshold * max_val else i)
+            for i in range(int(max_val) + 1)
+        ]
 
         prev_shape = img.shape
         img = sz_lut(img, np.array(lut, dtype=dtype), inplace=False)
@@ -163,7 +166,10 @@ def solarize(img: np.ndarray, threshold: float) -> np.ndarray:
 
 @uint8_io
 @clipped
-def posterize(img: np.ndarray, bits: Literal[1, 2, 3, 4, 5, 6, 7] | list[Literal[1, 2, 3, 4, 5, 6, 7]]) -> np.ndarray:
+def posterize(
+    img: np.ndarray,
+    bits: Literal[1, 2, 3, 4, 5, 6, 7] | list[Literal[1, 2, 3, 4, 5, 6, 7]],
+) -> np.ndarray:
     """Reduce the number of bits for each color channel by keeping only the highest N bits.
 
     This transform performs bit-depth reduction by masking out lower bits, effectively
@@ -383,7 +389,9 @@ def move_tone_curve(
         high_y: float | np.ndarray,
     ) -> np.ndarray:
         one_minus_t = 1 - t
-        return (3 * one_minus_t**2 * t * low_y + 3 * one_minus_t * t**2 * high_y + t**3) * 255
+        return (
+            3 * one_minus_t**2 * t * low_y + 3 * one_minus_t * t**2 * high_y + t**3
+        ) * 255
 
     num_channels = get_num_channels(img)
 
@@ -397,7 +405,10 @@ def move_tone_curve(
             inplace=False,
         )
         return cv2.merge(
-            [sz_lut(img[:, :, i], np.ascontiguousarray(luts[i]), inplace=False) for i in range(num_channels)],
+            [
+                sz_lut(img[:, :, i], np.ascontiguousarray(luts[i]), inplace=False)
+                for i in range(num_channels)
+            ],
         )
 
     raise TypeError(
@@ -450,17 +461,15 @@ def clahe(
         >>> assert result.shape == img.shape
         >>> assert result.dtype == img.dtype
     """
-    img = img.copy()
     clahe_mat = cv2.createCLAHE(clipLimit=clip_limit, tileGridSize=tile_grid_size)
 
     if is_grayscale_image(img):
         return clahe_mat.apply(img)
 
-    img = cv2.cvtColor(img, cv2.COLOR_RGB2LAB)
+    img_lab = cv2.cvtColor(img, cv2.COLOR_RGB2LAB)
+    img_lab[:, :, 0] = clahe_mat.apply(img_lab[:, :, 0])
 
-    img[:, :, 0] = clahe_mat.apply(img[:, :, 0])
-
-    return cv2.cvtColor(img, cv2.COLOR_LAB2RGB)
+    return cv2.cvtColor(img_lab, cv2.COLOR_LAB2RGB)
 
 
 @uint8_io
@@ -480,7 +489,9 @@ def image_compression(
     Returns:
         Compressed image with same number of channels as input
     """
-    quality_flag = cv2.IMWRITE_JPEG_QUALITY if image_type == ".jpg" else cv2.IMWRITE_WEBP_QUALITY
+    quality_flag = (
+        cv2.IMWRITE_JPEG_QUALITY if image_type == ".jpg" else cv2.IMWRITE_WEBP_QUALITY
+    )
 
     num_channels = get_num_channels(img)
 
@@ -748,7 +759,9 @@ def add_rain(
     rain_layer = np.zeros_like(img, dtype=np.uint8)
 
     # Calculate end points correctly
-    end_points = rain_drops + np.array([[slant, drop_length]])  # This creates correct shape
+    end_points = rain_drops + np.array(
+        [[slant, drop_length]]
+    )  # This creates correct shape
 
     # Stack arrays properly - both must be same shape arrays
     lines = np.stack((rain_drops, end_points), axis=1)  # Use tuple and proper axis
@@ -794,7 +807,10 @@ def get_fog_particle_radiuses(
     max_fog_radius = max(2, int(min(height, width) * 0.1 * fog_intensity))
     min_radius = max(1, max_fog_radius // 2)
 
-    return [random_generator.integers(min_radius, max_fog_radius) for _ in range(num_particles)]
+    return [
+        random_generator.integers(min_radius, max_fog_radius)
+        for _ in range(num_particles)
+    ]
 
 
 @uint8_io
@@ -925,7 +941,11 @@ def add_sun_flare_overlay(
 
     for i in range(num_times):
         cv2.circle(overlay, point, int(rad[i]), src_color, -1)
-        alp = alpha[num_times - i - 1] * alpha[num_times - i - 1] * alpha[num_times - i - 1]
+        alp = (
+            alpha[num_times - i - 1]
+            * alpha[num_times - i - 1]
+            * alpha[num_times - i - 1]
+        )
         output = add_weighted(overlay, alp, output, 1 - alp)
 
     return output
@@ -1547,7 +1567,11 @@ def adjust_contrast_torchvision(img: np.ndarray, factor: float) -> np.ndarray:
     if factor == 1:
         return img
 
-    mean = img.mean() if is_grayscale_image(img) else cv2.cvtColor(img, cv2.COLOR_RGB2GRAY).mean()
+    mean = (
+        img.mean()
+        if is_grayscale_image(img)
+        else cv2.cvtColor(img, cv2.COLOR_RGB2GRAY).mean()
+    )
 
     if factor == 0:
         if img.dtype != np.float32:
@@ -1570,7 +1594,11 @@ def adjust_saturation_torchvision(
     gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
     gray = cv2.cvtColor(gray, cv2.COLOR_GRAY2RGB)
 
-    return gray if factor == 0 else cv2.addWeighted(img, factor, gray, 1 - factor, gamma=gamma)
+    return (
+        gray
+        if factor == 0
+        else cv2.addWeighted(img, factor, gray, 1 - factor, gamma=gamma)
+    )
 
 
 def _adjust_hue_torchvision_uint8(img: np.ndarray, factor: float) -> np.ndarray:
@@ -1658,7 +1686,11 @@ def superpixels(
 
                 image_sp_c[mask] = value
 
-    return fgeometric.resize(image, orig_shape[:2], interpolation) if orig_shape != image.shape else image
+    return (
+        fgeometric.resize(image, orig_shape[:2], interpolation)
+        if orig_shape != image.shape
+        else image
+    )
 
 
 @float32_io
@@ -2269,7 +2301,10 @@ def sample_uniform(
             )
 
         return np.array(
-            [random_generator.uniform(low, high) for low, high in ranges[:num_channels]],
+            [
+                random_generator.uniform(low, high)
+                for low, high in ranges[:num_channels]
+            ],
         )
 
     # use first range for spatial noise
@@ -2437,7 +2472,9 @@ def generate_plasma_pattern(
 ) -> np.ndarray:
     """Generate Plasma Fractal with consistent brightness."""
 
-    def one_diamond_square_step(current_grid: np.ndarray, noise_scale: float) -> np.ndarray:
+    def one_diamond_square_step(
+        current_grid: np.ndarray, noise_scale: float
+    ) -> np.ndarray:
         next_height = (current_grid.shape[0] - 1) * 2 + 1
         next_width = (current_grid.shape[1] - 1) * 2 + 1
 
@@ -2445,23 +2482,31 @@ def generate_plasma_pattern(
         expanded_grid = np.zeros((next_height, next_width), dtype=np.float32)
 
         # Generate all noise at once for both steps (already scaled by noise_scale)
-        all_noise = random_generator.uniform(-noise_scale, noise_scale, (next_height, next_width)).astype(np.float32)
+        all_noise = random_generator.uniform(
+            -noise_scale, noise_scale, (next_height, next_width)
+        ).astype(np.float32)
 
         # Copy existing points with noise
         expanded_grid[::2, ::2] = current_grid + all_noise[::2, ::2]
 
         # Diamond step - keep separate for natural look
-        diamond_interpolation = cv2.filter2D(expanded_grid, -1, DIAMOND_KERNEL, borderType=cv2.BORDER_CONSTANT)
+        diamond_interpolation = cv2.filter2D(
+            expanded_grid, -1, DIAMOND_KERNEL, borderType=cv2.BORDER_CONSTANT
+        )
         diamond_mask = diamond_interpolation > 0
         expanded_grid += (diamond_interpolation + all_noise) * diamond_mask
 
         # Square step - keep separate for natural look
-        square_interpolation = cv2.filter2D(expanded_grid, -1, SQUARE_KERNEL, borderType=cv2.BORDER_CONSTANT)
+        square_interpolation = cv2.filter2D(
+            expanded_grid, -1, SQUARE_KERNEL, borderType=cv2.BORDER_CONSTANT
+        )
         square_mask = square_interpolation > 0
         expanded_grid += (square_interpolation + all_noise) * square_mask
 
         # Normalize after each step to prevent value drift
-        return cv2.normalize(expanded_grid, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
+        return cv2.normalize(
+            expanded_grid, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F
+        )
 
     # Pre-compute noise scales
     max_dimension = max(target_shape)
@@ -2477,7 +2522,14 @@ def generate_plasma_pattern(
         plasma_grid = one_diamond_square_step(plasma_grid, noise_scale)
 
     return np.clip(
-        cv2.normalize(plasma_grid[: target_shape[0], : target_shape[1]], None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F),
+        cv2.normalize(
+            plasma_grid[: target_shape[0], : target_shape[1]],
+            None,
+            0,
+            1,
+            cv2.NORM_MINMAX,
+            dtype=cv2.CV_32F,
+        ),
         0,
         1,
     )
@@ -2504,7 +2556,9 @@ def apply_plasma_brightness_contrast(
 
     # Apply brightness adjustment
     if brightness_factor != 0:
-        brightness_adjustment = multiply(plasma_pattern, brightness_factor, inplace=False)
+        brightness_adjustment = multiply(
+            plasma_pattern, brightness_factor, inplace=False
+        )
         img = add(img, brightness_adjustment, inplace=True)
 
     # Apply contrast adjustment
@@ -2558,15 +2612,23 @@ def create_directional_gradient(height: int, width: int, angle: float) -> np.nda
     """
     # Fast path for horizontal gradients
     if angle == 0:
-        return np.linspace(0, 1, width, dtype=np.float32)[None, :] * np.ones((height, 1), dtype=np.float32)
+        return np.linspace(0, 1, width, dtype=np.float32)[None, :] * np.ones(
+            (height, 1), dtype=np.float32
+        )
     if angle == 180:
-        return np.linspace(1, 0, width, dtype=np.float32)[None, :] * np.ones((height, 1), dtype=np.float32)
+        return np.linspace(1, 0, width, dtype=np.float32)[None, :] * np.ones(
+            (height, 1), dtype=np.float32
+        )
 
     # Fast path for vertical gradients
     if angle == 90:
-        return np.linspace(0, 1, height, dtype=np.float32)[:, None] * np.ones((1, width), dtype=np.float32)
+        return np.linspace(0, 1, height, dtype=np.float32)[:, None] * np.ones(
+            (1, width), dtype=np.float32
+        )
     if angle == 270:
-        return np.linspace(1, 0, height, dtype=np.float32)[:, None] * np.ones((1, width), dtype=np.float32)
+        return np.linspace(1, 0, height, dtype=np.float32)[:, None] * np.ones(
+            (1, width), dtype=np.float32
+        )
 
     # Fast path for diagonal gradients using broadcasting
     if angle in (45, 135, 225, 315):
@@ -2576,9 +2638,13 @@ def create_directional_gradient(height: int, width: int, angle: float) -> np.nda
         if angle == 45:  # Bottom-left to top-right
             return cv2.normalize(x + y, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
         if angle == 135:  # Bottom-right to top-left
-            return cv2.normalize((1 - x) + y, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
+            return cv2.normalize(
+                (1 - x) + y, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F
+            )
         if angle == 225:  # Top-right to bottom-left
-            return cv2.normalize((1 - x) + (1 - y), None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
+            return cv2.normalize(
+                (1 - x) + (1 - y), None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F
+            )
         # angle == 315:  # Top-left to bottom-right
         return cv2.normalize(x + (1 - y), None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
 
@@ -2597,7 +2663,9 @@ def create_directional_gradient(height: int, width: int, angle: float) -> np.nda
 
 
 @float32_io
-def apply_linear_illumination(img: np.ndarray, intensity: float, angle: float) -> np.ndarray:
+def apply_linear_illumination(
+    img: np.ndarray, intensity: float, angle: float
+) -> np.ndarray:
     """Apply directional illumination effect to an image using a linear gradient.
 
     The function creates a directional gradient and uses it to modulate image brightness.
@@ -2831,7 +2899,9 @@ def create_contrast_lut(
 
         # Create lookup table
         lut = np.zeros(256, dtype=np.uint8)
-        lut[min_intensity : max_intensity + 1] = np.clip(np.round(cdf), 0, max_value).astype(np.uint8)
+        lut[min_intensity : max_intensity + 1] = np.clip(
+            np.round(cdf), 0, max_value
+        ).astype(np.uint8)
         lut[max_intensity + 1 :] = max_value
         return lut
 
@@ -2840,7 +2910,9 @@ def create_contrast_lut(
     indices = np.arange(256, dtype=float)
     # Changed: Use np.round to get 128 for middle value
     # Test expects [0, 128, 255] for range [0, 2]
-    lut = np.clip(np.round((indices - min_intensity) * scale), 0, max_value).astype(np.uint8)
+    lut = np.clip(np.round((indices - min_intensity) * scale), 0, max_value).astype(
+        np.uint8
+    )
     lut[:min_intensity] = 0
     lut[max_intensity + 1 :] = max_value
     return lut
@@ -3220,14 +3292,18 @@ class SimpleNMF:
             dtype=np.float32,
         )
 
-    def fit_transform(self, optical_density: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    def fit_transform(
+        self, optical_density: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
         # Start with known H&E colors
         stain_colors = self.initial_colors.copy()
 
         # Initialize concentrations based on projection onto initial colors
         # This gives us a physically meaningful starting point
         stain_colors_normalized = normalize_vectors(stain_colors)
-        stain_concentrations = np.maximum(optical_density @ stain_colors_normalized.T, 0)
+        stain_concentrations = np.maximum(
+            optical_density @ stain_colors_normalized.T, 0
+        )
 
         # Iterative updates with careful normalization
         eps = 1e-6
@@ -3328,7 +3404,9 @@ class MacenkoNormalizer(StainNormalizer):
         # Step 4: Get principal components
         eigenvalues, eigenvectors = cv2.eigen(od_covariance)[1:]
         idx = np.argsort(eigenvalues.ravel())[-2:]
-        principal_eigenvectors = np.ascontiguousarray(eigenvectors[:, idx], dtype=np.float32)
+        principal_eigenvectors = np.ascontiguousarray(
+            eigenvectors[:, idx], dtype=np.float32
+        )
 
         # Step 5: Project onto eigenvector plane
         plane_coordinates = tissue_density @ principal_eigenvectors
@@ -3364,11 +3442,17 @@ class MacenkoNormalizer(StainNormalizer):
         stain_vectors = np.abs(stain_vectors)
 
         # Step 9: Normalize vectors to unit length
-        stain_vectors = stain_vectors / np.sqrt(np.sum(stain_vectors**2, axis=1, keepdims=True))
+        stain_vectors = stain_vectors / np.sqrt(
+            np.sum(stain_vectors**2, axis=1, keepdims=True)
+        )
 
         # Step 10: Order vectors as [hematoxylin, eosin]
         # Hematoxylin typically has larger red component
-        self.stain_matrix_target = stain_vectors if stain_vectors[0, 0] > stain_vectors[1, 0] else stain_vectors[::-1]
+        self.stain_matrix_target = (
+            stain_vectors
+            if stain_vectors[0, 0] > stain_vectors[1, 0]
+            else stain_vectors[::-1]
+        )
 
 
 def get_tissue_mask(img: np.ndarray, threshold: float = 0.85) -> np.ndarray:
@@ -3426,7 +3510,9 @@ def apply_he_stain_augmentation(
     if not augment_background:
         # Only modify tissue regions
         tissue_mask = get_tissue_mask(img).reshape(-1)
-        stain_concentrations[tissue_mask] = stain_concentrations[tissue_mask] * scale_factors + shift_values
+        stain_concentrations[tissue_mask] = (
+            stain_concentrations[tissue_mask] * scale_factors + shift_values
+        )
     else:
         # Modify all pixels
         stain_concentrations = stain_concentrations * scale_factors + shift_values
@@ -3448,5 +3534,7 @@ def convolve(img: np.ndarray, kernel: np.ndarray) -> np.ndarray:
 @clipped
 @preserve_channel_dim
 def separable_convolve(img: np.ndarray, kernel: np.ndarray) -> np.ndarray:
-    conv_fn = maybe_process_in_chunks(cv2.sepFilter2D, ddepth=-1, kernelX=kernel, kernelY=kernel)
+    conv_fn = maybe_process_in_chunks(
+        cv2.sepFilter2D, ddepth=-1, kernelX=kernel, kernelY=kernel
+    )
     return conv_fn(img)

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -147,10 +147,7 @@ def solarize(img: np.ndarray, threshold: float) -> np.ndarray:
     max_val = MAX_VALUES_BY_DTYPE[dtype]
 
     if dtype == np.uint8:
-        lut = [
-            (max_val - i if i >= threshold * max_val else i)
-            for i in range(int(max_val) + 1)
-        ]
+        lut = [(max_val - i if i >= threshold * max_val else i) for i in range(int(max_val) + 1)]
 
         prev_shape = img.shape
         img = sz_lut(img, np.array(lut, dtype=dtype), inplace=False)
@@ -389,9 +386,7 @@ def move_tone_curve(
         high_y: float | np.ndarray,
     ) -> np.ndarray:
         one_minus_t = 1 - t
-        return (
-            3 * one_minus_t**2 * t * low_y + 3 * one_minus_t * t**2 * high_y + t**3
-        ) * 255
+        return (3 * one_minus_t**2 * t * low_y + 3 * one_minus_t * t**2 * high_y + t**3) * 255
 
     num_channels = get_num_channels(img)
 
@@ -405,10 +400,7 @@ def move_tone_curve(
             inplace=False,
         )
         return cv2.merge(
-            [
-                sz_lut(img[:, :, i], np.ascontiguousarray(luts[i]), inplace=False)
-                for i in range(num_channels)
-            ],
+            [sz_lut(img[:, :, i], np.ascontiguousarray(luts[i]), inplace=False) for i in range(num_channels)],
         )
 
     raise TypeError(
@@ -489,9 +481,7 @@ def image_compression(
     Returns:
         Compressed image with same number of channels as input
     """
-    quality_flag = (
-        cv2.IMWRITE_JPEG_QUALITY if image_type == ".jpg" else cv2.IMWRITE_WEBP_QUALITY
-    )
+    quality_flag = cv2.IMWRITE_JPEG_QUALITY if image_type == ".jpg" else cv2.IMWRITE_WEBP_QUALITY
 
     num_channels = get_num_channels(img)
 
@@ -759,9 +749,7 @@ def add_rain(
     rain_layer = np.zeros_like(img, dtype=np.uint8)
 
     # Calculate end points correctly
-    end_points = rain_drops + np.array(
-        [[slant, drop_length]]
-    )  # This creates correct shape
+    end_points = rain_drops + np.array([[slant, drop_length]])  # This creates correct shape
 
     # Stack arrays properly - both must be same shape arrays
     lines = np.stack((rain_drops, end_points), axis=1)  # Use tuple and proper axis
@@ -807,10 +795,7 @@ def get_fog_particle_radiuses(
     max_fog_radius = max(2, int(min(height, width) * 0.1 * fog_intensity))
     min_radius = max(1, max_fog_radius // 2)
 
-    return [
-        random_generator.integers(min_radius, max_fog_radius)
-        for _ in range(num_particles)
-    ]
+    return [random_generator.integers(min_radius, max_fog_radius) for _ in range(num_particles)]
 
 
 @uint8_io
@@ -941,11 +926,7 @@ def add_sun_flare_overlay(
 
     for i in range(num_times):
         cv2.circle(overlay, point, int(rad[i]), src_color, -1)
-        alp = (
-            alpha[num_times - i - 1]
-            * alpha[num_times - i - 1]
-            * alpha[num_times - i - 1]
-        )
+        alp = alpha[num_times - i - 1] * alpha[num_times - i - 1] * alpha[num_times - i - 1]
         output = add_weighted(overlay, alp, output, 1 - alp)
 
     return output
@@ -1567,11 +1548,7 @@ def adjust_contrast_torchvision(img: np.ndarray, factor: float) -> np.ndarray:
     if factor == 1:
         return img
 
-    mean = (
-        img.mean()
-        if is_grayscale_image(img)
-        else cv2.cvtColor(img, cv2.COLOR_RGB2GRAY).mean()
-    )
+    mean = img.mean() if is_grayscale_image(img) else cv2.cvtColor(img, cv2.COLOR_RGB2GRAY).mean()
 
     if factor == 0:
         if img.dtype != np.float32:
@@ -1594,11 +1571,7 @@ def adjust_saturation_torchvision(
     gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
     gray = cv2.cvtColor(gray, cv2.COLOR_GRAY2RGB)
 
-    return (
-        gray
-        if factor == 0
-        else cv2.addWeighted(img, factor, gray, 1 - factor, gamma=gamma)
-    )
+    return gray if factor == 0 else cv2.addWeighted(img, factor, gray, 1 - factor, gamma=gamma)
 
 
 def _adjust_hue_torchvision_uint8(img: np.ndarray, factor: float) -> np.ndarray:
@@ -1686,11 +1659,7 @@ def superpixels(
 
                 image_sp_c[mask] = value
 
-    return (
-        fgeometric.resize(image, orig_shape[:2], interpolation)
-        if orig_shape != image.shape
-        else image
-    )
+    return fgeometric.resize(image, orig_shape[:2], interpolation) if orig_shape != image.shape else image
 
 
 @float32_io
@@ -2301,10 +2270,7 @@ def sample_uniform(
             )
 
         return np.array(
-            [
-                random_generator.uniform(low, high)
-                for low, high in ranges[:num_channels]
-            ],
+            [random_generator.uniform(low, high) for low, high in ranges[:num_channels]],
         )
 
     # use first range for spatial noise
@@ -2472,9 +2438,7 @@ def generate_plasma_pattern(
 ) -> np.ndarray:
     """Generate Plasma Fractal with consistent brightness."""
 
-    def one_diamond_square_step(
-        current_grid: np.ndarray, noise_scale: float
-    ) -> np.ndarray:
+    def one_diamond_square_step(current_grid: np.ndarray, noise_scale: float) -> np.ndarray:
         next_height = (current_grid.shape[0] - 1) * 2 + 1
         next_width = (current_grid.shape[1] - 1) * 2 + 1
 
@@ -2482,31 +2446,23 @@ def generate_plasma_pattern(
         expanded_grid = np.zeros((next_height, next_width), dtype=np.float32)
 
         # Generate all noise at once for both steps (already scaled by noise_scale)
-        all_noise = random_generator.uniform(
-            -noise_scale, noise_scale, (next_height, next_width)
-        ).astype(np.float32)
+        all_noise = random_generator.uniform(-noise_scale, noise_scale, (next_height, next_width)).astype(np.float32)
 
         # Copy existing points with noise
         expanded_grid[::2, ::2] = current_grid + all_noise[::2, ::2]
 
         # Diamond step - keep separate for natural look
-        diamond_interpolation = cv2.filter2D(
-            expanded_grid, -1, DIAMOND_KERNEL, borderType=cv2.BORDER_CONSTANT
-        )
+        diamond_interpolation = cv2.filter2D(expanded_grid, -1, DIAMOND_KERNEL, borderType=cv2.BORDER_CONSTANT)
         diamond_mask = diamond_interpolation > 0
         expanded_grid += (diamond_interpolation + all_noise) * diamond_mask
 
         # Square step - keep separate for natural look
-        square_interpolation = cv2.filter2D(
-            expanded_grid, -1, SQUARE_KERNEL, borderType=cv2.BORDER_CONSTANT
-        )
+        square_interpolation = cv2.filter2D(expanded_grid, -1, SQUARE_KERNEL, borderType=cv2.BORDER_CONSTANT)
         square_mask = square_interpolation > 0
         expanded_grid += (square_interpolation + all_noise) * square_mask
 
         # Normalize after each step to prevent value drift
-        return cv2.normalize(
-            expanded_grid, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F
-        )
+        return cv2.normalize(expanded_grid, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
 
     # Pre-compute noise scales
     max_dimension = max(target_shape)
@@ -2556,9 +2512,7 @@ def apply_plasma_brightness_contrast(
 
     # Apply brightness adjustment
     if brightness_factor != 0:
-        brightness_adjustment = multiply(
-            plasma_pattern, brightness_factor, inplace=False
-        )
+        brightness_adjustment = multiply(plasma_pattern, brightness_factor, inplace=False)
         img = add(img, brightness_adjustment, inplace=True)
 
     # Apply contrast adjustment
@@ -2612,23 +2566,15 @@ def create_directional_gradient(height: int, width: int, angle: float) -> np.nda
     """
     # Fast path for horizontal gradients
     if angle == 0:
-        return np.linspace(0, 1, width, dtype=np.float32)[None, :] * np.ones(
-            (height, 1), dtype=np.float32
-        )
+        return np.linspace(0, 1, width, dtype=np.float32)[None, :] * np.ones((height, 1), dtype=np.float32)
     if angle == 180:
-        return np.linspace(1, 0, width, dtype=np.float32)[None, :] * np.ones(
-            (height, 1), dtype=np.float32
-        )
+        return np.linspace(1, 0, width, dtype=np.float32)[None, :] * np.ones((height, 1), dtype=np.float32)
 
     # Fast path for vertical gradients
     if angle == 90:
-        return np.linspace(0, 1, height, dtype=np.float32)[:, None] * np.ones(
-            (1, width), dtype=np.float32
-        )
+        return np.linspace(0, 1, height, dtype=np.float32)[:, None] * np.ones((1, width), dtype=np.float32)
     if angle == 270:
-        return np.linspace(1, 0, height, dtype=np.float32)[:, None] * np.ones(
-            (1, width), dtype=np.float32
-        )
+        return np.linspace(1, 0, height, dtype=np.float32)[:, None] * np.ones((1, width), dtype=np.float32)
 
     # Fast path for diagonal gradients using broadcasting
     if angle in (45, 135, 225, 315):
@@ -2638,13 +2584,9 @@ def create_directional_gradient(height: int, width: int, angle: float) -> np.nda
         if angle == 45:  # Bottom-left to top-right
             return cv2.normalize(x + y, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
         if angle == 135:  # Bottom-right to top-left
-            return cv2.normalize(
-                (1 - x) + y, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F
-            )
+            return cv2.normalize((1 - x) + y, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
         if angle == 225:  # Top-right to bottom-left
-            return cv2.normalize(
-                (1 - x) + (1 - y), None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F
-            )
+            return cv2.normalize((1 - x) + (1 - y), None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
         # angle == 315:  # Top-left to bottom-right
         return cv2.normalize(x + (1 - y), None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
 
@@ -2663,9 +2605,7 @@ def create_directional_gradient(height: int, width: int, angle: float) -> np.nda
 
 
 @float32_io
-def apply_linear_illumination(
-    img: np.ndarray, intensity: float, angle: float
-) -> np.ndarray:
+def apply_linear_illumination(img: np.ndarray, intensity: float, angle: float) -> np.ndarray:
     """Apply directional illumination effect to an image using a linear gradient.
 
     The function creates a directional gradient and uses it to modulate image brightness.
@@ -2899,9 +2839,7 @@ def create_contrast_lut(
 
         # Create lookup table
         lut = np.zeros(256, dtype=np.uint8)
-        lut[min_intensity : max_intensity + 1] = np.clip(
-            np.round(cdf), 0, max_value
-        ).astype(np.uint8)
+        lut[min_intensity : max_intensity + 1] = np.clip(np.round(cdf), 0, max_value).astype(np.uint8)
         lut[max_intensity + 1 :] = max_value
         return lut
 
@@ -2910,9 +2848,7 @@ def create_contrast_lut(
     indices = np.arange(256, dtype=float)
     # Changed: Use np.round to get 128 for middle value
     # Test expects [0, 128, 255] for range [0, 2]
-    lut = np.clip(np.round((indices - min_intensity) * scale), 0, max_value).astype(
-        np.uint8
-    )
+    lut = np.clip(np.round((indices - min_intensity) * scale), 0, max_value).astype(np.uint8)
     lut[:min_intensity] = 0
     lut[max_intensity + 1 :] = max_value
     return lut
@@ -3292,18 +3228,14 @@ class SimpleNMF:
             dtype=np.float32,
         )
 
-    def fit_transform(
-        self, optical_density: np.ndarray
-    ) -> tuple[np.ndarray, np.ndarray]:
+    def fit_transform(self, optical_density: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         # Start with known H&E colors
         stain_colors = self.initial_colors.copy()
 
         # Initialize concentrations based on projection onto initial colors
         # This gives us a physically meaningful starting point
         stain_colors_normalized = normalize_vectors(stain_colors)
-        stain_concentrations = np.maximum(
-            optical_density @ stain_colors_normalized.T, 0
-        )
+        stain_concentrations = np.maximum(optical_density @ stain_colors_normalized.T, 0)
 
         # Iterative updates with careful normalization
         eps = 1e-6
@@ -3404,9 +3336,7 @@ class MacenkoNormalizer(StainNormalizer):
         # Step 4: Get principal components
         eigenvalues, eigenvectors = cv2.eigen(od_covariance)[1:]
         idx = np.argsort(eigenvalues.ravel())[-2:]
-        principal_eigenvectors = np.ascontiguousarray(
-            eigenvectors[:, idx], dtype=np.float32
-        )
+        principal_eigenvectors = np.ascontiguousarray(eigenvectors[:, idx], dtype=np.float32)
 
         # Step 5: Project onto eigenvector plane
         plane_coordinates = tissue_density @ principal_eigenvectors
@@ -3442,17 +3372,11 @@ class MacenkoNormalizer(StainNormalizer):
         stain_vectors = np.abs(stain_vectors)
 
         # Step 9: Normalize vectors to unit length
-        stain_vectors = stain_vectors / np.sqrt(
-            np.sum(stain_vectors**2, axis=1, keepdims=True)
-        )
+        stain_vectors = stain_vectors / np.sqrt(np.sum(stain_vectors**2, axis=1, keepdims=True))
 
         # Step 10: Order vectors as [hematoxylin, eosin]
         # Hematoxylin typically has larger red component
-        self.stain_matrix_target = (
-            stain_vectors
-            if stain_vectors[0, 0] > stain_vectors[1, 0]
-            else stain_vectors[::-1]
-        )
+        self.stain_matrix_target = stain_vectors if stain_vectors[0, 0] > stain_vectors[1, 0] else stain_vectors[::-1]
 
 
 def get_tissue_mask(img: np.ndarray, threshold: float = 0.85) -> np.ndarray:
@@ -3510,9 +3434,7 @@ def apply_he_stain_augmentation(
     if not augment_background:
         # Only modify tissue regions
         tissue_mask = get_tissue_mask(img).reshape(-1)
-        stain_concentrations[tissue_mask] = (
-            stain_concentrations[tissue_mask] * scale_factors + shift_values
-        )
+        stain_concentrations[tissue_mask] = stain_concentrations[tissue_mask] * scale_factors + shift_values
     else:
         # Modify all pixels
         stain_concentrations = stain_concentrations * scale_factors + shift_values
@@ -3534,7 +3456,5 @@ def convolve(img: np.ndarray, kernel: np.ndarray) -> np.ndarray:
 @clipped
 @preserve_channel_dim
 def separable_convolve(img: np.ndarray, kernel: np.ndarray) -> np.ndarray:
-    conv_fn = maybe_process_in_chunks(
-        cv2.sepFilter2D, ddepth=-1, kernelX=kernel, kernelY=kernel
-    )
+    conv_fn = maybe_process_in_chunks(cv2.sepFilter2D, ddepth=-1, kernelX=kernel, kernelY=kernel)
     return conv_fn(img)


### PR DESCRIPTION
### 📄 10% (0.10x) speedup for ***`clahe` in `albumentations/augmentations/functional.py`***

⏱️ Runtime :   **`331 milliseconds`**  **→** **`302 milliseconds`** (best of `18` runs)
<details>
<summary> 📝 Explanation and details</summary>

Sure, here are some optimizations that can be applied to the given `clahe` function.

1. Remove the redundant `img.copy()`. Since the function operates on the input image in-place and there are no concerns with modifying the original, the copy operation can be skipped.
2. The CLAHE object can be reused across multiple calls if reinitializing it proves costly, but that might require substantial interface changes which aren't allowed here.

Below is a more optimized version of the code.



By removing the unnecessary copying of the input image, we save memory and processing time. The key improvement is the elimination of redundant processing steps. This should provide a more efficient implementation while maintaining the original functionality.

</details>

✅ **Correctness verification report:**


| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | ✅ **124 Passed** |
| 🌀 Generated Regression Tests | ✅ **25 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>⚙️ Existing Unit Tests Details</summary>

```python
- functional/test_functional.py
```

</details>

<details>
<summary>🌀 Generated Regression Tests Details</summary>

```python
from __future__ import annotations

import cv2
import numpy as np
# imports
import pytest  # used for our unit tests
from albucore import is_grayscale_image, preserve_channel_dim, uint8_io
from albumentations.augmentations.functional import clahe

# unit tests

def test_basic_grayscale_image():
    # Simple 2D grayscale image with uniform intensity
    img = np.ones((100, 100), dtype=np.uint8) * 128
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))

def test_basic_color_image():
    # Simple 3D RGB image with uniform color
    img = np.ones((100, 100, 3), dtype=np.uint8) * 128
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))


def test_edge_single_pixel_image():
    # 1x1 grayscale image
    img = np.array([[128]], dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))

def test_edge_non_standard_shapes():
    # Very wide aspect ratio
    img = np.ones((1, 1000), dtype=np.uint8) * 128
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))

def test_data_types():
    # Image with float32 data type
    img = np.random.rand(100, 100).astype(np.float32)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))


def test_invalid_data_types():
    # Image with object data type
    img = np.array([['a', 'b'], ['c', 'd']], dtype=object)
    with pytest.raises(TypeError):
        clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))



def test_large_scale_grayscale_image():
    # Large 2D grayscale image
    img = np.random.randint(0, 256, (4000, 4000), dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))

def test_large_scale_color_image():
    # Large 3D RGB image
    img = np.random.randint(0, 256, (4000, 4000, 3), dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))

def test_performance_under_load():
    # Measure execution time for large image
    img = np.random.randint(0, 256, (4000, 4000), dtype=np.uint8)
    import time
    start_time = time.time()
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))
    end_time = time.time()

def test_color_space_integrity():
    # Verify conversion to LAB and back to RGB
    img = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))

def test_deterministic_behavior():
    # Ensure consistent output across runs
    img = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))
    np.testing.assert_array_equal(result1, result2)




from __future__ import annotations

import cv2
import numpy as np
# imports
import pytest  # used for our unit tests
from albucore import is_grayscale_image, preserve_channel_dim, uint8_io
from albumentations.augmentations.functional import clahe

# unit tests

def test_clahe_grayscale_uniform_values():
    # Grayscale image with uniform values
    img = np.full((100, 100), 128, dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))

def test_clahe_color_random_values():
    # Color image with random values
    img = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))


def test_clahe_single_pixel_image():
    # Single pixel image
    img = np.array([[128]], dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))

def test_clahe_non_standard_shape():
    # Very wide image
    img = np.random.randint(0, 256, (1, 1000), dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))

    # Very tall image
    img = np.random.randint(0, 256, (1000, 1), dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))



def test_clahe_high_clip_limit():
    # High clip limit
    img = np.random.randint(0, 256, (100, 100), dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=100.0, tile_grid_size=(8, 8))

def test_clahe_small_tile_grid_size():
    # Small tile grid size
    img = np.random.randint(0, 256, (100, 100), dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(1, 1))

def test_clahe_large_tile_grid_size():
    # Large tile grid size
    img = np.random.randint(0, 256, (100, 100), dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(50, 50))

def test_clahe_large_image():
    # Large image
    img = np.random.randint(0, 256, (4000, 4000, 3), dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))

def test_clahe_reproducibility():
    # Reproducibility
    img = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))

def test_clahe_input_image_integrity():
    # Input image integrity
    img = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
    img_copy = img.copy()
    codeflash_output = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))

def test_clahe_color_conversion_accuracy():
    # Color conversion accuracy
    img = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
    lab_img = cv2.cvtColor(img, cv2.COLOR_RGB2LAB)
    rgb_img = cv2.cvtColor(lab_img, cv2.COLOR_LAB2RGB)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>



[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)

## Summary by Sourcery

Enhancements:
- Improve the performance of the clahe function by removing the redundant img.copy() operation.