### PR TITLE
Small fix for duplicating set_random_seed in BaseCompose and BasicTransform

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -132,9 +132,6 @@ class BaseCompose(Serializable):
         self.processors: dict[str, BboxProcessor | KeypointsProcessor] = {}
         self._set_keys()
         self.set_mask_interpolation(mask_interpolation)
-        self.seed = seed
-        self.random_generator = np.random.default_rng(seed)
-        self.py_random = random.Random(seed)
         self.set_random_seed(seed)
         self.save_applied_params = save_applied_params
 

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -97,8 +97,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         self._set_keys()
         self.processors: dict[str, BboxProcessor | KeypointsProcessor] = {}
         self.seed: int | None = None
-        self.random_generator = np.random.default_rng(self.seed)
-        self.py_random = random.Random(self.seed)
+        self.set_random_seed(self.seed)
         self._strict = False  # Use private attribute
         self.invalid_args: list[str] = []  # Store invalid args found during init
 


### PR DESCRIPTION
There are few lines that are already a part of `set_random_seed`, we can remove them

## Summary by Sourcery

Enhancements:
- Simplify random seed initialization by removing redundant code and using the existing set_random_seed method in both BaseCompose and BasicTransform classes