### PR TITLE
Cleaned docstring in FancyPCA

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         files: setup.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.8
+    rev: v0.9.9
     hooks:
       # Run the linter.
       - id: ruff
@@ -77,7 +77,7 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.5.0"
+    rev: "v2.5.1"
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -3425,10 +3425,8 @@ class FancyPCA(ImageOnlyTransform):
     deviation 'alpha'.
 
     Args:
-        alpha (tuple[float, float] | float): Standard deviation of the Gaussian distribution used to generate
-            random noise for each principal component. If a single float is provided, it will be used for
-            all channels. If a tuple of two floats (min, max) is provided, the standard deviation will be
-            uniformly sampled from this range for each run. Default: 0.1.
+        alpha (float): Standard deviation of the Gaussian distribution used to generate
+            random noise for each principal component. Default: 0.1.
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:


### PR DESCRIPTION
## Summary by Sourcery

Updates the docstring for FancyPCA to remove the tuple option for the alpha parameter. Updates ruff pre-commit hook to v0.9.9 and pyproject-fmt to v2.5.1.

Enhancements:
- Updates the docstring for FancyPCA to remove the tuple option for the alpha parameter, clarifying that only a single float value is expected for the alpha parameter.
- Updates ruff pre-commit hook to v0.9.9.
- Updates pyproject-fmt to v2.5.1.