### PR TITLE
Apply resize in the loop

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1060,7 +1060,7 @@ def test_images_as_target(augmentation_cls, params, as_array, shape):
 
 
     # Check both images were transformed identically
-    np.testing.assert_allclose(transformed["images"][0], transformed["images"][1], atol=3)
+    np.testing.assert_allclose(transformed["images"][0], transformed["images"][1])
 
     # Check output format matches input format
     if as_array:


### PR DESCRIPTION
## Summary by Sourcery

Apply resizing directly in the image processing loop instead of using a dedicated helper, remove the now-unused batch volume resize method, and tighten the image comparison assertion in the tests.

Enhancements:
- Replace the internal _resize_volume helper with an explicit per-slice resize inside apply_to_images.
- Remove the obsolete batch_transform-based _resize_volume method.

Tests:
- Remove tolerance in numpy assert_allclose to enforce exact image matching.