### PR TITLE
added apply_to_images for RandomRotate90

### DIFF
--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -1292,6 +1292,28 @@ def rot90(img: np.ndarray, factor: Literal[0, 1, 2, 3]) -> np.ndarray:
     return np.rot90(img, factor)
 
 
+def rot90_images(images: np.ndarray, factor: Literal[0, 1, 2, 3]) -> np.ndarray:
+    """Rotate a batch of images 90 degrees counter-clockwise multiple times.
+
+    Args:
+        images (np.ndarray): Batch of images to rotate with shape:
+            - (N, H, W) for grayscale images
+            - (N, H, W, C) for multi-channel images
+            where N is the batch size, H is height, W is width, C is channels
+        factor (Literal[0, 1, 2, 3]): The number of 90-degree rotations to apply.
+
+    Returns:
+        np.ndarray: Rotated batch of images with shape:
+            - (N, W, H) for grayscale images when factor is 1 or 3
+            - (N, H, W) for grayscale images when factor is 0 or 2
+            - (N, W, H, C) for multi-channel images when factor is 1 or 3
+            - (N, H, W, C) for multi-channel images when factor is 0 or 2
+
+    """
+    # Axes 1 (height) and 2 (width) for rotation, preserving batch dimension
+    return np.rot90(images, k=factor, axes=(1, 2))
+
+
 @handle_empty_array("bboxes")
 def bboxes_vflip(bboxes: np.ndarray) -> np.ndarray:
     """Flip bounding boxes vertically.

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -179,6 +179,20 @@ class RandomRotate90(DualTransform):
         """
         return fgeometric.keypoints_rot90(keypoints, factor, params["shape"])
 
+    def apply_to_images(self, images: np.ndarray, factor: Literal[0, 1, 2, 3], **params: Any) -> np.ndarray:
+        """Apply rotation to a batch of images.
+
+        Args:
+            images (np.ndarray): Images to rotate.
+            factor (Literal[0, 1, 2, 3]): Number of times to rotate by 90 degrees.
+            **params (Any): Additional parameters.
+
+        Returns:
+            np.ndarray: Rotated images.
+
+        """
+        return fgeometric.rot90_images(images, factor)
+
     def apply_to_volume(self, volume: np.ndarray, factor: Literal[0, 1, 2, 3], **params: Any) -> np.ndarray:
         """Apply rotation to the input volume.
 
@@ -191,7 +205,7 @@ class RandomRotate90(DualTransform):
             np.ndarray: Rotated volume.
 
         """
-        return fgeometric.volume_rot90(volume, factor)
+        return self.apply_to_images(volume, factor, **params)
 
     def apply_to_volumes(self, volumes: np.ndarray, factor: Literal[0, 1, 2, 3], **params: Any) -> np.ndarray:
         """Apply rotation to the input volumes.
@@ -219,7 +233,7 @@ class RandomRotate90(DualTransform):
             np.ndarray: Rotated mask3d.
 
         """
-        return fgeometric.volume_rot90(mask3d, factor)
+        return self.apply_to_images(mask3d, factor, **params)
 
     def apply_to_masks3d(self, masks3d: np.ndarray, factor: Literal[0, 1, 2, 3], **params: Any) -> np.ndarray:
         """Apply rotation to the input masks3d.
@@ -233,7 +247,7 @@ class RandomRotate90(DualTransform):
             np.ndarray: Rotated masks3d.
 
         """
-        return fgeometric.volumes_rot90(masks3d, factor)
+        return self.apply_to_volumes(masks3d, factor, **params)
 
 
 class RotateInitSchema(BaseTransformInitSchema):


### PR DESCRIPTION
## Summary by Sourcery

Add support for rotating batches of images in RandomRotate90 by introducing a new rot90_images utility and an apply_to_images method, and refactor volume and mask rotations to leverage this unified approach.

New Features:
- Introduce rot90_images in the geometric functional API to rotate batches of images by 90-degree increments
- Add apply_to_images method to the RandomRotate90 transform to handle batch image rotation

Enhancements:
- Refactor volume and mask rotation methods in RandomRotate90 to delegate to the new apply_to_images implementation