### PR TITLE
Updated sponsorship

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -10,4 +10,4 @@ liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
 lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+custom: ['https://albumentations.ai/support/', 'https://www.paypal.com/paypalme/ternaus'] # Albumentations support page and PayPal.me

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
         language: system
         files: setup.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.11.9
     hooks:
       - id: ruff
         exclude: '__pycache__/'

--- a/README.md
+++ b/README.md
@@ -32,23 +32,23 @@ Here is an example of how you can apply some [pixel-level](#pixel-level-transfor
 
 Albumentations thrives on developer contributions. We appreciate our sponsors who help sustain the project's infrastructure.
 
-| 🏆 Gold Sponsors |
-|-----------------|
+| 🟠 Exclusive Partner |
+|-------------------|
 | Your company could be here |
 
-| 🥈 Silver Sponsors |
+| 🟡 Integration Partner |
 |-------------------|
-| <a href="https://datature.io" target="_blank"><img src="https://albumentations.ai/assets/sponsors/datature-full.png" width="100" alt="Datature"/></a> |
+| Your company could be here |
 
-| 🥉 Bronze Sponsors |
-|-------------------|
-| <a href="https://roboflow.com" target="_blank"><img src="https://albumentations.ai/assets/sponsors/roboflow.png" width="100" alt="Roboflow"/></a> |
+| 🟢 Community Sponsor |
+|-----------------|
+| <a href="https://datature.io" target="_blank"><img src="https://albumentations.ai/assets/sponsors/datature-full.png" width="100" alt="Datature"/></a> |
 
 ---
 
 ### 💝 Become a Sponsor
 
-Your sponsorship is a way to say "thank you" to the maintainers and contributors who spend their free time building and maintaining Albumentations. Sponsors are featured on our website and README. View sponsorship tiers on [GitHub Sponsors](https://github.com/sponsors/albumentations-team)
+Your sponsorship is a way to say "thank you" to the maintainers and contributors who spend their free time building and maintaining Albumentations. Sponsors are featured on our website and README. View sponsorship tiers on [our support page](https://albumentations.ai/support/)
 
 ## Table of contents
 


### PR DESCRIPTION
## Summary by Sourcery

Update sponsorship information and tooling versions

Enhancements:
- Rename sponsorship tiers (Gold/Silver/Bronze) to Exclusive Partner, Integration Partner, and Community Sponsor in README
- Update sponsor call-to-action link to the new support page

CI:
- Bump ruff-pre-commit hook from v0.11.8 to v0.11.9 in pre-commit configuration

Chores:
- Add custom funding URLs for support page and PayPal in FUNDING.yml