### PR TITLE
Fixed Serialization FromFloat

### DIFF
--- a/albumentations/augmentations/other/type_transform.py
+++ b/albumentations/augmentations/other/type_transform.py
@@ -177,6 +177,7 @@ class FromFloat(ImageOnlyTransform):
     ):
         super().__init__(p=p)
         self.dtype_value = np.dtype(dtype)
+        self.dtype = dtype
         self.max_value = max_value
 
     def apply(self, img: np.ndarray, **params: Any) -> np.ndarray:

--- a/albumentations/augmentations/other/type_transform.py
+++ b/albumentations/augmentations/other/type_transform.py
@@ -176,7 +176,6 @@ class FromFloat(ImageOnlyTransform):
         p: float = 1.0,
     ):
         super().__init__(p=p)
-        self.dtype_value = np.dtype(dtype)
         self.dtype = dtype
         self.max_value = max_value
 
@@ -191,7 +190,7 @@ class FromFloat(ImageOnlyTransform):
             np.ndarray: The image with the applied FromFloat transform.
 
         """
-        return from_float(img, self.dtype_value, self.max_value)
+        return from_float(img, np.dtype(self.dtype), self.max_value)
 
     def apply_to_images(self, images: np.ndarray, **params: Any) -> np.ndarray:
         """Apply the FromFloat transform to the input images.
@@ -201,7 +200,7 @@ class FromFloat(ImageOnlyTransform):
             **params (Any): Additional parameters (not used in this transform).
 
         """
-        return clip(np.rint(images * self.max_value), self.dtype_value, inplace=True)
+        return clip(np.rint(images * self.max_value), np.dtype(self.dtype), inplace=True)
 
     def apply_to_volume(self, volume: np.ndarray, **params: Any) -> np.ndarray:
         """Apply the FromFloat transform to the input volume.

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -812,3 +812,12 @@ def test_serialization_excludes_strict() -> None:
     transform = A.HorizontalFlip(strict=True)
     transform_dict = A.to_dict(transform)["transform"]
     assert "strict" not in transform_dict
+
+
+def test_serialization_from_float() -> None:
+    dtype = "uint8"
+    max_value = 255
+    transform = A.FromFloat(dtype=dtype, max_value=max_value)
+    transform_dict = A.to_dict(transform)["transform"]
+    assert transform_dict["dtype"] == dtype
+    assert transform_dict["max_value"] == max_value

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -816,7 +816,7 @@ def test_serialization_excludes_strict() -> None:
 
 def test_serialization_from_float() -> None:
     dtype = "uint8"
-    max_value = 255
+    max_value = 137
     transform = A.FromFloat(dtype=dtype, max_value=max_value)
     transform_dict = A.to_dict(transform)["transform"]
     assert transform_dict["dtype"] == dtype


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2514

## Summary by Sourcery

Ensure the FromFloat transform properly exposes its dtype and max_value in serialized output and add a test to verify this behavior

Bug Fixes:
- Include the original dtype attribute in the FromFloat transform to enable correct serialization of dtype and max_value

Tests:
- Add a test to verify that FromFloat serialization includes the correct dtype and max_value values