### PR TITLE
Fix in return values

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         files: setup.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.1
+    rev: v0.11.2
     hooks:
       # Run the linter.
       - id: ruff
@@ -89,7 +89,7 @@ repos:
         args:
           [ --config-file=pyproject.toml ]
   - repo: https://github.com/ternaus/google-docstring-parser
-    rev: 0.0.4  # Use the latest version
+    rev: 0.0.7  # Use the latest version
     hooks:
       - id: check-google-docstrings
         additional_dependencies: ["tomli>=2.0.0"]

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -3448,7 +3448,7 @@ def generate_random_values(
         random_generator (np.random.Generator): Random number generator
 
     Returns:
-        Array of random values
+        np.ndarray: Random values
 
     """
     if dtype == np.uint8:

--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -407,7 +407,7 @@ def normalize_bboxes(bboxes: np.ndarray, shape: ShapeType | tuple[int, int]) -> 
         shape (ShapeType | tuple[int, int]): Image shape `(height, width)`.
 
     Returns:
-        Normalized bounding boxes `[(x_min, y_min, x_max, y_max, ...)]`.
+        np.ndarray: Normalized bounding boxes `[(x_min, y_min, x_max, y_max, ...)]`.
 
     """
     if isinstance(shape, tuple):
@@ -433,7 +433,7 @@ def denormalize_bboxes(
         shape (ShapeType | tuple[int, int]): Image shape `(height, width)`.
 
     Returns:
-        Denormalized bounding boxes `[(x_min, y_min, x_max, y_max, ...)]`.
+        np.ndarray: Denormalized bounding boxes `[(x_min, y_min, x_max, y_max, ...)]`.
 
     """
     scale_factors = (shape[1], shape[0]) if isinstance(shape, tuple) else (shape["width"], shape["height"])
@@ -703,7 +703,7 @@ def filter_bboxes(
             Boxes with higher ratios will be filtered out. Default: None.
 
     Returns:
-        numpy array of filtered bounding boxes.
+        np.ndarray: Filtered bounding boxes.
 
     """
     epsilon = 1e-7

--- a/albumentations/core/hub_mixin.py
+++ b/albumentations/core/hub_mixin.py
@@ -272,7 +272,7 @@ class HubMixin:
                 Whether or not to create a Pull Request from `branch` with that commit. Defaults to `False`.
 
         Returns:
-            The url of the commit of your transform in the given repository.
+            str: The url of the commit of your transform in the given repository.
 
         """
         if not allow_custom_keys and key not in self._CONFIG_KEYS:

--- a/albumentations/core/keypoints_utils.py
+++ b/albumentations/core/keypoints_utils.py
@@ -64,7 +64,7 @@ class KeypointParams(Params):
 
             a - Keypoint orientation in radians or degrees (depending on KeypointParams.angle_in_degrees)
 
-        label_fields (list): list of fields that are joined with keypoints, e.g labels.
+        label_fields (list[str]): list of fields that are joined with keypoints, e.g labels.
             Should be same type as keypoints.
         remove_invisible (bool): to remove invisible points after transform or not
         angle_in_degrees (bool): angle in degrees or radians in 'xya', 'xyas', 'xysa' keypoints
@@ -187,7 +187,7 @@ class KeypointsProcessor(DataProcessor):
             shape (ShapeType): Shape to check against as {'height': height, 'width': width, 'depth': depth}
 
         Returns:
-            Filtered keypoints
+            np.ndarray: Filtered keypoints
 
         """
         self.params: KeypointParams
@@ -343,7 +343,7 @@ def filter_keypoints(
         remove_invisible (bool): If True, remove keypoints outside the boundaries.
 
     Returns:
-        A numpy array of filtered keypoints.
+        np.ndarray: Filtered keypoints.
 
     """
     if not remove_invisible:

--- a/albumentations/core/pydantic.py
+++ b/albumentations/core/pydantic.py
@@ -172,8 +172,8 @@ def check_range_bounds(
             If True, max_val is inclusive (<=). If False, exclusive (<).
 
     Returns:
-        Validator function that checks if all values in tuple are within bounds.
-        Returns None if input is None.
+        Callable[[tuple[T, ...] | None], tuple[T, ...] | None]: Validator function that
+            checks if all values in tuple are within bounds. Returns None if input is None.
 
     Raises:
         ValueError: If any value in tuple is outside the allowed range

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -346,7 +346,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
             **params (Any): Additional parameters specific to the transform
 
         Returns:
-            Transformed images as numpy array in the same format as input
+            np.ndarray: Transformed images as numpy array in the same format as input
 
         """
         # Handle batched numpy array input
@@ -362,7 +362,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
             **params (Any): Additional parameters specific to the transform
 
         Returns:
-            Transformed volume as numpy array in the same format as input
+            np.ndarray: Transformed volume as numpy array in the same format as input
 
         """
         return self.apply_to_images(volume, *args, **params)
@@ -383,7 +383,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
             data (dict[str, Any]): Input data dictionary containing images/volumes
 
         Returns:
-            Updated parameters dictionary with shape and transform-specific params
+            dict[str, Any]: Updated parameters dictionary with shape and transform-specific params
 
         """
         # Extract shape from volume, volumes, image, or images
@@ -451,7 +451,8 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         by the way you must have at least one object with key 'image'
 
         Args:
-            additional_targets (dict): keys - new target name, values - old target name. ex: {'image2': 'image'}
+            additional_targets (dict[str, str]): keys - new target name, values
+                - old target name. ex: {'image2': 'image'}
 
         """
         for k, v in additional_targets.items():
@@ -713,7 +714,7 @@ class DualTransform(BasicTransform):
             **params (Any): Additional parameters specific to the transform
 
         Returns:
-            Transformed masks as numpy array
+            np.ndarray: Transformed masks as numpy array
 
         """
         return np.stack([self.apply_to_mask(mask, **params) for mask in masks])
@@ -728,7 +729,7 @@ class DualTransform(BasicTransform):
             **params (Any): Additional parameters specific to the transform
 
         Returns:
-            Transformed 3D mask as numpy array
+            np.ndarray: Transformed 3D mask as numpy array
 
         """
         return self.apply_to_mask(mask3d, **params)
@@ -743,7 +744,7 @@ class DualTransform(BasicTransform):
             **params (Any): Additional parameters specific to the transform
 
         Returns:
-            Transformed 3D masks as numpy array
+            np.ndarray: Transformed 3D masks as numpy array
 
         """
         return np.stack([self.apply_to_mask3d(mask3d, **params) for mask3d in masks3d])


### PR DESCRIPTION
## Summary by Sourcery

Improve type annotations and docstring return type descriptions across multiple files in the Albumentations library

Enhancements:
- Update docstring return type annotations to explicitly specify return types using more precise type hints
- Add explicit numpy array type annotations to return values in docstrings

Chores:
- Update pre-commit hook versions for Ruff and Google docstring parser