### PR TITLE
⚡️ Speed up function `_handle_mask` by 40%

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -163,10 +163,7 @@ def solarize(img: np.ndarray, threshold: float) -> np.ndarray:
 
 @uint8_io
 @clipped
-def posterize(
-    img: np.ndarray,
-    bits: Literal[1, 2, 3, 4, 5, 6, 7] | list[Literal[1, 2, 3, 4, 5, 6, 7]],
-) -> np.ndarray:
+def posterize(img: np.ndarray, bits: Literal[1, 2, 3, 4, 5, 6, 7] | list[Literal[1, 2, 3, 4, 5, 6, 7]]) -> np.ndarray:
     """Reduce the number of bits for each color channel by keeping only the highest N bits.
 
     This transform performs bit-depth reduction by masking out lower bits, effectively
@@ -2480,14 +2477,7 @@ def generate_plasma_pattern(
         plasma_grid = one_diamond_square_step(plasma_grid, noise_scale)
 
     return np.clip(
-        cv2.normalize(
-            plasma_grid[: target_shape[0], : target_shape[1]],
-            None,
-            0,
-            1,
-            cv2.NORM_MINMAX,
-            dtype=cv2.CV_32F,
-        ),
+        cv2.normalize(plasma_grid[: target_shape[0], : target_shape[1]], None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F),
         0,
         1,
     )

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -147,10 +147,7 @@ def solarize(img: np.ndarray, threshold: float) -> np.ndarray:
     max_val = MAX_VALUES_BY_DTYPE[dtype]
 
     if dtype == np.uint8:
-        lut = [
-            (max_val - i if i >= threshold * max_val else i)
-            for i in range(int(max_val) + 1)
-        ]
+        lut = [(max_val - i if i >= threshold * max_val else i) for i in range(int(max_val) + 1)]
 
         prev_shape = img.shape
         img = sz_lut(img, np.array(lut, dtype=dtype), inplace=False)
@@ -389,9 +386,7 @@ def move_tone_curve(
         high_y: float | np.ndarray,
     ) -> np.ndarray:
         one_minus_t = 1 - t
-        return (
-            3 * one_minus_t**2 * t * low_y + 3 * one_minus_t * t**2 * high_y + t**3
-        ) * 255
+        return (3 * one_minus_t**2 * t * low_y + 3 * one_minus_t * t**2 * high_y + t**3) * 255
 
     num_channels = get_num_channels(img)
 
@@ -405,10 +400,7 @@ def move_tone_curve(
             inplace=False,
         )
         return cv2.merge(
-            [
-                sz_lut(img[:, :, i], np.ascontiguousarray(luts[i]), inplace=False)
-                for i in range(num_channels)
-            ],
+            [sz_lut(img[:, :, i], np.ascontiguousarray(luts[i]), inplace=False) for i in range(num_channels)],
         )
 
     raise TypeError(
@@ -491,9 +483,7 @@ def image_compression(
     Returns:
         Compressed image with same number of channels as input
     """
-    quality_flag = (
-        cv2.IMWRITE_JPEG_QUALITY if image_type == ".jpg" else cv2.IMWRITE_WEBP_QUALITY
-    )
+    quality_flag = cv2.IMWRITE_JPEG_QUALITY if image_type == ".jpg" else cv2.IMWRITE_WEBP_QUALITY
 
     num_channels = get_num_channels(img)
 
@@ -761,9 +751,7 @@ def add_rain(
     rain_layer = np.zeros_like(img, dtype=np.uint8)
 
     # Calculate end points correctly
-    end_points = rain_drops + np.array(
-        [[slant, drop_length]]
-    )  # This creates correct shape
+    end_points = rain_drops + np.array([[slant, drop_length]])  # This creates correct shape
 
     # Stack arrays properly - both must be same shape arrays
     lines = np.stack((rain_drops, end_points), axis=1)  # Use tuple and proper axis
@@ -809,10 +797,7 @@ def get_fog_particle_radiuses(
     max_fog_radius = max(2, int(min(height, width) * 0.1 * fog_intensity))
     min_radius = max(1, max_fog_radius // 2)
 
-    return [
-        random_generator.integers(min_radius, max_fog_radius)
-        for _ in range(num_particles)
-    ]
+    return [random_generator.integers(min_radius, max_fog_radius) for _ in range(num_particles)]
 
 
 @uint8_io
@@ -943,11 +928,7 @@ def add_sun_flare_overlay(
 
     for i in range(num_times):
         cv2.circle(overlay, point, int(rad[i]), src_color, -1)
-        alp = (
-            alpha[num_times - i - 1]
-            * alpha[num_times - i - 1]
-            * alpha[num_times - i - 1]
-        )
+        alp = alpha[num_times - i - 1] * alpha[num_times - i - 1] * alpha[num_times - i - 1]
         output = add_weighted(overlay, alp, output, 1 - alp)
 
     return output
@@ -1569,11 +1550,7 @@ def adjust_contrast_torchvision(img: np.ndarray, factor: float) -> np.ndarray:
     if factor == 1:
         return img
 
-    mean = (
-        img.mean()
-        if is_grayscale_image(img)
-        else cv2.cvtColor(img, cv2.COLOR_RGB2GRAY).mean()
-    )
+    mean = img.mean() if is_grayscale_image(img) else cv2.cvtColor(img, cv2.COLOR_RGB2GRAY).mean()
 
     if factor == 0:
         if img.dtype != np.float32:
@@ -1596,11 +1573,7 @@ def adjust_saturation_torchvision(
     gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
     gray = cv2.cvtColor(gray, cv2.COLOR_GRAY2RGB)
 
-    return (
-        gray
-        if factor == 0
-        else cv2.addWeighted(img, factor, gray, 1 - factor, gamma=gamma)
-    )
+    return gray if factor == 0 else cv2.addWeighted(img, factor, gray, 1 - factor, gamma=gamma)
 
 
 def _adjust_hue_torchvision_uint8(img: np.ndarray, factor: float) -> np.ndarray:
@@ -1688,11 +1661,7 @@ def superpixels(
 
                 image_sp_c[mask] = value
 
-    return (
-        fgeometric.resize(image, orig_shape[:2], interpolation)
-        if orig_shape != image.shape
-        else image
-    )
+    return fgeometric.resize(image, orig_shape[:2], interpolation) if orig_shape != image.shape else image
 
 
 @float32_io
@@ -2303,10 +2272,7 @@ def sample_uniform(
             )
 
         return np.array(
-            [
-                random_generator.uniform(low, high)
-                for low, high in ranges[:num_channels]
-            ],
+            [random_generator.uniform(low, high) for low, high in ranges[:num_channels]],
         )
 
     # use first range for spatial noise
@@ -2474,9 +2440,7 @@ def generate_plasma_pattern(
 ) -> np.ndarray:
     """Generate Plasma Fractal with consistent brightness."""
 
-    def one_diamond_square_step(
-        current_grid: np.ndarray, noise_scale: float
-    ) -> np.ndarray:
+    def one_diamond_square_step(current_grid: np.ndarray, noise_scale: float) -> np.ndarray:
         next_height = (current_grid.shape[0] - 1) * 2 + 1
         next_width = (current_grid.shape[1] - 1) * 2 + 1
 
@@ -2484,31 +2448,23 @@ def generate_plasma_pattern(
         expanded_grid = np.zeros((next_height, next_width), dtype=np.float32)
 
         # Generate all noise at once for both steps (already scaled by noise_scale)
-        all_noise = random_generator.uniform(
-            -noise_scale, noise_scale, (next_height, next_width)
-        ).astype(np.float32)
+        all_noise = random_generator.uniform(-noise_scale, noise_scale, (next_height, next_width)).astype(np.float32)
 
         # Copy existing points with noise
         expanded_grid[::2, ::2] = current_grid + all_noise[::2, ::2]
 
         # Diamond step - keep separate for natural look
-        diamond_interpolation = cv2.filter2D(
-            expanded_grid, -1, DIAMOND_KERNEL, borderType=cv2.BORDER_CONSTANT
-        )
+        diamond_interpolation = cv2.filter2D(expanded_grid, -1, DIAMOND_KERNEL, borderType=cv2.BORDER_CONSTANT)
         diamond_mask = diamond_interpolation > 0
         expanded_grid += (diamond_interpolation + all_noise) * diamond_mask
 
         # Square step - keep separate for natural look
-        square_interpolation = cv2.filter2D(
-            expanded_grid, -1, SQUARE_KERNEL, borderType=cv2.BORDER_CONSTANT
-        )
+        square_interpolation = cv2.filter2D(expanded_grid, -1, SQUARE_KERNEL, borderType=cv2.BORDER_CONSTANT)
         square_mask = square_interpolation > 0
         expanded_grid += (square_interpolation + all_noise) * square_mask
 
         # Normalize after each step to prevent value drift
-        return cv2.normalize(
-            expanded_grid, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F
-        )
+        return cv2.normalize(expanded_grid, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
 
     # Pre-compute noise scales
     max_dimension = max(target_shape)
@@ -2558,9 +2514,7 @@ def apply_plasma_brightness_contrast(
 
     # Apply brightness adjustment
     if brightness_factor != 0:
-        brightness_adjustment = multiply(
-            plasma_pattern, brightness_factor, inplace=False
-        )
+        brightness_adjustment = multiply(plasma_pattern, brightness_factor, inplace=False)
         img = add(img, brightness_adjustment, inplace=True)
 
     # Apply contrast adjustment
@@ -2614,23 +2568,15 @@ def create_directional_gradient(height: int, width: int, angle: float) -> np.nda
     """
     # Fast path for horizontal gradients
     if angle == 0:
-        return np.linspace(0, 1, width, dtype=np.float32)[None, :] * np.ones(
-            (height, 1), dtype=np.float32
-        )
+        return np.linspace(0, 1, width, dtype=np.float32)[None, :] * np.ones((height, 1), dtype=np.float32)
     if angle == 180:
-        return np.linspace(1, 0, width, dtype=np.float32)[None, :] * np.ones(
-            (height, 1), dtype=np.float32
-        )
+        return np.linspace(1, 0, width, dtype=np.float32)[None, :] * np.ones((height, 1), dtype=np.float32)
 
     # Fast path for vertical gradients
     if angle == 90:
-        return np.linspace(0, 1, height, dtype=np.float32)[:, None] * np.ones(
-            (1, width), dtype=np.float32
-        )
+        return np.linspace(0, 1, height, dtype=np.float32)[:, None] * np.ones((1, width), dtype=np.float32)
     if angle == 270:
-        return np.linspace(1, 0, height, dtype=np.float32)[:, None] * np.ones(
-            (1, width), dtype=np.float32
-        )
+        return np.linspace(1, 0, height, dtype=np.float32)[:, None] * np.ones((1, width), dtype=np.float32)
 
     # Fast path for diagonal gradients using broadcasting
     if angle in (45, 135, 225, 315):
@@ -2640,13 +2586,9 @@ def create_directional_gradient(height: int, width: int, angle: float) -> np.nda
         if angle == 45:  # Bottom-left to top-right
             return cv2.normalize(x + y, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
         if angle == 135:  # Bottom-right to top-left
-            return cv2.normalize(
-                (1 - x) + y, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F
-            )
+            return cv2.normalize((1 - x) + y, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
         if angle == 225:  # Top-right to bottom-left
-            return cv2.normalize(
-                (1 - x) + (1 - y), None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F
-            )
+            return cv2.normalize((1 - x) + (1 - y), None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
         # angle == 315:  # Top-left to bottom-right
         return cv2.normalize(x + (1 - y), None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
 
@@ -2665,9 +2607,7 @@ def create_directional_gradient(height: int, width: int, angle: float) -> np.nda
 
 
 @float32_io
-def apply_linear_illumination(
-    img: np.ndarray, intensity: float, angle: float
-) -> np.ndarray:
+def apply_linear_illumination(img: np.ndarray, intensity: float, angle: float) -> np.ndarray:
     """Apply directional illumination effect to an image using a linear gradient.
 
     The function creates a directional gradient and uses it to modulate image brightness.
@@ -2901,9 +2841,7 @@ def create_contrast_lut(
 
         # Create lookup table
         lut = np.zeros(256, dtype=np.uint8)
-        lut[min_intensity : max_intensity + 1] = np.clip(
-            np.round(cdf), 0, max_value
-        ).astype(np.uint8)
+        lut[min_intensity : max_intensity + 1] = np.clip(np.round(cdf), 0, max_value).astype(np.uint8)
         lut[max_intensity + 1 :] = max_value
         return lut
 
@@ -2912,9 +2850,7 @@ def create_contrast_lut(
     indices = np.arange(256, dtype=float)
     # Changed: Use np.round to get 128 for middle value
     # Test expects [0, 128, 255] for range [0, 2]
-    lut = np.clip(np.round((indices - min_intensity) * scale), 0, max_value).astype(
-        np.uint8
-    )
+    lut = np.clip(np.round((indices - min_intensity) * scale), 0, max_value).astype(np.uint8)
     lut[:min_intensity] = 0
     lut[max_intensity + 1 :] = max_value
     return lut
@@ -3294,18 +3230,14 @@ class SimpleNMF:
             dtype=np.float32,
         )
 
-    def fit_transform(
-        self, optical_density: np.ndarray
-    ) -> tuple[np.ndarray, np.ndarray]:
+    def fit_transform(self, optical_density: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         # Start with known H&E colors
         stain_colors = self.initial_colors.copy()
 
         # Initialize concentrations based on projection onto initial colors
         # This gives us a physically meaningful starting point
         stain_colors_normalized = normalize_vectors(stain_colors)
-        stain_concentrations = np.maximum(
-            optical_density @ stain_colors_normalized.T, 0
-        )
+        stain_concentrations = np.maximum(optical_density @ stain_colors_normalized.T, 0)
 
         # Iterative updates with careful normalization
         eps = 1e-6
@@ -3406,9 +3338,7 @@ class MacenkoNormalizer(StainNormalizer):
         # Step 4: Get principal components
         eigenvalues, eigenvectors = cv2.eigen(od_covariance)[1:]
         idx = np.argsort(eigenvalues.ravel())[-2:]
-        principal_eigenvectors = np.ascontiguousarray(
-            eigenvectors[:, idx], dtype=np.float32
-        )
+        principal_eigenvectors = np.ascontiguousarray(eigenvectors[:, idx], dtype=np.float32)
 
         # Step 5: Project onto eigenvector plane
         plane_coordinates = tissue_density @ principal_eigenvectors
@@ -3444,17 +3374,11 @@ class MacenkoNormalizer(StainNormalizer):
         stain_vectors = np.abs(stain_vectors)
 
         # Step 9: Normalize vectors to unit length
-        stain_vectors = stain_vectors / np.sqrt(
-            np.sum(stain_vectors**2, axis=1, keepdims=True)
-        )
+        stain_vectors = stain_vectors / np.sqrt(np.sum(stain_vectors**2, axis=1, keepdims=True))
 
         # Step 10: Order vectors as [hematoxylin, eosin]
         # Hematoxylin typically has larger red component
-        self.stain_matrix_target = (
-            stain_vectors
-            if stain_vectors[0, 0] > stain_vectors[1, 0]
-            else stain_vectors[::-1]
-        )
+        self.stain_matrix_target = stain_vectors if stain_vectors[0, 0] > stain_vectors[1, 0] else stain_vectors[::-1]
 
 
 def get_tissue_mask(img: np.ndarray, threshold: float = 0.85) -> np.ndarray:
@@ -3512,9 +3436,7 @@ def apply_he_stain_augmentation(
     if not augment_background:
         # Only modify tissue regions
         tissue_mask = get_tissue_mask(img).reshape(-1)
-        stain_concentrations[tissue_mask] = (
-            stain_concentrations[tissue_mask] * scale_factors + shift_values
-        )
+        stain_concentrations[tissue_mask] = stain_concentrations[tissue_mask] * scale_factors + shift_values
     else:
         # Modify all pixels
         stain_concentrations = stain_concentrations * scale_factors + shift_values
@@ -3536,7 +3458,5 @@ def convolve(img: np.ndarray, kernel: np.ndarray) -> np.ndarray:
 @clipped
 @preserve_channel_dim
 def separable_convolve(img: np.ndarray, kernel: np.ndarray) -> np.ndarray:
-    conv_fn = maybe_process_in_chunks(
-        cv2.sepFilter2D, ddepth=-1, kernelX=kernel, kernelY=kernel
-    )
+    conv_fn = maybe_process_in_chunks(cv2.sepFilter2D, ddepth=-1, kernelX=kernel, kernelY=kernel)
     return conv_fn(img)

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -147,7 +147,10 @@ def solarize(img: np.ndarray, threshold: float) -> np.ndarray:
     max_val = MAX_VALUES_BY_DTYPE[dtype]
 
     if dtype == np.uint8:
-        lut = [(max_val - i if i >= threshold * max_val else i) for i in range(int(max_val) + 1)]
+        lut = [
+            (max_val - i if i >= threshold * max_val else i)
+            for i in range(int(max_val) + 1)
+        ]
 
         prev_shape = img.shape
         img = sz_lut(img, np.array(lut, dtype=dtype), inplace=False)
@@ -163,7 +166,10 @@ def solarize(img: np.ndarray, threshold: float) -> np.ndarray:
 
 @uint8_io
 @clipped
-def posterize(img: np.ndarray, bits: Literal[1, 2, 3, 4, 5, 6, 7] | list[Literal[1, 2, 3, 4, 5, 6, 7]]) -> np.ndarray:
+def posterize(
+    img: np.ndarray,
+    bits: Literal[1, 2, 3, 4, 5, 6, 7] | list[Literal[1, 2, 3, 4, 5, 6, 7]],
+) -> np.ndarray:
     """Reduce the number of bits for each color channel by keeping only the highest N bits.
 
     This transform performs bit-depth reduction by masking out lower bits, effectively
@@ -287,11 +293,11 @@ def _handle_mask(
 ) -> np.ndarray | None:
     if mask is None:
         return None
-    mask = mask.astype(np.uint8)
-    if is_grayscale_image(mask) or i is None:
-        return mask
 
-    return mask[..., i]
+    if i is None or is_grayscale_image(mask):
+        return mask.astype(np.uint8)
+
+    return mask[..., i].astype(np.uint8)
 
 
 @uint8_io
@@ -383,7 +389,9 @@ def move_tone_curve(
         high_y: float | np.ndarray,
     ) -> np.ndarray:
         one_minus_t = 1 - t
-        return (3 * one_minus_t**2 * t * low_y + 3 * one_minus_t * t**2 * high_y + t**3) * 255
+        return (
+            3 * one_minus_t**2 * t * low_y + 3 * one_minus_t * t**2 * high_y + t**3
+        ) * 255
 
     num_channels = get_num_channels(img)
 
@@ -397,7 +405,10 @@ def move_tone_curve(
             inplace=False,
         )
         return cv2.merge(
-            [sz_lut(img[:, :, i], np.ascontiguousarray(luts[i]), inplace=False) for i in range(num_channels)],
+            [
+                sz_lut(img[:, :, i], np.ascontiguousarray(luts[i]), inplace=False)
+                for i in range(num_channels)
+            ],
         )
 
     raise TypeError(
@@ -480,7 +491,9 @@ def image_compression(
     Returns:
         Compressed image with same number of channels as input
     """
-    quality_flag = cv2.IMWRITE_JPEG_QUALITY if image_type == ".jpg" else cv2.IMWRITE_WEBP_QUALITY
+    quality_flag = (
+        cv2.IMWRITE_JPEG_QUALITY if image_type == ".jpg" else cv2.IMWRITE_WEBP_QUALITY
+    )
 
     num_channels = get_num_channels(img)
 
@@ -748,7 +761,9 @@ def add_rain(
     rain_layer = np.zeros_like(img, dtype=np.uint8)
 
     # Calculate end points correctly
-    end_points = rain_drops + np.array([[slant, drop_length]])  # This creates correct shape
+    end_points = rain_drops + np.array(
+        [[slant, drop_length]]
+    )  # This creates correct shape
 
     # Stack arrays properly - both must be same shape arrays
     lines = np.stack((rain_drops, end_points), axis=1)  # Use tuple and proper axis
@@ -794,7 +809,10 @@ def get_fog_particle_radiuses(
     max_fog_radius = max(2, int(min(height, width) * 0.1 * fog_intensity))
     min_radius = max(1, max_fog_radius // 2)
 
-    return [random_generator.integers(min_radius, max_fog_radius) for _ in range(num_particles)]
+    return [
+        random_generator.integers(min_radius, max_fog_radius)
+        for _ in range(num_particles)
+    ]
 
 
 @uint8_io
@@ -925,7 +943,11 @@ def add_sun_flare_overlay(
 
     for i in range(num_times):
         cv2.circle(overlay, point, int(rad[i]), src_color, -1)
-        alp = alpha[num_times - i - 1] * alpha[num_times - i - 1] * alpha[num_times - i - 1]
+        alp = (
+            alpha[num_times - i - 1]
+            * alpha[num_times - i - 1]
+            * alpha[num_times - i - 1]
+        )
         output = add_weighted(overlay, alp, output, 1 - alp)
 
     return output
@@ -1547,7 +1569,11 @@ def adjust_contrast_torchvision(img: np.ndarray, factor: float) -> np.ndarray:
     if factor == 1:
         return img
 
-    mean = img.mean() if is_grayscale_image(img) else cv2.cvtColor(img, cv2.COLOR_RGB2GRAY).mean()
+    mean = (
+        img.mean()
+        if is_grayscale_image(img)
+        else cv2.cvtColor(img, cv2.COLOR_RGB2GRAY).mean()
+    )
 
     if factor == 0:
         if img.dtype != np.float32:
@@ -1570,7 +1596,11 @@ def adjust_saturation_torchvision(
     gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
     gray = cv2.cvtColor(gray, cv2.COLOR_GRAY2RGB)
 
-    return gray if factor == 0 else cv2.addWeighted(img, factor, gray, 1 - factor, gamma=gamma)
+    return (
+        gray
+        if factor == 0
+        else cv2.addWeighted(img, factor, gray, 1 - factor, gamma=gamma)
+    )
 
 
 def _adjust_hue_torchvision_uint8(img: np.ndarray, factor: float) -> np.ndarray:
@@ -1658,7 +1688,11 @@ def superpixels(
 
                 image_sp_c[mask] = value
 
-    return fgeometric.resize(image, orig_shape[:2], interpolation) if orig_shape != image.shape else image
+    return (
+        fgeometric.resize(image, orig_shape[:2], interpolation)
+        if orig_shape != image.shape
+        else image
+    )
 
 
 @float32_io
@@ -2269,7 +2303,10 @@ def sample_uniform(
             )
 
         return np.array(
-            [random_generator.uniform(low, high) for low, high in ranges[:num_channels]],
+            [
+                random_generator.uniform(low, high)
+                for low, high in ranges[:num_channels]
+            ],
         )
 
     # use first range for spatial noise
@@ -2437,7 +2474,9 @@ def generate_plasma_pattern(
 ) -> np.ndarray:
     """Generate Plasma Fractal with consistent brightness."""
 
-    def one_diamond_square_step(current_grid: np.ndarray, noise_scale: float) -> np.ndarray:
+    def one_diamond_square_step(
+        current_grid: np.ndarray, noise_scale: float
+    ) -> np.ndarray:
         next_height = (current_grid.shape[0] - 1) * 2 + 1
         next_width = (current_grid.shape[1] - 1) * 2 + 1
 
@@ -2445,23 +2484,31 @@ def generate_plasma_pattern(
         expanded_grid = np.zeros((next_height, next_width), dtype=np.float32)
 
         # Generate all noise at once for both steps (already scaled by noise_scale)
-        all_noise = random_generator.uniform(-noise_scale, noise_scale, (next_height, next_width)).astype(np.float32)
+        all_noise = random_generator.uniform(
+            -noise_scale, noise_scale, (next_height, next_width)
+        ).astype(np.float32)
 
         # Copy existing points with noise
         expanded_grid[::2, ::2] = current_grid + all_noise[::2, ::2]
 
         # Diamond step - keep separate for natural look
-        diamond_interpolation = cv2.filter2D(expanded_grid, -1, DIAMOND_KERNEL, borderType=cv2.BORDER_CONSTANT)
+        diamond_interpolation = cv2.filter2D(
+            expanded_grid, -1, DIAMOND_KERNEL, borderType=cv2.BORDER_CONSTANT
+        )
         diamond_mask = diamond_interpolation > 0
         expanded_grid += (diamond_interpolation + all_noise) * diamond_mask
 
         # Square step - keep separate for natural look
-        square_interpolation = cv2.filter2D(expanded_grid, -1, SQUARE_KERNEL, borderType=cv2.BORDER_CONSTANT)
+        square_interpolation = cv2.filter2D(
+            expanded_grid, -1, SQUARE_KERNEL, borderType=cv2.BORDER_CONSTANT
+        )
         square_mask = square_interpolation > 0
         expanded_grid += (square_interpolation + all_noise) * square_mask
 
         # Normalize after each step to prevent value drift
-        return cv2.normalize(expanded_grid, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
+        return cv2.normalize(
+            expanded_grid, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F
+        )
 
     # Pre-compute noise scales
     max_dimension = max(target_shape)
@@ -2477,7 +2524,14 @@ def generate_plasma_pattern(
         plasma_grid = one_diamond_square_step(plasma_grid, noise_scale)
 
     return np.clip(
-        cv2.normalize(plasma_grid[: target_shape[0], : target_shape[1]], None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F),
+        cv2.normalize(
+            plasma_grid[: target_shape[0], : target_shape[1]],
+            None,
+            0,
+            1,
+            cv2.NORM_MINMAX,
+            dtype=cv2.CV_32F,
+        ),
         0,
         1,
     )
@@ -2504,7 +2558,9 @@ def apply_plasma_brightness_contrast(
 
     # Apply brightness adjustment
     if brightness_factor != 0:
-        brightness_adjustment = multiply(plasma_pattern, brightness_factor, inplace=False)
+        brightness_adjustment = multiply(
+            plasma_pattern, brightness_factor, inplace=False
+        )
         img = add(img, brightness_adjustment, inplace=True)
 
     # Apply contrast adjustment
@@ -2558,15 +2614,23 @@ def create_directional_gradient(height: int, width: int, angle: float) -> np.nda
     """
     # Fast path for horizontal gradients
     if angle == 0:
-        return np.linspace(0, 1, width, dtype=np.float32)[None, :] * np.ones((height, 1), dtype=np.float32)
+        return np.linspace(0, 1, width, dtype=np.float32)[None, :] * np.ones(
+            (height, 1), dtype=np.float32
+        )
     if angle == 180:
-        return np.linspace(1, 0, width, dtype=np.float32)[None, :] * np.ones((height, 1), dtype=np.float32)
+        return np.linspace(1, 0, width, dtype=np.float32)[None, :] * np.ones(
+            (height, 1), dtype=np.float32
+        )
 
     # Fast path for vertical gradients
     if angle == 90:
-        return np.linspace(0, 1, height, dtype=np.float32)[:, None] * np.ones((1, width), dtype=np.float32)
+        return np.linspace(0, 1, height, dtype=np.float32)[:, None] * np.ones(
+            (1, width), dtype=np.float32
+        )
     if angle == 270:
-        return np.linspace(1, 0, height, dtype=np.float32)[:, None] * np.ones((1, width), dtype=np.float32)
+        return np.linspace(1, 0, height, dtype=np.float32)[:, None] * np.ones(
+            (1, width), dtype=np.float32
+        )
 
     # Fast path for diagonal gradients using broadcasting
     if angle in (45, 135, 225, 315):
@@ -2576,9 +2640,13 @@ def create_directional_gradient(height: int, width: int, angle: float) -> np.nda
         if angle == 45:  # Bottom-left to top-right
             return cv2.normalize(x + y, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
         if angle == 135:  # Bottom-right to top-left
-            return cv2.normalize((1 - x) + y, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
+            return cv2.normalize(
+                (1 - x) + y, None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F
+            )
         if angle == 225:  # Top-right to bottom-left
-            return cv2.normalize((1 - x) + (1 - y), None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
+            return cv2.normalize(
+                (1 - x) + (1 - y), None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F
+            )
         # angle == 315:  # Top-left to bottom-right
         return cv2.normalize(x + (1 - y), None, 0, 1, cv2.NORM_MINMAX, dtype=cv2.CV_32F)
 
@@ -2597,7 +2665,9 @@ def create_directional_gradient(height: int, width: int, angle: float) -> np.nda
 
 
 @float32_io
-def apply_linear_illumination(img: np.ndarray, intensity: float, angle: float) -> np.ndarray:
+def apply_linear_illumination(
+    img: np.ndarray, intensity: float, angle: float
+) -> np.ndarray:
     """Apply directional illumination effect to an image using a linear gradient.
 
     The function creates a directional gradient and uses it to modulate image brightness.
@@ -2831,7 +2901,9 @@ def create_contrast_lut(
 
         # Create lookup table
         lut = np.zeros(256, dtype=np.uint8)
-        lut[min_intensity : max_intensity + 1] = np.clip(np.round(cdf), 0, max_value).astype(np.uint8)
+        lut[min_intensity : max_intensity + 1] = np.clip(
+            np.round(cdf), 0, max_value
+        ).astype(np.uint8)
         lut[max_intensity + 1 :] = max_value
         return lut
 
@@ -2840,7 +2912,9 @@ def create_contrast_lut(
     indices = np.arange(256, dtype=float)
     # Changed: Use np.round to get 128 for middle value
     # Test expects [0, 128, 255] for range [0, 2]
-    lut = np.clip(np.round((indices - min_intensity) * scale), 0, max_value).astype(np.uint8)
+    lut = np.clip(np.round((indices - min_intensity) * scale), 0, max_value).astype(
+        np.uint8
+    )
     lut[:min_intensity] = 0
     lut[max_intensity + 1 :] = max_value
     return lut
@@ -3220,14 +3294,18 @@ class SimpleNMF:
             dtype=np.float32,
         )
 
-    def fit_transform(self, optical_density: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    def fit_transform(
+        self, optical_density: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
         # Start with known H&E colors
         stain_colors = self.initial_colors.copy()
 
         # Initialize concentrations based on projection onto initial colors
         # This gives us a physically meaningful starting point
         stain_colors_normalized = normalize_vectors(stain_colors)
-        stain_concentrations = np.maximum(optical_density @ stain_colors_normalized.T, 0)
+        stain_concentrations = np.maximum(
+            optical_density @ stain_colors_normalized.T, 0
+        )
 
         # Iterative updates with careful normalization
         eps = 1e-6
@@ -3328,7 +3406,9 @@ class MacenkoNormalizer(StainNormalizer):
         # Step 4: Get principal components
         eigenvalues, eigenvectors = cv2.eigen(od_covariance)[1:]
         idx = np.argsort(eigenvalues.ravel())[-2:]
-        principal_eigenvectors = np.ascontiguousarray(eigenvectors[:, idx], dtype=np.float32)
+        principal_eigenvectors = np.ascontiguousarray(
+            eigenvectors[:, idx], dtype=np.float32
+        )
 
         # Step 5: Project onto eigenvector plane
         plane_coordinates = tissue_density @ principal_eigenvectors
@@ -3364,11 +3444,17 @@ class MacenkoNormalizer(StainNormalizer):
         stain_vectors = np.abs(stain_vectors)
 
         # Step 9: Normalize vectors to unit length
-        stain_vectors = stain_vectors / np.sqrt(np.sum(stain_vectors**2, axis=1, keepdims=True))
+        stain_vectors = stain_vectors / np.sqrt(
+            np.sum(stain_vectors**2, axis=1, keepdims=True)
+        )
 
         # Step 10: Order vectors as [hematoxylin, eosin]
         # Hematoxylin typically has larger red component
-        self.stain_matrix_target = stain_vectors if stain_vectors[0, 0] > stain_vectors[1, 0] else stain_vectors[::-1]
+        self.stain_matrix_target = (
+            stain_vectors
+            if stain_vectors[0, 0] > stain_vectors[1, 0]
+            else stain_vectors[::-1]
+        )
 
 
 def get_tissue_mask(img: np.ndarray, threshold: float = 0.85) -> np.ndarray:
@@ -3426,7 +3512,9 @@ def apply_he_stain_augmentation(
     if not augment_background:
         # Only modify tissue regions
         tissue_mask = get_tissue_mask(img).reshape(-1)
-        stain_concentrations[tissue_mask] = stain_concentrations[tissue_mask] * scale_factors + shift_values
+        stain_concentrations[tissue_mask] = (
+            stain_concentrations[tissue_mask] * scale_factors + shift_values
+        )
     else:
         # Modify all pixels
         stain_concentrations = stain_concentrations * scale_factors + shift_values
@@ -3448,5 +3536,7 @@ def convolve(img: np.ndarray, kernel: np.ndarray) -> np.ndarray:
 @clipped
 @preserve_channel_dim
 def separable_convolve(img: np.ndarray, kernel: np.ndarray) -> np.ndarray:
-    conv_fn = maybe_process_in_chunks(cv2.sepFilter2D, ddepth=-1, kernelX=kernel, kernelY=kernel)
+    conv_fn = maybe_process_in_chunks(
+        cv2.sepFilter2D, ddepth=-1, kernelX=kernel, kernelY=kernel
+    )
     return conv_fn(img)


### PR DESCRIPTION
### 📄 40% (0.40x) speedup for ***`_handle_mask` in `albumentations/augmentations/functional.py`***

⏱️ Runtime :   **`17.4 microseconds`**  **→** **`12.4 microseconds`** (best of `25` runs)
<details>
<summary> 📝 Explanation and details</summary>

To optimize the given Python code, let's focus on improving the performance by avoiding repeated checks and unnecessary conversions, and by efficiently handling the mask.

Here's an optimized version.



### Changes made.

1. **Avoiding Repeated Conversions:**
    - The conversion to `np.uint8` is now done only once, right before the final return statement. Previously, the mask was converted to `np.uint8` directly even if it wasn't necessary.

2. **Efficient Handling Based on Conditions:**
    - The checks and handling are now clearly separated to avoid unnecessary operations. Specifically, by checking `(i is None or is_grayscale_image(mask))` together before the conversion, the code simplifies its flow and avoids unnecessary slicing of the array.

3. **Order of Conditions:**
    - The condition to return `None` if the mask is `None` is kept first to immediately exit from the function.

These improvements help in reducing unnecessary computations and improve the overall efficiency of the function.

</details>

✅ **Correctness verification report:**


| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **26 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 83.3% |
<details>
<summary>🌀 Generated Regression Tests Details</summary>

```python
from __future__ import annotations

import numpy as np
# imports
import pytest  # used for our unit tests
from albucore import is_grayscale_image
from albumentations.augmentations.functional import _handle_mask


# Mocking is_grayscale_image function for testing purposes
def mock_is_grayscale_image(mask):
    return len(mask.shape) == 2

# unit tests
@pytest.fixture(autouse=True)
def mock_is_grayscale_image_fixture(monkeypatch):
    monkeypatch.setattr('albucore.is_grayscale_image', mock_is_grayscale_image)

def test_no_mask_provided():
    codeflash_output = _handle_mask(None)
    codeflash_output = _handle_mask(None, 0)

def test_grayscale_image():
    mask = np.array([[0, 1], [2, 3]])

def test_multi_channel_image_with_i():
    mask = np.array([[[0, 1], [2, 3]], [[4, 5], [6, 7]]])
    expected_channel_0 = np.array([[0, 2], [4, 6]])
    expected_channel_1 = np.array([[1, 3], [5, 7]])

def test_invalid_mask_type():
    with pytest.raises(AttributeError):
        _handle_mask("invalid_mask")
    with pytest.raises(AttributeError):
        _handle_mask(12345)

def test_invalid_channel_index():
    mask = np.array([[[0, 1], [2, 3]], [[4, 5], [6, 7]]])
    with pytest.raises(IndexError):
        _handle_mask(mask, 2)
    with pytest.raises(IndexError):
        _handle_mask(mask, -1)

def test_non_grayscale_multi_channel_mask_with_i_none():
    mask = np.array([[[0, 1], [2, 3]], [[4, 5], [6, 7]]])

def test_type_conversion():
    mask = np.array([[0.1, 1.2], [2.3, 3.4]])
    expected = np.array([[0, 1], [2, 3]], dtype=np.uint8)
    
    mask = np.array([[0, 1], [2, 3]], dtype=np.float32)
    expected = np.array([[0, 1], [2, 3]], dtype=np.uint8)

def test_large_mask_arrays():
    mask = np.random.randint(0, 256, size=(1000, 1000), dtype=np.uint8)
    
    mask = np.random.randint(0, 256, size=(1000, 1000, 3), dtype=np.uint8)

def test_multi_dimensional_masks():
    mask = np.random.randint(0, 256, size=(10, 10, 10, 3), dtype=np.uint8)
    
    mask = np.random.randint(0, 256, size=(5, 5, 5, 5), dtype=np.uint8)

def test_empty_masks():
    mask = np.array([])
    
    mask = np.array([[]])

def test_single_pixel_masks():
    mask = np.array([[255]])
    
    mask = np.array([[[255, 0]]])
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.

from __future__ import annotations

import numpy as np
# imports
import pytest  # used for our unit tests
from albucore import is_grayscale_image
from albumentations.augmentations.functional import _handle_mask

# unit tests

# Mocking the is_grayscale_image function
def mock_is_grayscale_image(mask):
    return mask.ndim == 2

@pytest.fixture(autouse=True)
def mock_albucore(monkeypatch):
    monkeypatch.setattr("albucore.is_grayscale_image", mock_is_grayscale_image)

# Basic Functionality
def test_no_mask_provided():
    codeflash_output = _handle_mask(None)
    codeflash_output = _handle_mask(None, i=0)

def test_grayscale_mask_provided():
    mask = np.array([[0, 255], [255, 0]])

def test_color_mask_provided():
    mask = np.array([[[0, 0, 0], [255, 255, 255]], [[255, 0, 0], [0, 255, 0]]])

# Edge Cases
def test_out_of_bounds_channel_index():
    mask = np.array([[[0, 0, 0], [255, 255, 255]], [[255, 0, 0], [0, 255, 0]]])
    with pytest.raises(IndexError):
        _handle_mask(mask, i=3)

def test_negative_channel_index():
    mask = np.array([[[0, 0, 0], [255, 255, 255]], [[255, 0, 0], [0, 255, 0]]])

def test_non_image_input():
    mask = np.array([0, 255, 255, 0])

    mask = np.random.randint(0, 256, (2, 2, 2, 3), dtype=np.uint8)

# Data Type Handling
def test_different_data_types():
    mask = np.array([[0.0, 1.0], [1.0, 0.0]])
    expected = np.array([[0, 1], [1, 0]], dtype=np.uint8)

    mask = np.array([[0, 255], [255, 0]], dtype=np.int16)
    expected = np.array([[0, 255], [255, 0]], dtype=np.uint8)

    mask = np.array([[True, False], [False, True]])
    expected = np.array([[1, 0], [0, 1]], dtype=np.uint8)

# Large Scale Test Cases
def test_large_grayscale_image():
    mask = np.random.randint(0, 256, (1000, 1000), dtype=np.uint8)

def test_large_color_image():
    mask = np.random.randint(0, 256, (1000, 1000, 3), dtype=np.uint8)

# Performance and Scalability
def test_very_large_grayscale_image():
    mask = np.random.randint(0, 256, (10000, 10000), dtype=np.uint8)

def test_very_large_color_image():
    mask = np.random.randint(0, 256, (10000, 10000, 3), dtype=np.uint8)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>



[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)

## Summary by Sourcery

Enhancements:
- Improve the performance of the `_handle_mask` function by avoiding repeated checks and unnecessary conversions.