### PR TITLE
Fix BGR→RGB conversion and use INTER_AREA interpolation in Resize

### DIFF
--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -801,7 +801,7 @@ class Resize(DualTransform):
             cv2.INTER_AREA,
             cv2.INTER_LANCZOS4,
             cv2.INTER_LINEAR_EXACT,
-        ] = cv2.INTER_LINEAR,
+        ] = cv2.INTER_AREA,
         mask_interpolation: Literal[
             cv2.INTER_NEAREST,
             cv2.INTER_NEAREST_EXACT,


### PR DESCRIPTION
This PR fixes a small but important issue when using Albumentations instead of Torchvision for image preprocessing.

Albumentations uses OpenCV, which loads images in **BGR**, while Torchvision (and PIL) use **RGB**. That means the colors are wrong unless we convert them. So I added a line to convert BGR → RGB before resizing.

Also, I changed the interpolation method in the `Resize` transform. The default is `INTER_LINEAR`, but when we downscale images, `INTER_AREA` works much better and gives results closer to what Torchvision does.

With these two changes, the preprocessing output should now match what you'd get using Torchvision.

## Summary by Sourcery

Improve image preprocessing compatibility with Torchvision by fixing color conversion and resizing interpolation

Bug Fixes:
- Ensure correct color conversion from BGR to RGB when using OpenCV-based image loading

Enhancements:
- Change default image resize interpolation to INTER_AREA for better downscaling results