### PR TITLE
Added apply funcs to Transpose

### DIFF
--- a/albumentations/augmentations/geometric/flip.py
+++ b/albumentations/augmentations/geometric/flip.py
@@ -434,6 +434,71 @@ class Transpose(DualTransform):
         """
         return fgeometric.keypoints_transpose(keypoints)
 
+    def apply_to_images(self, images: np.ndarray, **params: Any) -> np.ndarray:
+        """Apply the transpose to a batch of images.
+
+        Args:
+            images (np.ndarray): Images to be transposed.
+            **params (Any): Additional parameters.
+
+        Returns:
+            np.ndarray: Transposed images.
+
+        """
+        return fgeometric.transpose_images(images)
+
+    def apply_to_volume(self, volume: np.ndarray, **params: Any) -> np.ndarray:
+        """Apply the transpose to a volume.
+
+        Args:
+            volume (np.ndarray): Volume to be transposed.
+            **params (Any): Additional parameters.
+
+        Returns:
+            np.ndarray: Transposed volume.
+
+        """
+        return self.apply_to_images(volume, **params)
+
+    def apply_to_volumes(self, volumes: np.ndarray, **params: Any) -> np.ndarray:
+        """Apply the transpose to a batch of volumes.
+
+        Args:
+            volumes (np.ndarray): Volumes to be transposed.
+            **params (Any): Additional parameters.
+
+        Returns:
+            np.ndarray: Transposed volumes.
+
+        """
+        return fgeometric.transpose_volumes(volumes)
+
+    def apply_to_mask3d(self, mask3d: np.ndarray, **params: Any) -> np.ndarray:
+        """Apply the transpose to a 3D mask.
+
+        Args:
+            mask3d (np.ndarray): 3D mask to be transposed.
+            **params (Any): Additional parameters.
+
+        Returns:
+            np.ndarray: Transposed 3D mask.
+
+        """
+        return self.apply_to_images(mask3d, **params)
+
+    def apply_to_masks3d(self, masks3d: np.ndarray, **params: Any) -> np.ndarray:
+        """Apply the transpose to a batch of 3D masks.
+
+        Args:
+            masks3d (np.ndarray): 3D masks to be transposed.
+            **params (Any): Additional parameters.
+
+        Returns:
+            np.ndarray: Transposed 3D masks.
+
+        """
+        return self.apply_to_volumes(masks3d, **params)
+
 
 class D4(DualTransform):
     """Applies one of the eight possible D4 dihedral group transformations to a square-shaped input,

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -1230,6 +1230,60 @@ def transpose(img: np.ndarray) -> np.ndarray:
     return img.transpose(new_axes)
 
 
+def transpose_images(images: np.ndarray) -> np.ndarray:
+    """Transpose a batch of images.
+
+    Args:
+        images (np.ndarray): Batch of images to transpose with shape:
+            - (N, H, W) for grayscale images
+            - (N, H, W, C) for multi-channel images
+            where N is the batch size, H is height, W is width, C is channels
+
+    Returns:
+        np.ndarray: Transposed batch of images with shape:
+            - (N, W, H) for grayscale images
+            - (N, W, H, C) for multi-channel images
+
+    """
+    if images.ndim not in [3, 4]:
+        raise ValueError(f"Expected 3D or 4D array for batch of images, got {images.ndim}D array")
+
+    # Generate the new axes order
+    new_axes = list(range(images.ndim))
+    # Swap dimensions 1 and 2 (Height and Width), preserving batch dimension and channels
+    new_axes[1], new_axes[2] = 2, 1
+
+    # Transpose the array using the new axes order
+    return images.transpose(new_axes)
+
+
+def transpose_volumes(volumes: np.ndarray) -> np.ndarray:
+    """Transpose a batch of volumes.
+
+    Args:
+        volumes (np.ndarray): Batch of volumes to transpose with shape:
+            - (N, D, H, W) for grayscale volumes
+            - (N, D, H, W, C) for multi-channel volumes
+            where N is the batch size, D is depth, H is height, W is width, C is channels
+
+    Returns:
+        np.ndarray: Transposed batch of volumes with shape:
+            - (N, D, W, H) for grayscale volumes
+            - (N, D, W, H, C) for multi-channel volumes
+
+    """
+    if volumes.ndim not in [4, 5]:
+        raise ValueError(f"Expected 4D or 5D array for batch of volumes, got {volumes.ndim}D array")
+
+    # Generate the new axes order
+    new_axes = list(range(volumes.ndim))
+    # Swap dimensions 2 and 3 (Height and Width), preserving batch, depth and channels
+    new_axes[2], new_axes[3] = 3, 2
+
+    # Transpose the array using the new axes order
+    return volumes.transpose(new_axes)
+
+
 def rot90(img: np.ndarray, factor: Literal[0, 1, 2, 3]) -> np.ndarray:
     """Rotate an image 90 degrees counterclockwise.
 

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -1245,9 +1245,6 @@ def transpose_images(images: np.ndarray) -> np.ndarray:
             - (N, W, H, C) for multi-channel images
 
     """
-    if images.ndim not in [3, 4]:
-        raise ValueError(f"Expected 3D or 4D array for batch of images, got {images.ndim}D array")
-
     # Generate the new axes order
     new_axes = list(range(images.ndim))
     # Swap dimensions 1 and 2 (Height and Width), preserving batch dimension and channels
@@ -1272,9 +1269,6 @@ def transpose_volumes(volumes: np.ndarray) -> np.ndarray:
             - (N, D, W, H, C) for multi-channel volumes
 
     """
-    if volumes.ndim not in [4, 5]:
-        raise ValueError(f"Expected 4D or 5D array for batch of volumes, got {volumes.ndim}D array")
-
     # Generate the new axes order
     new_axes = list(range(volumes.ndim))
     # Swap dimensions 2 and 3 (Height and Width), preserving batch, depth and channels


### PR DESCRIPTION
## Summary by Sourcery

Extend the Transpose augmentation to handle single and batched images, volumes, and 3D masks by introducing corresponding apply methods and utility functions

New Features:
- Add apply_to_images, apply_to_volume, apply_to_volumes, apply_to_mask3d, and apply_to_masks3d methods to the Transpose transform
- Implement transpose_images and transpose_volumes functions for batch transposition in the functional module