### PR TITLE
⚡️ Speed up method `PCA.fit_transform` by 13%

### DIFF
--- a/albumentations/augmentations/utils.py
+++ b/albumentations/augmentations/utils.py
@@ -49,9 +49,7 @@ def angle_2pi_range(
     func: Callable[Concatenate[np.ndarray, P], np.ndarray],
 ) -> Callable[Concatenate[np.ndarray, P], np.ndarray]:
     @wraps(func)
-    def wrapped_function(
-        keypoints: np.ndarray, *args: P.args, **kwargs: P.kwargs
-    ) -> np.ndarray:
+    def wrapped_function(keypoints: np.ndarray, *args: P.args, **kwargs: P.kwargs) -> np.ndarray:
         result = func(keypoints, *args, **kwargs)
         if len(result) > 0 and result.shape[1] > 3:
             result[:, 3] = angle_to_2pi_range(result[:, 3])
@@ -95,19 +93,13 @@ def non_rgb_error(image: np.ndarray) -> None:
         message = "This transformation expects 3-channel images"
         if is_grayscale_image(image):
             message += "\nYou can convert your grayscale image to RGB using cv2.cvtColor(image, cv2.COLOR_GRAY2RGB))"
-        if is_multispectral_image(
-            image
-        ):  # Any image with a number of channels other than 1 and 3
-            message += (
-                "\nThis transformation cannot be applied to multi-spectral images"
-            )
+        if is_multispectral_image(image):  # Any image with a number of channels other than 1 and 3
+            message += "\nThis transformation cannot be applied to multi-spectral images"
 
         raise ValueError(message)
 
 
-def check_range(
-    value: tuple[float, float], lower_bound: float, upper_bound: float, name: str | None
-) -> None:
+def check_range(value: tuple[float, float], lower_bound: float, upper_bound: float, name: str | None) -> None:
     """Checks if the given value is within the specified bounds
 
     Args:
@@ -120,13 +112,9 @@ def check_range(
         ValueError: If the value is outside the bounds or if the tuple values are not ordered correctly.
     """
     if not all(lower_bound <= x <= upper_bound for x in value):
-        raise ValueError(
-            f"All values in {name} must be within [{lower_bound}, {upper_bound}] for tuple inputs."
-        )
+        raise ValueError(f"All values in {name} must be within [{lower_bound}, {upper_bound}] for tuple inputs.")
     if not value[0] <= value[1]:
-        raise ValueError(
-            f"{name!s} tuple values must be ordered as (min, max). Got: {value}"
-        )
+        raise ValueError(f"{name!s} tuple values must be ordered as (min, max). Got: {value}")
 
 
 class PCA:
@@ -139,18 +127,14 @@ class PCA:
         self.explained_variance_: np.ndarray | None = None
 
     def fit(self, x: np.ndarray) -> None:
-        x = x.astype(
-            np.float64, copy=False
-        )  # avoid unnecessary copy if already float64
+        x = x.astype(np.float64, copy=False)  # avoid unnecessary copy if already float64
         n_samples, n_features = x.shape
 
         # Determine the number of components if not set
         if self.n_components is None:
             self.n_components = min(n_samples, n_features)
 
-        self.mean, eigenvectors, eigenvalues = cv2.PCACompute2(
-            x, mean=None, maxComponents=self.n_components
-        )
+        self.mean, eigenvectors, eigenvalues = cv2.PCACompute2(x, mean=None, maxComponents=self.n_components)
         self.components_ = eigenvectors
         self.explained_variance_ = eigenvalues.flatten()
 
@@ -160,9 +144,7 @@ class PCA:
                 "This PCA instance is not fitted yet. "
                 "Call 'fit' with appropriate arguments before using this estimator.",
             )
-        x = x.astype(
-            np.float64, copy=False
-        )  # avoid unnecessary copy if already float64
+        x = x.astype(np.float64, copy=False)  # avoid unnecessary copy if already float64
         return cv2.PCAProject(x, self.mean, self.components_)
 
     def fit_transform(self, x: np.ndarray) -> np.ndarray:

--- a/albumentations/augmentations/utils.py
+++ b/albumentations/augmentations/utils.py
@@ -49,7 +49,9 @@ def angle_2pi_range(
     func: Callable[Concatenate[np.ndarray, P], np.ndarray],
 ) -> Callable[Concatenate[np.ndarray, P], np.ndarray]:
     @wraps(func)
-    def wrapped_function(keypoints: np.ndarray, *args: P.args, **kwargs: P.kwargs) -> np.ndarray:
+    def wrapped_function(
+        keypoints: np.ndarray, *args: P.args, **kwargs: P.kwargs
+    ) -> np.ndarray:
         result = func(keypoints, *args, **kwargs)
         if len(result) > 0 and result.shape[1] > 3:
             result[:, 3] = angle_to_2pi_range(result[:, 3])
@@ -93,13 +95,19 @@ def non_rgb_error(image: np.ndarray) -> None:
         message = "This transformation expects 3-channel images"
         if is_grayscale_image(image):
             message += "\nYou can convert your grayscale image to RGB using cv2.cvtColor(image, cv2.COLOR_GRAY2RGB))"
-        if is_multispectral_image(image):  # Any image with a number of channels other than 1 and 3
-            message += "\nThis transformation cannot be applied to multi-spectral images"
+        if is_multispectral_image(
+            image
+        ):  # Any image with a number of channels other than 1 and 3
+            message += (
+                "\nThis transformation cannot be applied to multi-spectral images"
+            )
 
         raise ValueError(message)
 
 
-def check_range(value: tuple[float, float], lower_bound: float, upper_bound: float, name: str | None) -> None:
+def check_range(
+    value: tuple[float, float], lower_bound: float, upper_bound: float, name: str | None
+) -> None:
     """Checks if the given value is within the specified bounds
 
     Args:
@@ -112,9 +120,13 @@ def check_range(value: tuple[float, float], lower_bound: float, upper_bound: flo
         ValueError: If the value is outside the bounds or if the tuple values are not ordered correctly.
     """
     if not all(lower_bound <= x <= upper_bound for x in value):
-        raise ValueError(f"All values in {name} must be within [{lower_bound}, {upper_bound}] for tuple inputs.")
+        raise ValueError(
+            f"All values in {name} must be within [{lower_bound}, {upper_bound}] for tuple inputs."
+        )
     if not value[0] <= value[1]:
-        raise ValueError(f"{name!s} tuple values must be ordered as (min, max). Got: {value}")
+        raise ValueError(
+            f"{name!s} tuple values must be ordered as (min, max). Got: {value}"
+        )
 
 
 class PCA:
@@ -127,14 +139,18 @@ class PCA:
         self.explained_variance_: np.ndarray | None = None
 
     def fit(self, x: np.ndarray) -> None:
-        x = x.astype(np.float64)
+        x = x.astype(
+            np.float64, copy=False
+        )  # avoid unnecessary copy if already float64
         n_samples, n_features = x.shape
 
         # Determine the number of components if not set
         if self.n_components is None:
             self.n_components = min(n_samples, n_features)
 
-        self.mean, eigenvectors, eigenvalues = cv2.PCACompute2(x, mean=None, maxComponents=self.n_components)
+        self.mean, eigenvectors, eigenvalues = cv2.PCACompute2(
+            x, mean=None, maxComponents=self.n_components
+        )
         self.components_ = eigenvectors
         self.explained_variance_ = eigenvalues.flatten()
 
@@ -144,7 +160,9 @@ class PCA:
                 "This PCA instance is not fitted yet. "
                 "Call 'fit' with appropriate arguments before using this estimator.",
             )
-        x = x.astype(np.float64)
+        x = x.astype(
+            np.float64, copy=False
+        )  # avoid unnecessary copy if already float64
         return cv2.PCAProject(x, self.mean, self.components_)
 
     def fit_transform(self, x: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
### 📄 13% (0.13x) speedup for ***`PCA.fit_transform` in `albumentations/augmentations/utils.py`***

⏱️ Runtime :   **`45.2 milliseconds`**  **→** **`40.0 milliseconds`** (best of `5` runs)
<details>
<summary> 📝 Explanation and details</summary>

**Key Changes and Justifications:**

</details>

✅ **Correctness verification report:**


| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | ✅ **20 Passed** |
| 🌀 Generated Regression Tests | ✅ **32 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>⚙️ Existing Unit Tests Details</summary>

```python
- test_domain_adaptation.py
```

</details>

<details>
<summary>🌀 Generated Regression Tests Details</summary>

```python
from __future__ import annotations

import cv2
import numpy as np
# imports
import pytest  # used for our unit tests
from albumentations.augmentations.utils import PCA

# unit tests

def test_basic_functionality():
    # Basic functionality test
    pca = PCA()
    x = np.array([[1, 2], [3, 4], [5, 6]])
    codeflash_output = pca.fit_transform(x)

def test_different_data_types():
    # Test with integer data
    pca = PCA()
    x = np.array([[1, 2], [3, 4], [5, 6]], dtype=int)
    codeflash_output = pca.fit_transform(x)

    # Test with float data
    pca = PCA()
    x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=float)
    codeflash_output = pca.fit_transform(x)

def test_n_components():
    # Test with n_components=None
    pca = PCA()
    x = np.array([[1, 2], [3, 4], [5, 6]])
    codeflash_output = pca.fit_transform(x)

    # Test with n_components=1
    pca = PCA(n_components=1)
    x = np.array([[1, 2], [3, 4], [5, 6]])
    codeflash_output = pca.fit_transform(x)

    # Test with n_components=2
    pca = PCA(n_components=2)
    x = np.array([[1, 2], [3, 4], [5, 6]])
    codeflash_output = pca.fit_transform(x)

    # Test with n_components=3 (greater than the number of features)
    pca = PCA(n_components=3)
    x = np.array([[1, 2], [3, 4], [5, 6]])
    with pytest.raises(cv2.error):
        pca.fit_transform(x)



def test_numerical_stability():
    # Test with very large values
    pca = PCA()
    x = np.array([[1e10, 2e10], [3e10, 4e10], [5e10, 6e10]])
    codeflash_output = pca.fit_transform(x)

    # Test with very small values
    pca = PCA()
    x = np.array([[1e-10, 2e-10], [3e-10, 4e-10], [5e-10, 6e-10]])
    codeflash_output = pca.fit_transform(x)

def test_input_not_modified():
    # Ensure input array is not modified
    pca = PCA()
    x = np.array([[1, 2], [3, 4], [5, 6]])
    x_copy = x.copy()
    pca.fit_transform(x)

def test_consistency():
    # Ensure consistent results for the same input
    pca = PCA()
    x = np.array([[1, 2], [3, 4], [5, 6]])
    codeflash_output = pca.fit_transform(x)
    codeflash_output = pca.fit_transform(x)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.

from __future__ import annotations

import cv2
import numpy as np
# imports
import pytest  # used for our unit tests
from albumentations.augmentations.utils import PCA

# unit tests

def test_basic_functionality():
    # Standard Input: more samples than features
    pca = PCA()
    x = np.array([[1, 2], [3, 4], [5, 6]])
    codeflash_output = pca.fit_transform(x)

    # Standard Input: more features than samples
    pca = PCA()
    x = np.array([[1, 2, 3], [4, 5, 6]])
    codeflash_output = pca.fit_transform(x)

def test_minimum_input():
    # Single sample, single feature
    pca = PCA()
    x = np.array([[1]])
    codeflash_output = pca.fit_transform(x)

    # Single sample, multiple features
    pca = PCA()
    x = np.array([[1, 2, 3]])
    codeflash_output = pca.fit_transform(x)

    # Multiple samples, single feature
    pca = PCA()
    x = np.array([[1], [2], [3]])
    codeflash_output = pca.fit_transform(x)

def test_empty_input():
    # Empty array (0 samples, 0 features)
    pca = PCA()
    x = np.empty((0, 0))
    with pytest.raises(cv2.error):
        pca.fit_transform(x)

    # Zero samples, some features
    pca = PCA()
    x = np.empty((0, 3))
    with pytest.raises(cv2.error):
        pca.fit_transform(x)

def test_invalid_n_components():
    # n_components set to zero
    with pytest.raises(ValueError):
        PCA(n_components=0)

    # n_components set to negative number
    with pytest.raises(ValueError):
        PCA(n_components=-1)

def test_non_numeric_data():
    pca = PCA()
    x = np.array([['a', 'b'], ['c', 'd']])
    with pytest.raises(ValueError):
        pca.fit_transform(x)


def test_specified_n_components():
    # n_components less than number of features
    pca = PCA(n_components=1)
    x = np.array([[1, 2], [3, 4], [5, 6]])
    codeflash_output = pca.fit_transform(x)

    # n_components equal to number of features
    pca = PCA(n_components=2)
    x = np.array([[1, 2], [3, 4], [5, 6]])
    codeflash_output = pca.fit_transform(x)

    # n_components greater than number of features
    pca = PCA(n_components=5)
    x = np.array([[1, 2], [3, 4], [5, 6]])
    codeflash_output = pca.fit_transform(x)

def test_data_with_zero_variance():
    pca = PCA()
    x = np.array([[1, 1], [1, 1], [1, 1]])
    codeflash_output = pca.fit_transform(x)

def test_highly_correlated_data():
    pca = PCA()
    x = np.array([[1, 2], [2, 4], [3, 6]])
    codeflash_output = pca.fit_transform(x)

def test_multiple_fit_calls():
    pca = PCA()
    x1 = np.array([[1, 2], [3, 4], [5, 6]])
    pca.fit(x1)
    x2 = np.array([[7, 8], [9, 10], [11, 12]])
    pca.fit(x2)

def test_multiple_fit_transform_calls():
    pca = PCA()
    x1 = np.array([[1, 2], [3, 4], [5, 6]])
    codeflash_output = pca.fit_transform(x1)
    x2 = np.array([[7, 8], [9, 10], [11, 12]])
    codeflash_output = pca.fit_transform(x2)

def test_unfitted_transform():
    pca = PCA()
    x = np.array([[1, 2], [3, 4], [5, 6]])
    with pytest.raises(ValueError):
        pca.transform(x)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>



[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)

## Summary by Sourcery

Enhancements:
- Speeds up the `PCA.fit_transform` method by avoiding an unnecessary copy when casting the input array to float64.