### PR TITLE
Fix in PixelDropout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         files: setup.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.9
+    rev: v0.9.10
     hooks:
       # Run the linter.
       - id: ruff

--- a/albumentations/augmentations/__init__.py
+++ b/albumentations/augmentations/__init__.py
@@ -7,6 +7,7 @@ from .dropout.coarse_dropout import *
 from .dropout.functional import *
 from .dropout.grid_dropout import *
 from .dropout.mask_dropout import *
+from .dropout.transforms import *
 from .dropout.xy_masking import *
 from .functional import *
 from .geometric.functional import *

--- a/albumentations/augmentations/dropout/__init__.py
+++ b/albumentations/augmentations/dropout/__init__.py
@@ -2,4 +2,5 @@ from .channel_dropout import *
 from .coarse_dropout import *
 from .grid_dropout import *
 from .mask_dropout import *
+from .transforms import *
 from .xy_masking import *

--- a/albumentations/augmentations/dropout/transforms.py
+++ b/albumentations/augmentations/dropout/transforms.py
@@ -4,7 +4,10 @@ from typing import Any, Literal, cast
 
 import numpy as np
 from albucore import get_num_channels
+from pydantic import Field
 
+from albumentations.augmentations import functional as fmain
+from albumentations.augmentations.dropout import functional as fdropout
 from albumentations.augmentations.dropout.functional import (
     cutout,
     filter_bboxes_by_holes,
@@ -14,6 +17,8 @@ from albumentations.core.bbox_utils import BboxProcessor, denormalize_bboxes, no
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
 from albumentations.core.type_definitions import ALL_TARGETS, Targets
+
+__all__ = ["PixelDropout"]
 
 
 class BaseDropout(DualTransform):
@@ -126,3 +131,202 @@ class BaseDropout(DualTransform):
             tuple: Names of the arguments.
         """
         return "fill", "fill_mask"
+
+
+class PixelDropout(DualTransform):
+    """Drops random pixels from the image.
+
+    This transform randomly sets pixels in the image to a specified value, effectively "dropping out" those pixels.
+    It can be applied to both the image and its corresponding mask.
+
+    Args:
+        dropout_prob (float): Probability of dropping out each pixel. Should be in the range [0, 1].
+            Default: 0.01
+
+        per_channel (bool): If True, the dropout mask will be generated independently for each channel.
+            If False, the same dropout mask will be applied to all channels.
+            Default: False
+
+        drop_value (float | tuple[float, ...] | None): Value to assign to the dropped pixels.
+            If None, the value will be randomly sampled for each application:
+                - For uint8 images: Random integer in [0, 255]
+                - For float32 images: Random float in [0, 1]
+            If a single number, that value will be used for all dropped pixels.
+            If a sequence, it should contain one value per channel.
+            Default: 0
+
+        mask_drop_value (float | tuple[float, ...] | None): Value to assign to dropped pixels in the mask.
+            If None, the mask will remain unchanged.
+            If a single number, that value will be used for all dropped pixels in the mask.
+            If a sequence, it should contain one value per channel.
+            Default: None
+
+        p (float): Probability of applying the transform. Should be in the range [0, 1].
+            Default: 0.5
+
+    Targets:
+        image, mask, bboxes, keypoints, volume, mask3d
+
+    Image types:
+        uint8, float32
+
+    Note:
+        - When applied to bounding boxes, this transform may cause some boxes to have zero area
+          if all pixels within the box are dropped. Such boxes will be removed.
+        - When applied to keypoints, keypoints that fall on dropped pixels will be removed if
+          the keypoint processor is configured to remove invisible keypoints.
+
+    Example:
+        >>> import numpy as np
+        >>> import albumentations as A
+        >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+        >>> mask = np.random.randint(0, 2, (100, 100), dtype=np.uint8)
+        >>> transform = A.PixelDropout(dropout_prob=0.1, per_channel=True, p=1.0)
+        >>> result = transform(image=image, mask=mask)
+        >>> dropped_image, dropped_mask = result['image'], result['mask']
+    """
+
+    class InitSchema(BaseTransformInitSchema):
+        dropout_prob: float = Field(ge=0, le=1)
+        per_channel: bool
+        drop_value: tuple[float, ...] | float | None
+        mask_drop_value: tuple[float, ...] | float | None
+
+    _targets = ALL_TARGETS
+
+    def __init__(
+        self,
+        dropout_prob: float = 0.01,
+        per_channel: bool = False,
+        drop_value: tuple[float, ...] | float | None = 0,
+        mask_drop_value: tuple[float, ...] | float | None = None,
+        p: float = 0.5,
+    ):
+        super().__init__(p=p)
+        self.dropout_prob = dropout_prob
+        self.per_channel = per_channel
+        self.drop_value = drop_value
+        self.mask_drop_value = mask_drop_value
+
+    def apply(
+        self,
+        img: np.ndarray,
+        drop_mask: np.ndarray,
+        drop_values: np.ndarray,
+        **params: Any,
+    ) -> np.ndarray:
+        return fmain.pixel_dropout(img, drop_mask, drop_values)
+
+    def apply_to_mask(
+        self,
+        mask: np.ndarray,
+        mask_drop_mask: np.ndarray,
+        mask_drop_values: float | np.ndarray,
+        **params: Any,
+    ) -> np.ndarray:
+        if self.mask_drop_value is None:
+            return mask
+
+        return fmain.pixel_dropout(mask, mask_drop_mask, mask_drop_values)
+
+    def apply_to_bboxes(
+        self,
+        bboxes: np.ndarray,
+        drop_mask: np.ndarray | None,
+        **params: Any,
+    ) -> np.ndarray:
+        if drop_mask is None or self.per_channel:
+            return bboxes
+
+        processor = cast(BboxProcessor, self.get_processor("bboxes"))
+        if processor is None:
+            return bboxes
+
+        image_shape = params["shape"][:2]
+
+        denormalized_bboxes = denormalize_bboxes(bboxes, image_shape)
+
+        # If per_channel is True, we need to create a single channel mask
+        # by combining the multi-channel mask (considering a pixel dropped if it's dropped in any channel)
+        if self.per_channel and len(drop_mask.shape) > 2:
+            # Create a single channel mask where a pixel is considered dropped if it's dropped in any channel
+            combined_mask = np.any(drop_mask, axis=-1 if drop_mask.shape[-1] <= 4 else 0)
+            # Ensure the mask has the right shape for the bboxes function
+            if combined_mask.ndim == 3 and combined_mask.shape[0] == 1:
+                combined_mask = combined_mask[0]
+        else:
+            combined_mask = drop_mask
+
+        result = fdropout.mask_dropout_bboxes(
+            denormalized_bboxes,
+            combined_mask,
+            image_shape,
+            processor.params.min_area,
+            processor.params.min_visibility,
+        )
+
+        return normalize_bboxes(result, image_shape)
+
+    def apply_to_keypoints(
+        self,
+        keypoints: np.ndarray,
+        drop_mask: np.ndarray | None,
+        **params: Any,
+    ) -> np.ndarray:
+        return keypoints
+
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Generate parameters for pixel dropout based on input data.
+
+        Args:
+            params: Transform parameters
+            data: Input data dictionary
+
+        Returns:
+            Dictionary of parameters for applying the transform
+        """
+        reference_array = data["image"] if "image" in data else data["images"][0]
+
+        # Generate drop mask and values for all targets
+        drop_mask = fmain.get_drop_mask(
+            reference_array.shape,
+            self.per_channel,
+            self.dropout_prob,
+            self.random_generator,
+        )
+        drop_values = fmain.prepare_drop_values(
+            reference_array,
+            self.drop_value,
+            self.random_generator,
+        )
+
+        # Handle mask drop values if specified
+        mask_drop_mask = None
+        mask_drop_values = None
+        mask = fmain.get_mask_array(data)
+        if self.mask_drop_value is not None and mask is not None:
+            mask_drop_mask = fmain.get_drop_mask(
+                mask.shape,
+                self.per_channel,
+                self.dropout_prob,
+                self.random_generator,
+            )
+            mask_drop_values = fmain.prepare_drop_values(
+                mask,
+                self.mask_drop_value,
+                self.random_generator,
+            )
+
+        return {
+            "drop_mask": drop_mask,
+            "drop_values": drop_values,
+            "mask_drop_mask": mask_drop_mask if mask_drop_mask is not None else None,
+            "mask_drop_values": mask_drop_values if mask_drop_values is not None else None,
+        }
+
+    def get_transform_init_args_names(self) -> tuple[str, ...]:
+        return "dropout_prob", "per_channel", "drop_value", "mask_drop_value"

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -37,14 +37,12 @@ from pydantic import (
 from scipy import special
 from typing_extensions import Literal, Self
 
-import albumentations.augmentations.dropout.functional as fdropout
 import albumentations.augmentations.geometric.functional as fgeometric
 from albumentations.augmentations import functional as fmain
 from albumentations.augmentations.blur import functional as fblur
 from albumentations.augmentations.blur.transforms import BlurInitSchema
 from albumentations.augmentations.utils import check_range, non_rgb_error
 from albumentations.core.bbox_utils import (
-    BboxProcessor,
     denormalize_bboxes,
     normalize_bboxes,
 )
@@ -95,7 +93,6 @@ __all__ = [
     "Morphological",
     "MultiplicativeNoise",
     "Normalize",
-    "PixelDropout",
     "PlanckianJitter",
     "PlasmaBrightnessContrast",
     "PlasmaShadow",
@@ -4362,194 +4359,6 @@ class UnsharpMask(ImageOnlyTransform):
 
     def get_transform_init_args_names(self) -> tuple[str, ...]:
         return "blur_limit", "sigma_limit", "alpha", "threshold"
-
-
-class PixelDropout(DualTransform):
-    """Drops random pixels from the image.
-
-    This transform randomly sets pixels in the image to a specified value, effectively "dropping out" those pixels.
-    It can be applied to both the image and its corresponding mask.
-
-    Args:
-        dropout_prob (float): Probability of dropping out each pixel. Should be in the range [0, 1].
-            Default: 0.01
-
-        per_channel (bool): If True, the dropout mask will be generated independently for each channel.
-            If False, the same dropout mask will be applied to all channels.
-            Default: False
-
-        drop_value (float | tuple[float, ...] | None): Value to assign to the dropped pixels.
-            If None, the value will be randomly sampled for each application:
-                - For uint8 images: Random integer in [0, 255]
-                - For float32 images: Random float in [0, 1]
-            If a single number, that value will be used for all dropped pixels.
-            If a sequence, it should contain one value per channel.
-            Default: 0
-
-        mask_drop_value (float | tuple[float, ...] | None): Value to assign to dropped pixels in the mask.
-            If None, the mask will remain unchanged.
-            If a single number, that value will be used for all dropped pixels in the mask.
-            If a sequence, it should contain one value per channel.
-            Default: None
-
-        p (float): Probability of applying the transform. Should be in the range [0, 1].
-            Default: 0.5
-
-    Targets:
-        image, mask, bboxes, keypoints, volume, mask3d
-
-    Image types:
-        uint8, float32
-
-    Note:
-        - When applied to bounding boxes, this transform may cause some boxes to have zero area
-          if all pixels within the box are dropped. Such boxes will be removed.
-        - When applied to keypoints, keypoints that fall on dropped pixels will be removed if
-          the keypoint processor is configured to remove invisible keypoints.
-
-    Example:
-        >>> import numpy as np
-        >>> import albumentations as A
-        >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-        >>> mask = np.random.randint(0, 2, (100, 100), dtype=np.uint8)
-        >>> transform = A.PixelDropout(dropout_prob=0.1, per_channel=True, p=1.0)
-        >>> result = transform(image=image, mask=mask)
-        >>> dropped_image, dropped_mask = result['image'], result['mask']
-    """
-
-    class InitSchema(BaseTransformInitSchema):
-        dropout_prob: float = Field(ge=0, le=1)
-        per_channel: bool
-        drop_value: tuple[float, ...] | float | None
-        mask_drop_value: tuple[float, ...] | float | None
-
-    _targets = ALL_TARGETS
-
-    def __init__(
-        self,
-        dropout_prob: float = 0.01,
-        per_channel: bool = False,
-        drop_value: tuple[float, ...] | float | None = 0,
-        mask_drop_value: tuple[float, ...] | float | None = None,
-        p: float = 0.5,
-    ):
-        super().__init__(p=p)
-        self.dropout_prob = dropout_prob
-        self.per_channel = per_channel
-        self.drop_value = drop_value
-        self.mask_drop_value = mask_drop_value
-
-    def apply(
-        self,
-        img: np.ndarray,
-        drop_mask: np.ndarray,
-        drop_values: np.ndarray,
-        **params: Any,
-    ) -> np.ndarray:
-        return fmain.pixel_dropout(img, drop_mask, drop_values)
-
-    def apply_to_mask(
-        self,
-        mask: np.ndarray,
-        mask_drop_mask: np.ndarray,
-        mask_drop_values: float | np.ndarray,
-        **params: Any,
-    ) -> np.ndarray:
-        if self.mask_drop_value is None:
-            return mask
-
-        return fmain.pixel_dropout(mask, mask_drop_mask, mask_drop_values)
-
-    def apply_to_bboxes(
-        self,
-        bboxes: np.ndarray,
-        drop_mask: np.ndarray | None,
-        **params: Any,
-    ) -> np.ndarray:
-        if drop_mask is None or self.per_channel:
-            return bboxes
-
-        processor = cast(BboxProcessor, self.get_processor("bboxes"))
-        if processor is None:
-            return bboxes
-
-        image_shape = params["shape"][:2]
-
-        denormalized_bboxes = denormalize_bboxes(bboxes, image_shape)
-
-        result = fdropout.mask_dropout_bboxes(
-            denormalized_bboxes,
-            drop_mask,
-            image_shape,
-            processor.params.min_area,
-            processor.params.min_visibility,
-        )
-
-        return normalize_bboxes(result, image_shape)
-
-    def apply_to_keypoints(
-        self,
-        keypoints: np.ndarray,
-        drop_mask: np.ndarray | None,
-        **params: Any,
-    ) -> np.ndarray:
-        return keypoints
-
-    def get_params_dependent_on_data(
-        self,
-        params: dict[str, Any],
-        data: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Generate parameters for pixel dropout based on input data.
-
-        Args:
-            params: Transform parameters
-            data: Input data dictionary
-
-        Returns:
-            Dictionary of parameters for applying the transform
-        """
-        reference_array = data["image"] if "image" in data else data["images"][0]
-
-        # Generate drop mask and values for all targets
-        drop_mask = fmain.get_drop_mask(
-            reference_array.shape,
-            self.per_channel,
-            self.dropout_prob,
-            self.random_generator,
-        )
-        drop_values = fmain.prepare_drop_values(
-            reference_array,
-            self.drop_value,
-            self.random_generator,
-        )
-
-        # Handle mask drop values if specified
-        mask_drop_mask = None
-        mask_drop_values = None
-        mask = fmain.get_mask_array(data)
-        if self.mask_drop_value is not None and mask is not None:
-            mask_drop_mask = fmain.get_drop_mask(
-                mask.shape,
-                self.per_channel,
-                self.dropout_prob,
-                self.random_generator,
-            )
-            mask_drop_values = fmain.prepare_drop_values(
-                mask,
-                self.mask_drop_value,
-                self.random_generator,
-            )
-
-        return {
-            "drop_mask": drop_mask,
-            "drop_values": drop_values,
-            "mask_drop_mask": mask_drop_mask if mask_drop_mask is not None else None,
-            "mask_drop_values": mask_drop_values if mask_drop_values is not None else None,
-        }
-
-    def get_transform_init_args_names(self) -> tuple[str, ...]:
-        return "dropout_prob", "per_channel", "drop_value", "mask_drop_value"
 
 
 class Spatter(ImageOnlyTransform):


### PR DESCRIPTION
## Summary by Sourcery

This pull request fixes an issue with the PixelDropout transform where bounding boxes were not being correctly handled when the per_channel option was enabled. It also moves the PixelDropout transform to the dropout module.

Enhancements:
- Move PixelDropout transform to the dropout module.
- Improve the handling of bounding boxes in PixelDropout when per_channel is enabled.
- Improve the handling of keypoints in PixelDropout.
- Update ruff version.