### PR TITLE
apply_to_images for ToGray

### DIFF
--- a/albumentations/augmentations/pixel/functional.py
+++ b/albumentations/augmentations/pixel/functional.py
@@ -1418,11 +1418,7 @@ def to_gray_from_lab(img: np.ndarray) -> np.ndarray:
         has_depth_dim=has_depth_dim,
     )
 
-    if original_dtype in [np.float32, np.float64]:
-        # LAB L channel is in [0, 100], normalize to [0, 1]
-        grayscale = grayscale / 100.0
-
-    return grayscale
+    return grayscale / 100.0 if original_dtype in [np.float32, np.float64] else grayscale
 
 
 @clipped

--- a/albumentations/augmentations/pixel/functional.py
+++ b/albumentations/augmentations/pixel/functional.py
@@ -1335,17 +1335,6 @@ def to_gray_from_lab(img: np.ndarray) -> np.ndarray:
 
         This enables processing all images in a single OpenCV call
 
-        Performance benefits:
-            - 2-8x faster than iterating with OpenCV
-            - 20-40x faster than pure NumPy implementations
-            - Memory efficient with minimal allocations
-            - Produces identical results to standard OpenCV processing
-
-    The optimization works because:
-        1. OpenCV processes images row by row
-        2. LAB conversion is a pixel-wise operation (no spatial dependencies)
-        3. Multiple images can be stacked vertically and processed in one call
-
     Args:
         img: Input RGB image(s) as a numpy array. Must have 3 channels in the last dimension.
             Supported shapes:

--- a/albumentations/augmentations/pixel/functional.py
+++ b/albumentations/augmentations/pixel/functional.py
@@ -1648,15 +1648,11 @@ def grayscale_to_multichannel(
         np.ndarray: Multi-channel image with shape (height, width, num_channels)
 
     """
-    # Ensure we have a 2D array
-    squeezed = np.squeeze(grayscale_image)
-
     # If output should be single channel, add channel dimension if needed
     if num_output_channels == 1:
-        if squeezed.ndim == 2:
-            return np.expand_dims(squeezed, axis=-1)
         return grayscale_image
 
+    squeezed = np.squeeze(grayscale_image)
     # For multi-channel output, stack channels
     return np.stack([squeezed] * num_output_channels, axis=-1)
 

--- a/albumentations/augmentations/pixel/functional.py
+++ b/albumentations/augmentations/pixel/functional.py
@@ -1345,7 +1345,7 @@ def to_gray_from_lab(img: np.ndarray) -> np.ndarray:
 
             Supported dtypes:
             - np.uint8: Values in range [0, 255]
-            - np.float32/float64: Values in range [0, 1]
+            - np.float32: Values in range [0, 1]
 
     Returns:
         Grayscale image(s) with the same spatial dimensions as input but without channel dimension:
@@ -1418,7 +1418,7 @@ def to_gray_from_lab(img: np.ndarray) -> np.ndarray:
         has_depth_dim=has_depth_dim,
     )
 
-    return grayscale / 100.0 if original_dtype in [np.float32, np.float64] else grayscale
+    return grayscale / 100.0 if original_dtype == np.float32 else grayscale
 
 
 @clipped

--- a/albumentations/augmentations/pixel/functional.py
+++ b/albumentations/augmentations/pixel/functional.py
@@ -1537,13 +1537,9 @@ def to_gray_pca(img: np.ndarray) -> np.ndarray:
 
     Args:
         img (np.ndarray): Input image as a numpy array. Can be:
-            - Single grayscale image: (H, W)
             - Single multi-channel image: (H, W, C)
-            - Batch of grayscale images: (N, H, W)
             - Batch of multi-channel images: (N, H, W, C)
-            - Single grayscale volume: (D, H, W)
             - Single multi-channel volume: (D, H, W, C)
-            - Batch of grayscale volumes: (N, D, H, W)
             - Batch of multi-channel volumes: (N, D, H, W, C)
 
     Returns:

--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -3458,6 +3458,57 @@ class ToGray(ImageOnlyTransform):
 
         return fpixel.to_gray(img, self.num_output_channels, self.method)
 
+    def apply_to_images(self, images: np.ndarray, **params: Any) -> np.ndarray:
+        """Apply ToGray to a batch of images.
+
+        Args:
+            images (np.ndarray): Batch of images with shape (N, H, W, C) or (N, H, W).
+            **params (Any): Additional parameters.
+
+        Returns:
+            np.ndarray: Batch of grayscale images.
+
+        """
+        if is_grayscale_image(images, has_batch_dim=True):
+            warnings.warn("The image is already gray.", stacklevel=2)
+            return images
+
+        return fpixel.to_gray(images, self.num_output_channels, self.method)
+
+    def apply_to_volume(self, volume: np.ndarray, **params: Any) -> np.ndarray:
+        """Apply ToGray to a single volume.
+
+        Args:
+            volume (np.ndarray): Volume with shape (D, H, W, C) or (D, H, W).
+            **params (Any): Additional parameters.
+
+        Returns:
+            np.ndarray: Grayscale volume.
+
+        """
+        if is_grayscale_image(volume, has_depth_dim=True):
+            warnings.warn("The volume is already gray.", stacklevel=2)
+            return volume
+
+        return fpixel.to_gray(volume, self.num_output_channels, self.method)
+
+    def apply_to_volumes(self, volumes: np.ndarray, **params: Any) -> np.ndarray:
+        """Apply ToGray to a batch of volumes.
+
+        Args:
+            volumes (np.ndarray): Batch of volumes with shape (N, D, H, W, C) or (N, D, H, W).
+            **params (Any): Additional parameters.
+
+        Returns:
+            np.ndarray: Batch of grayscale volumes.
+
+        """
+        if is_grayscale_image(volumes, has_batch_dim=True, has_depth_dim=True):
+            warnings.warn("The volumes are already gray.", stacklevel=2)
+            return volumes
+
+        return fpixel.to_gray(volumes, self.num_output_channels, self.method)
+
 
 class ToRGB(ImageOnlyTransform):
     """Convert an input image from grayscale to RGB format.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ INSTALL_REQUIRES = [
     "PyYAML",
     "typing-extensions>=4.9.0; python_version<'3.10'",
     "pydantic>=2.9.2",
-    "albucore==0.0.25",
+    "albucore==0.0.26",
     "eval-type-backport; python_version<'3.10'",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ INSTALL_REQUIRES = [
     "PyYAML",
     "typing-extensions>=4.9.0; python_version<'3.10'",
     "pydantic>=2.9.2",
-    "albucore==0.0.24",
+    "albucore==0.0.25",
     "eval-type-backport; python_version<'3.10'",
 ]
 


### PR DESCRIPTION
## Summary by Sourcery

Enhance grayscale conversion functions to support batched and volumetric inputs and improve shape and dtype handling, and add corresponding batch/volume apply methods to the ToGray transform.

New Features:
- Support batch images and multi-dimensional volumes in ToGray transform via apply_to_images, apply_to_volume, and apply_to_volumes methods.

Enhancements:
- Extend to_gray_from_lab to handle single images, batches, volumes, and batch volumes efficiently using reshape_for_channel and restore_from_channel utilities.
- Update to_gray_pca and grayscale_to_multichannel to generalize shape handling and streamline multi-channel stacking.
- Adjust to_gray_from_lab float32 output to normalize L channel to [0,1] and maintain dtype consistency.

Build:
- Bump albucore dependency to 0.0.26