### PR TITLE
Fix add remove transforms

### DIFF
--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -68,7 +68,7 @@ class CoarseDropout(BaseDropout):
         - For 'random_uniform' fill, each hole gets a single random color, unlike 'random' where each pixel
             gets its own random value.
 
-    Example:
+    Examples:
         >>> import numpy as np
         >>> import albumentations as A
         >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
@@ -232,7 +232,7 @@ class Erasing(BaseDropout):
           the specified ranges for each application.
         - When using inpainting methods, only grayscale or RGB images are supported.
 
-    Example:
+    Examples:
         >>> import numpy as np
         >>> import albumentations as A
         >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)

--- a/albumentations/augmentations/mixing/domain_adaptation_functional.py
+++ b/albumentations/augmentations/mixing/domain_adaptation_functional.py
@@ -291,7 +291,7 @@ def fourier_domain_adaptation(img: np.ndarray, target_img: np.ndarray, beta: flo
     The `low_freq_mutate` function (not shown here) is responsible for the actual
     amplitude mutation, focusing on low-frequency components which carry style information.
 
-    Example:
+    Examples:
         >>> import numpy as np
         >>> import albumentations as A
         >>> source_img = np.random.rand(100, 100, 3).astype(np.float32)

--- a/albumentations/augmentations/pixel/functional.py
+++ b/albumentations/augmentations/pixel/functional.py
@@ -307,7 +307,7 @@ def equalize(
           color space, equalized on the Y channel, and then converted back to RGB.
         - The function preserves the original number of channels in the image.
 
-    Example:
+    Examples:
         >>> import numpy as np
         >>> import albumentations as A
         >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
@@ -435,7 +435,7 @@ def clahe(
     Raises:
         ValueError: If the input image is not 2D or 3D.
 
-    Example:
+    Examples:
         >>> import numpy as np
         >>> img = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
         >>> result = clahe(img, clip_limit=2.0, tile_grid_size=(8, 8))

--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -456,7 +456,7 @@ def calculate_bbox_areas_in_pixels(bboxes: np.ndarray, shape: ShapeType) -> np.n
         - The function preserves the input array and creates a copy for internal calculations.
         - The returned areas are in pixel units, not normalized.
 
-    Example:
+    Examples:
         >>> bboxes = np.array([[0.1, 0.1, 0.5, 0.5], [0.2, 0.2, 0.8, 0.8]])
         >>> image_shape = (100, 100)
         >>> areas = calculate_bbox_areas(bboxes, image_shape)
@@ -652,7 +652,7 @@ def clip_bboxes(bboxes: np.ndarray, shape: ShapeType) -> np.ndarray:
     # But this would cause the bounding box to be clipped to the image dimensions - 1 which is not what we want.
     # Bounding box lives not in the middle of pixels but between them.
 
-    # Example: for image with height 100, width 100, the pixel values are in the range [0, 99]
+    # Examples: for image with height 100, width 100, the pixel values are in the range [0, 99]
     # but if we want bounding box to be 1 pixel width and height and lie on the boundary of the image
     # it will be described as [99, 99, 100, 100] => clip by image_size - 1 will lead to [99, 99, 99, 99]
     # which is incorrect

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -462,7 +462,7 @@ class BaseCompose(Serializable):
         Raises:
             TypeError: If other is not a valid transform or sequence of transforms
 
-        Example:
+        Examples:
             >>> new_compose = compose + A.HorizontalFlip()
             >>> new_compose = compose + [A.HorizontalFlip(), A.VerticalFlip()]
 
@@ -481,7 +481,7 @@ class BaseCompose(Serializable):
         Raises:
             TypeError: If other is not a valid transform or sequence of transforms
 
-        Example:
+        Examples:
             >>> new_compose = A.HorizontalFlip() + compose
             >>> new_compose = [A.HorizontalFlip(), A.VerticalFlip()] + compose
 
@@ -505,7 +505,7 @@ class BaseCompose(Serializable):
             If the same transform instance appears multiple times in the compose,
             only the first occurrence will be removed.
 
-        Example:
+        Examples:
             >>> new_compose = compose - transform_instance
             >>>
             >>> # With duplicates - only first occurrence removed
@@ -620,7 +620,7 @@ class Compose(BaseCompose, HubMixin):
         save_applied_params (bool): If True, saves the applied parameters of each transform. Default is False.
             You will need to use the `applied_transforms` key in the output dictionary to access the parameters.
 
-    Example:
+    Examples:
         >>> # Basic usage:
         >>> import albumentations as A
         >>> transform = A.Compose([
@@ -1722,7 +1722,7 @@ class Sequential(BaseCompose):
         create an augmentation pipeline that contains multiple sequences of augmentations and applies one randomly
         chose sequence to input data (see the `Example` section for an example definition of such pipeline).
 
-    Example:
+    Examples:
         >>> import albumentations as A
         >>> transform = A.Compose([
         >>>    A.OneOf([


### PR DESCRIPTION
## Summary by Sourcery

Implement class-based subtraction for Compose pipelines, replacing instance-based removal with class-type removal and updating related behavior, tests, and documentation

Enhancements:
- Change BaseCompose.__sub__ to accept transform classes and remove the first matching transform of that class
- Update subtraction operator to return new pipeline instances without modifying originals and adjust error messages for invalid types and missing transforms

Documentation:
- Standardize docstrings and examples to demonstrate removal by class and use "Examples:" headings across composition and augmentation modules

Tests:
- Revise tests to validate class-based subtraction semantics, including removal of specific transform classes, error handling, and immutability