### PR TITLE
Changed functionality of SomeOf

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         files: setup.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.2
+    rev: v0.11.4
     hooks:
       # Run the linter.
       - id: ruff

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1088,7 +1088,6 @@ class SomeOf(BaseCompose):
             size=self.n,
             replace=self.replace,
         )
-        # Sorting is optional but can make replay/debugging easier if needed
         idx.sort()
         return idx
 


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2474

## Summary by Sourcery

Refactor the functionality of SomeOf and RandomOrder transforms in Albumentations to improve transform selection and application logic

Enhancements:
- Modify SomeOf to use uniform random selection of transforms
- Clarify the probabilistic behavior of transform selection and application
- Update type hints for improved type checking

Documentation:
- Improve docstrings for SomeOf and RandomOrder to explain new selection and application behavior

Chores:
- Update Ruff linter version in pre-commit configuration