### PR TITLE
Can use empty masks as target

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -685,6 +685,9 @@ class Compose(BaseCompose, HubMixin):
 
         if isinstance(data["images"], (list, tuple)):
             self._images_was_list = True
+            # Skip stacking for empty lists
+            if not data["images"]:
+                return
             data["images"] = np.stack(data["images"])
         else:
             self._images_was_list = False
@@ -696,6 +699,9 @@ class Compose(BaseCompose, HubMixin):
 
         if isinstance(data["masks"], (list, tuple)):
             self._masks_was_list = True
+            # Skip stacking for empty lists
+            if not data["masks"]:
+                return
             data["masks"] = np.stack(data["masks"])
         else:
             self._masks_was_list = False
@@ -771,7 +777,7 @@ class Compose(BaseCompose, HubMixin):
         return data.shape[:2]
 
     @staticmethod
-    def _check_masks_data(data_name: str, data: Any) -> tuple[int, int]:
+    def _check_masks_data(data_name: str, data: Any) -> tuple[int, int] | None:
         """Check masks data format and return shape.
 
         Args:
@@ -779,9 +785,10 @@ class Compose(BaseCompose, HubMixin):
             data (Any): Input data in one of these formats:
                 - List of numpy arrays, each of shape (H, W) or (H, W, C)
                 - Numpy array of shape (N, H, W) or (N, H, W, C)
+                - Empty list for cases where no masks are present
 
         Returns:
-            tuple[int, int]: (height, width) of the first mask
+            tuple[int, int] | None: (height, width) of the first mask, or None if masks list is empty
         Raises:
             TypeError: If data format is invalid
 
@@ -793,7 +800,8 @@ class Compose(BaseCompose, HubMixin):
 
         if isinstance(data, (list, tuple)):
             if not data:
-                raise ValueError(f"{data_name} cannot be empty")
+                # Allow empty list/tuple of masks
+                return None
             if not all(isinstance(m, np.ndarray) for m in data):
                 raise TypeError(f"All elements in {data_name} must be numpy arrays")
             if any(m.ndim not in {2, 3} for m in data):
@@ -883,29 +891,47 @@ class Compose(BaseCompose, HubMixin):
 
     def _get_data_shape(self, data_name: str, internal_name: str, data: Any) -> tuple[int, ...] | None:
         """Get shape of data based on its type."""
+        # Handle single images and masks
         if internal_name in CHECKED_SINGLE:
-            if not isinstance(data, np.ndarray):
-                raise TypeError(f"{data_name} must be numpy array type")
-            return data.shape
+            return self._get_single_data_shape(data_name, data)
 
+        # Handle volumes
         if internal_name in CHECKED_VOLUME:
             return self._check_volume_data(data_name, data)
 
+        # Handle 3D masks
         if internal_name in CHECKED_MASK3D:
             return self._check_mask3d_data(data_name, data)
 
+        # Handle multi-item data (masks, images, volumes)
         if internal_name in CHECKED_MULTI:
-            if internal_name == "masks":
-                return self._check_masks_data(data_name, data)
-            if internal_name in {"volumes", "masks3d"}:  # Group these together
-                if not isinstance(data, np.ndarray):
-                    raise TypeError(f"{data_name} must be numpy array type")
-                if data.ndim not in {4, 5}:  # (N,D,H,W) or (N,D,H,W,C)
-                    raise TypeError(f"{data_name} must be 4D or 5D array")
-                return data.shape  # Return full shape
-            return self._check_multi_data(data_name, data)
+            return self._get_multi_data_shape(data_name, internal_name, data)
 
         return None
+
+    def _get_single_data_shape(self, data_name: str, data: np.ndarray) -> tuple[int, ...]:
+        """Get shape of single image or mask."""
+        if not isinstance(data, np.ndarray):
+            raise TypeError(f"{data_name} must be numpy array type")
+        return data.shape
+
+    def _get_multi_data_shape(self, data_name: str, internal_name: str, data: Any) -> tuple[int, ...] | None:
+        """Get shape of multi-item data (masks, images, volumes)."""
+        if internal_name == "masks":
+            shape = self._check_masks_data(data_name, data)
+            # Skip empty masks lists when returning shape
+            if shape is None:
+                return None
+            return shape
+
+        if internal_name in {"volumes", "masks3d"}:  # Group these together
+            if not isinstance(data, np.ndarray):
+                raise TypeError(f"{data_name} must be numpy array type")
+            if data.ndim not in {4, 5}:  # (N,D,H,W) or (N,D,H,W,C)
+                raise TypeError(f"{data_name} must be 4D or 5D array")
+            return data.shape  # Return full shape
+
+        return self._check_multi_data(data_name, data)
 
     def _check_shape_consistency(self, shapes: list[tuple[int, ...]], volume_shapes: list[tuple[int, ...]]) -> None:
         """Check consistency of shapes."""

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -920,9 +920,7 @@ class Compose(BaseCompose, HubMixin):
         if internal_name == "masks":
             shape = self._check_masks_data(data_name, data)
             # Skip empty masks lists when returning shape
-            if shape is None:
-                return None
-            return shape
+            return None if shape is None else shape
 
         if internal_name in {"volumes", "masks3d"}:  # Group these together
             if not isinstance(data, np.ndarray):

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -301,10 +301,14 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         res = {}
         for key, arg in kwargs.items():
             if key in self._key2func and arg is not None:
-                target_function = self._key2func[key]
-                res[key] = ensure_contiguous_output(
-                    target_function(ensure_contiguous_output(arg), **params),
-                )
+                # Handle empty lists for mask-like keys
+                if key in {"masks", "masks3d"} and isinstance(arg, list) and not arg:
+                    res[key] = arg  # Keep empty list as is
+                else:
+                    target_function = self._key2func[key]
+                    res[key] = ensure_contiguous_output(
+                        target_function(ensure_contiguous_output(arg), **params),
+                    )
             else:
                 res[key] = arg
         return res

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -302,7 +302,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         for key, arg in kwargs.items():
             if key in self._key2func and arg is not None:
                 # Handle empty lists for mask-like keys
-                if key in {"masks", "masks3d"} and isinstance(arg, list) and not arg:
+                if key in {"masks", "masks3d"} and isinstance(arg, (list, tuple)) and not arg:
                     res[key] = arg  # Keep empty list as is
                 else:
                     target_function = self._key2func[key]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1957,5 +1957,5 @@ def test_compose_with_empty_masks():
     result = transform(image=image, masks=[])
     # Verify that the result contains an empty masks list
     assert "masks" in result
-    assert isinstance(result["masks"], list)
+    assert isinstance(result["masks"], (list, tuple))
     assert len(result["masks"]) == 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1945,3 +1945,17 @@ def test_keypoint_hflip_hflip_no_labels(kp_format: str, keypoints: list[list[flo
     transformed = aug(image=image, keypoints=original_keypoints)
 
     assert np.allclose(transformed["keypoints"], original_keypoints, atol=1e-6)
+
+
+def test_compose_with_empty_masks():
+    """Test that Compose can handle empty masks list."""
+    transform = Compose([
+        A.Resize(288, 384),
+        A.ToFloat(max_value=255)
+    ])
+    image = np.zeros((288, 384, 3), dtype=np.uint8)
+    result = transform(image=image, masks=[])
+    # Verify that the result contains an empty masks list
+    assert "masks" in result
+    assert isinstance(result["masks"], list)
+    assert len(result["masks"]) == 0


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/albumentations/issues/2519

## Summary by Sourcery

Enable processing of empty mask (and image) lists by bypassing stacking and shape checks, refactor data shape logic into helper methods, and update transformation pipeline to preserve empty lists.

Bug Fixes:
- Allow Compose to handle empty masks lists without errors

Enhancements:
- Skip stacking for empty image and mask lists during preprocessing
- Preserve empty lists for mask-like keys in apply_with_params
- Extract single and multi-item data shape determination into helper methods

Tests:
- Add test to verify Compose handles empty masks list