### PR TITLE
added d4_images

### DIFF
--- a/albumentations/augmentations/geometric/flip.py
+++ b/albumentations/augmentations/geometric/flip.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from typing import Any, Literal
 
 import numpy as np
-from albucore import batch_transform, hflip, vflip
+from albucore import hflip, vflip
 
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
@@ -614,7 +614,6 @@ class D4(DualTransform):
         """
         return fgeometric.keypoints_d4(keypoints, group_element, params["shape"])
 
-    @batch_transform("spatial", has_batch_dim=True, has_depth_dim=False)
     def apply_to_images(
         self,
         images: np.ndarray,
@@ -631,7 +630,6 @@ class D4(DualTransform):
         """
         return fgeometric.d4_images(images, group_element)
 
-    @batch_transform("spatial", has_batch_dim=False, has_depth_dim=True)
     def apply_to_volume(
         self,
         volume: np.ndarray,
@@ -648,7 +646,6 @@ class D4(DualTransform):
         """
         return self.apply_to_images(volume, group_element, **params)
 
-    @batch_transform("spatial", has_batch_dim=True, has_depth_dim=True)
     def apply_to_volumes(
         self,
         volumes: np.ndarray,
@@ -665,7 +662,6 @@ class D4(DualTransform):
         """
         return fgeometric.d4_images(volumes, group_element)
 
-    @batch_transform("spatial", has_batch_dim=True, has_depth_dim=False)
     def apply_to_mask3d(
         self,
         mask3d: np.ndarray,

--- a/albumentations/augmentations/geometric/flip.py
+++ b/albumentations/augmentations/geometric/flip.py
@@ -615,48 +615,88 @@ class D4(DualTransform):
         return fgeometric.keypoints_d4(keypoints, group_element, params["shape"])
 
     @batch_transform("spatial", has_batch_dim=True, has_depth_dim=False)
-    def apply_to_images(self, images: np.ndarray, **params: Any) -> np.ndarray:
+    def apply_to_images(
+        self,
+        images: np.ndarray,
+        group_element: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"],
+        **params: Any,
+    ) -> np.ndarray:
         """Apply the D4 transform to a batch of images.
 
         Args:
             images (np.ndarray): Images to be transformed.
+            group_element (Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]): Group element to apply.
             **params (Any): Additional parameters.
 
         """
-        return self.apply(images, **params)
+        return fgeometric.d4_images(images, group_element)
 
     @batch_transform("spatial", has_batch_dim=False, has_depth_dim=True)
-    def apply_to_volume(self, volume: np.ndarray, **params: Any) -> np.ndarray:
+    def apply_to_volume(
+        self,
+        volume: np.ndarray,
+        group_element: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"],
+        **params: Any,
+    ) -> np.ndarray:
         """Apply the D4 transform to a volume.
 
         Args:
             volume (np.ndarray): Volume to be transformed.
+            group_element (Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]): Group element to apply.
             **params (Any): Additional parameters.
 
         """
-        return self.apply(volume, **params)
+        return self.apply_to_images(volume, group_element, **params)
 
     @batch_transform("spatial", has_batch_dim=True, has_depth_dim=True)
-    def apply_to_volumes(self, volumes: np.ndarray, **params: Any) -> np.ndarray:
+    def apply_to_volumes(
+        self,
+        volumes: np.ndarray,
+        group_element: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"],
+        **params: Any,
+    ) -> np.ndarray:
         """Apply the D4 transform to a batch of volumes.
 
         Args:
             volumes (np.ndarray): Volumes to be transformed.
+            group_element (Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]): Group element to apply.
             **params (Any): Additional parameters.
 
         """
-        return self.apply(volumes, **params)
+        return fgeometric.d4_images(volumes, group_element)
 
     @batch_transform("spatial", has_batch_dim=True, has_depth_dim=False)
-    def apply_to_mask3d(self, mask3d: np.ndarray, **params: Any) -> np.ndarray:
+    def apply_to_mask3d(
+        self,
+        mask3d: np.ndarray,
+        group_element: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"],
+        **params: Any,
+    ) -> np.ndarray:
         """Apply the D4 transform to a 3D mask.
 
         Args:
             mask3d (np.ndarray): 3D mask to be transformed.
+            group_element (Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]): Group element to apply.
             **params (Any): Additional parameters.
 
         """
-        return self.apply(mask3d, **params)
+        return self.apply_to_images(mask3d, group_element, **params)
+
+    def apply_to_masks3d(
+        self,
+        masks3d: np.ndarray,
+        group_element: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"],
+        **params: Any,
+    ) -> np.ndarray:
+        """Apply the D4 transform to a batch of 3D masks.
+
+        Args:
+            masks3d (np.ndarray): 3D masks to be transformed.
+            group_element (Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]): Group element to apply.
+            **params (Any): Additional parameters.
+
+        """
+        return self.apply_to_volumes(masks3d, group_element, **params)
 
     def get_params(self) -> dict[str, Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]]:
         """Get the parameters for the D4 transform.

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -1166,6 +1166,10 @@ def from_distance_maps(
     return keypoints
 
 
+# Group elements for D4 symmetry group
+D4_GROUP_ELEMENTS = ["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]
+
+
 def d4(img: np.ndarray, group_member: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]) -> np.ndarray:
     """Applies a `D_4` symmetry group transformation to an image array.
 
@@ -1189,26 +1193,9 @@ def d4(img: np.ndarray, group_member: Literal["e", "r90", "r180", "r270", "v", "
     Returns:
         np.ndarray: The transformed image array.
 
-    Raises:
-        ValueError: If an invalid group member is specified.
-
     """
-    transformations = {
-        "e": lambda x: x,  # Identity transformation
-        "r90": lambda x: rot90(x, 1),  # Rotate 90 degrees
-        "r180": lambda x: rot90(x, 2),  # Rotate 180 degrees
-        "r270": lambda x: rot90(x, 3),  # Rotate 270 degrees
-        "v": vflip,  # Vertical flip
-        "hvt": lambda x: transpose(rot90(x, 2)),  # Reflect over anti-diagonal
-        "h": hflip,  # Horizontal flip
-        "t": transpose,  # Transpose (reflect over main diagonal)
-    }
-
     # Execute the appropriate transformation
-    if group_member in transformations:
-        return transformations[group_member](img)
-
-    raise ValueError(f"Invalid group member: {group_member}")
+    return D4_TRANSFORMATIONS[group_member](img)
 
 
 def transpose(img: np.ndarray) -> np.ndarray:
@@ -1228,6 +1215,18 @@ def transpose(img: np.ndarray) -> np.ndarray:
 
     # Transpose the array using the new axes order
     return img.transpose(new_axes)
+
+
+D4_TRANSFORMATIONS = {
+    "e": lambda x: x,  # Identity transformation
+    "r90": lambda x: rot90(x, 1),  # Rotate 90 degrees
+    "r180": lambda x: rot90(x, 2),  # Rotate 180 degrees
+    "r270": lambda x: rot90(x, 3),  # Rotate 270 degrees
+    "v": vflip,  # Vertical flip
+    "hvt": lambda x: transpose(rot90(x, 2)),  # Reflect over anti-diagonal
+    "h": hflip,  # Horizontal flip
+    "t": transpose,  # Transpose (reflect over main diagonal)
+}
 
 
 def transpose_images(images: np.ndarray) -> np.ndarray:
@@ -4109,6 +4108,18 @@ def bboxes_morphology(
     return bboxes
 
 
+D4_TRANSFORMATIONS_IMAGES = {
+    "e": lambda x: x,  # Identity transformation
+    "r90": lambda x: rot90_images(x, 1),  # Rotate 90 degrees
+    "r180": lambda x: rot90_images(x, 2),  # Rotate 180 degrees
+    "r270": lambda x: rot90_images(x, 3),  # Rotate 270 degrees
+    "v": vflip,  # Vertical flip (already batch-aware)
+    "hvt": lambda x: transpose_images(rot90_images(x, 2)),  # Reflect over anti-diagonal
+    "h": hflip,  # Horizontal flip (already batch-aware)
+    "t": transpose_images,  # Transpose (reflect over main diagonal)
+}
+
+
 def d4_images(img: np.ndarray, group_member: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]) -> np.ndarray:
     """Applies a `D_4` symmetry group transformation to a batch of images.
 
@@ -4135,23 +4146,6 @@ def d4_images(img: np.ndarray, group_member: Literal["e", "r90", "r180", "r270",
     Returns:
         np.ndarray: The transformed batch of images.
 
-    Raises:
-        ValueError: If an invalid group member is specified.
-
     """
-    transformations = {
-        "e": lambda x: x,  # Identity transformation
-        "r90": lambda x: rot90_images(x, 1),  # Rotate 90 degrees
-        "r180": lambda x: rot90_images(x, 2),  # Rotate 180 degrees
-        "r270": lambda x: rot90_images(x, 3),  # Rotate 270 degrees
-        "v": vflip,  # Vertical flip (already batch-aware)
-        "hvt": lambda x: transpose_images(rot90_images(x, 2)),  # Reflect over anti-diagonal
-        "h": hflip,  # Horizontal flip (already batch-aware)
-        "t": transpose_images,  # Transpose (reflect over main diagonal)
-    }
-
     # Execute the appropriate transformation
-    if group_member in transformations:
-        return transformations[group_member](img)
-
-    raise ValueError(f"Invalid group member: {group_member}")
+    return D4_TRANSFORMATIONS_IMAGES[group_member](img)


### PR DESCRIPTION
## Summary by Sourcery

Integrate full D4 symmetry support into geometric flips by introducing a dedicated d4_images utility and updating Flip augmentation methods—including 3D masks—to accept and apply explicit group elements.

New Features:
- Add d4_images function to apply D4 symmetry group transformations to batches of images
- Extend Flip augmentation to accept explicit D4 group elements and support 3D mask batches

Enhancements:
- Refactor Flip methods to enforce a Literal group_element parameter with updated type annotations
- Standardize Flip augmentation docstrings for clarity and batch/depth dimensions