### PR TITLE
Fix reproducibility

### DIFF
--- a/.cursor/rules/albumentations-rules.mdc
+++ b/.cursor/rules/albumentations-rules.mdc
@@ -11,3 +11,4 @@ alwaysApply: true
 - we do not use fill_value, but fill. Not fill_mask_value, but fill_mask
 - We do not have ANY default values in the InitSchema class
 - Use pytest.mark.parametrize for parameterized tests
+- In the code, when need default value use 137, not 42

--- a/.cursor/rules/coding-guidelines.mdc
+++ b/.cursor/rules/coding-guidelines.mdc
@@ -667,6 +667,6 @@ Before submitting your PR:
 
 If you have questions about these guidelines:
 
-1. Join our [Discord community](mdc:https:/discord.gg/e6zHCXTvaN)
-2. Open a GitHub [issue](mdc:https:/github.com/albumentations-team/albumentations/issues)
-3. Ask in your [pull request](mdc:https:/github.com/albumentations-team/albumentations/pulls)
+1. Join our [Discord community](https://discord.gg/e6zHCXTvaN)
+2. Open a GitHub [issue](https://github.com/albumentations-team/albumentations/issues)
+3. Ask in your [pull request](https://github.com/albumentations-team/albumentations/pulls)

--- a/.cursor/rules/coding-guidelines.mdc
+++ b/.cursor/rules/coding-guidelines.mdc
@@ -667,6 +667,6 @@ Before submitting your PR:
 
 If you have questions about these guidelines:
 
-1. Join our [Discord community](https://discord.gg/e6zHCXTvaN)
-2. Open a GitHub [issue](https://github.com/albumentations-team/albumentations/issues)
-3. Ask in your [pull request](https://github.com/albumentations-team/albumentations/pulls)
+1. Join our [Discord community](mdc:https:/discord.gg/e6zHCXTvaN)
+2. Open a GitHub [issue](mdc:https:/github.com/albumentations-team/albumentations/issues)
+3. Ask in your [pull request](mdc:https:/github.com/albumentations-team/albumentations/pulls)

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1636,7 +1636,7 @@ class SelectiveChannelTransform(BaseCompose):
             for t in self.transforms:
                 sub_data = {"image": sub_image}
                 sub_image = t(**sub_data)["image"]
-                self._track_transform_params(t, data)
+                self._track_transform_params(t, sub_data)
 
             transformed_channels = cv2.split(sub_image)
             output_img = image.copy()

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -842,7 +842,6 @@ class Compose(BaseCompose, HubMixin):
         # Check and sync worker seed if needed
         self._check_worker_seed()
 
-        # Original __call__ implementation
         if args:
             msg = "You have to pass data to augmentations as named arguments, for example: aug(image=image)"
             raise KeyError(msg)

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -905,6 +905,8 @@ class Compose(BaseCompose, HubMixin):
         self.__dict__.update(state)
         # If we have a seed, recalculate effective seed in worker context
         if hasattr(self, "seed") and self.seed is not None:
+            # Reset _last_torch_seed to ensure worker-seed sync runs after unpickling
+            self._last_torch_seed = None
             # Recalculate effective seed in worker context
             self.set_random_seed(self.seed)
 

--- a/tests/test_per_worker_seed.py
+++ b/tests/test_per_worker_seed.py
@@ -277,7 +277,7 @@ def test_worker_seed_diversity():
         sequences = [result.get() for result in worker_results]
 
     # Check that workers produced different sequences
-    unique_sequences = set(tuple(seq) for seq in sequences)
+    unique_sequences = {tuple(seq) for seq in sequences}
     assert len(unique_sequences) > 1, "All workers produced identical augmentation sequences"
 
     # Each worker should have some flips and some non-flips (with high probability)

--- a/tests/test_per_worker_seed.py
+++ b/tests/test_per_worker_seed.py
@@ -117,8 +117,8 @@ def test_worker_seed_with_torch():
     reason="PyTorch not available"
 )
 @pytest.mark.skipif(
-    sys.platform == "darwin",
-    reason="Multiprocessing test skipped on macOS due to spawn/fork issues"
+    sys.platform in ["darwin", "win32"],
+    reason="Multiprocessing test incompatible with spawn method used on macOS/Windows"
 )
 def test_dataloader_epoch_diversity():
     """Test that DataLoader produces different augmentations across epochs with worker-aware seed."""

--- a/tests/test_per_worker_seed.py
+++ b/tests/test_per_worker_seed.py
@@ -32,6 +32,10 @@ def test_worker_seed_without_torch():
     "torch" not in sys.modules and not any("torch" in str(p) for p in sys.path),
     reason="PyTorch not available"
 )
+@pytest.mark.skipif(
+    sys.platform in ["darwin", "win32"],
+    reason="Multiprocessing test incompatible with spawn method used on macOS/Windows"
+)
 def test_worker_seed_with_torch():
     """Test worker seed functionality with PyTorch available."""
     import torch
@@ -112,6 +116,10 @@ def test_worker_seed_with_torch():
     "torch" not in sys.modules and not any("torch" in str(p) for p in sys.path),
     reason="PyTorch not available"
 )
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="Multiprocessing test skipped on macOS due to spawn/fork issues"
+)
 def test_dataloader_epoch_diversity():
     """Test that DataLoader produces different augmentations across epochs with worker-aware seed."""
     import torch
@@ -142,10 +150,6 @@ def test_dataloader_epoch_diversity():
     ], seed=42)
 
     dataset = SimpleDataset(transform=transform)
-
-    # Skip on platforms where multiprocessing is problematic
-    if sys.platform == "darwin":
-        pytest.skip("Multiprocessing test skipped on macOS due to spawn/fork issues")
 
     # Test with persistent_workers=False
     dataloader = torch.utils.data.DataLoader(
@@ -279,11 +283,12 @@ def worker_process_simulation(worker_id: int, base_seed: int, num_iterations: in
     return results
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Multiprocessing test skipped on Windows"
+)
 def test_worker_seed_diversity():
     """Test that different workers produce different augmentation sequences."""
-    if sys.platform == "win32":
-        # Skip on Windows due to multiprocessing limitations
-        pytest.skip("Multiprocessing test skipped on Windows")
 
     base_seed = 137
     num_workers = 4

--- a/tests/test_per_worker_seed.py
+++ b/tests/test_per_worker_seed.py
@@ -1,0 +1,287 @@
+"""Tests for worker-aware seed functionality in Compose."""
+
+import multiprocessing
+import sys
+
+import numpy as np
+import pytest
+
+import albumentations as A
+
+
+class MockWorkerInfo:
+    """Mock torch.utils.data.get_worker_info() response."""
+    def __init__(self, id: int):
+        self.id = id
+
+
+def test_worker_seed_without_torch():
+    """Test that worker seed functionality works when PyTorch is not available."""
+    # Create compose (worker-aware seed is now always enabled)
+    transform = A.Compose([
+        A.HorizontalFlip(p=0.5),
+    ], seed=137)
+
+    # Should work fine without PyTorch
+    img = np.ones((100, 100, 3), dtype=np.uint8)
+    result = transform(image=img)
+    assert result['image'].shape == (100, 100, 3)
+
+
+@pytest.mark.skipif(
+    "torch" not in sys.modules and not any("torch" in str(p) for p in sys.path),
+    reason="PyTorch not available"
+)
+def test_worker_seed_with_torch():
+    """Test worker seed functionality with PyTorch available."""
+    import torch
+    import torch.utils.data
+
+    class TestDataset(torch.utils.data.Dataset):
+        def __init__(self, transform):
+            self.transform = transform
+
+        def __len__(self):
+            return 10
+
+        def __getitem__(self, idx):
+            # Create a simple test image
+            img = np.ones((100, 100, 3), dtype=np.uint8) * idx
+            result = self.transform(image=img)
+            # Return whether the image was flipped
+            return np.array_equal(result['image'], img)
+
+    # Test with worker-aware seed (now always enabled)
+    transform_with_worker_seed = A.Compose([
+        A.HorizontalFlip(p=0.5),
+    ], seed=137)
+
+    dataset = TestDataset(transform_with_worker_seed)
+
+    # Test with multiple workers
+    if sys.platform != "darwin" or sys.version_info < (3, 8):
+        # Skip multiprocessing tests on macOS with older Python due to fork/spawn issues
+        loader = torch.utils.data.DataLoader(
+            dataset,
+            batch_size=1,
+            num_workers=2,
+            persistent_workers=False
+        )
+
+        # Collect results from multiple epochs
+        epoch_results = []
+        for epoch in range(3):
+            epoch_data = []
+            for batch in loader:
+                epoch_data.append(batch.item())
+            epoch_results.append(epoch_data)
+
+        # With worker-aware seed and persistent_workers=False,
+        # results should vary between epochs
+        assert epoch_results[0] != epoch_results[1] or epoch_results[1] != epoch_results[2], \
+            "All epochs produced identical results with worker-aware seed"
+
+
+@pytest.mark.skipif(
+    "torch" not in sys.modules and not any("torch" in str(p) for p in sys.path),
+    reason="PyTorch not available"
+)
+def test_dataloader_epoch_diversity():
+    """Test that DataLoader produces different augmentations across epochs with worker-aware seed."""
+    import torch
+    import torch.utils.data
+
+    class SimpleDataset(torch.utils.data.Dataset):
+        def __init__(self, transform):
+            self.transform = transform
+            # Create identical images
+            self.data = [np.ones((10, 10, 3), dtype=np.uint8) * 255] * 4
+
+        def __len__(self):
+            return len(self.data)
+
+        def __getitem__(self, idx):
+            image = self.data[idx].copy()
+            if self.transform:
+                augmented = self.transform(image=image)
+                image = augmented['image']
+            # Return sum of pixel values as a simple hash
+            return float(np.sum(image))
+
+    # Create transform with fixed seed (worker-aware seed is always enabled)
+    transform = A.Compose([
+        A.RandomBrightnessContrast(p=1.0, brightness_limit=0.3),
+        A.HorizontalFlip(p=0.5),
+        A.Rotate(limit=30, p=0.5),
+    ], seed=42)
+
+    dataset = SimpleDataset(transform=transform)
+
+    # Skip on platforms where multiprocessing is problematic
+    if sys.platform == "darwin" and sys.version_info >= (3, 8):
+        pytest.skip("Multiprocessing test skipped on macOS with Python 3.8+")
+
+    # Test with persistent_workers=False
+    dataloader = torch.utils.data.DataLoader(
+        dataset,
+        batch_size=2,
+        num_workers=2,
+        persistent_workers=False
+    )
+
+    # Collect data from multiple epochs
+    epoch_data = []
+    for epoch in range(3):
+        epoch_batch_sums = []
+        for batch in dataloader:
+            # Convert batch to list and sum all values
+            batch_sum = float(torch.sum(batch))
+            epoch_batch_sums.append(batch_sum)
+        epoch_data.append(epoch_batch_sums)
+
+    # Check that epochs produce different results
+    # At least one epoch should differ from the others
+    assert not (epoch_data[0] == epoch_data[1] == epoch_data[2]), \
+        f"All epochs produced identical augmentations: {epoch_data}"
+
+
+def test_compose_serialization():
+    """Test that Compose serialization works properly."""
+    # Test with worker-aware seed (always enabled)
+    transform1 = A.Compose([
+        A.HorizontalFlip(p=0.5),
+    ], seed=137)
+
+    # Serialize and deserialize
+    serialized = transform1.to_dict()
+
+    # Test deserialization
+    transform2 = A.from_dict(serialized)
+    assert hasattr(transform2, 'seed')
+    assert transform2.seed == 137
+
+
+def test_effective_seed_calculation():
+    """Test the _get_effective_seed method directly."""
+    transform = A.Compose([
+        A.HorizontalFlip(p=0.5),
+    ], seed=137)
+
+    # Test with None seed
+    assert transform._get_effective_seed(None) is None
+
+    # Test without worker context
+    assert transform._get_effective_seed(137) == 137
+
+    # Test seed overflow
+    large_seed = 2**32 - 1
+    result = transform._get_effective_seed(large_seed)
+    assert 0 <= result < 2**32
+
+
+def test_deterministic_behavior_single_process():
+    """Test that transforms are deterministic in a single process."""
+    transform = A.Compose([
+        A.HorizontalFlip(p=0.5),
+        A.RandomBrightnessContrast(p=0.5),
+    ], seed=137)
+
+    img = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+
+    # Reset seed and get results
+    results = []
+    for _ in range(3):
+        transform.set_random_seed(137)
+        result = transform(image=img.copy())
+        results.append(result['image'])
+
+    # All results should be identical
+    for i in range(1, len(results)):
+        np.testing.assert_array_equal(results[0], results[i])
+
+
+def test_multiple_compose_instances():
+    """Test that multiple Compose instances with same seed produce same results."""
+    # Create two instances with same configuration
+    transform1 = A.Compose([
+        A.HorizontalFlip(p=0.5),
+        A.Rotate(limit=45, p=0.5),
+    ], seed=137)
+
+    transform2 = A.Compose([
+        A.HorizontalFlip(p=0.5),
+        A.Rotate(limit=45, p=0.5),
+    ], seed=137)
+
+    img = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+
+    # Both should produce the same result
+    result1 = transform1(image=img.copy())
+    result2 = transform2(image=img.copy())
+
+    np.testing.assert_array_equal(result1['image'], result2['image'])
+
+
+def worker_process_simulation(worker_id: int, base_seed: int, num_iterations: int) -> list[bool]:
+    """Simulate a worker process with given ID and seed.
+
+    Returns list of booleans indicating whether HorizontalFlip was applied.
+    """
+    # Each worker uses a different seed to simulate worker diversity
+    # This simulates what would happen with torch.initial_seed()
+    # Use a hash to get more diverse seeds
+    import hashlib
+    worker_seed = int(hashlib.md5(f"{base_seed}_{worker_id}".encode()).hexdigest()[:8], 16)
+
+    # Create transform with a unique seed per worker
+    transform = A.Compose([
+        A.HorizontalFlip(p=0.5),
+    ], seed=worker_seed)  # Simulating worker-aware behavior
+
+    # Run iterations
+    results = []
+    # Create an asymmetric image so we can detect flips
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+    img[:, :5] = 255  # Left half white
+
+    for _ in range(num_iterations):
+        result = transform(image=img.copy())
+        # Check if image was flipped by checking left corner
+        was_flipped = result['image'][0, 0, 0] == 0  # If flipped, left corner will be black
+        results.append(was_flipped)
+
+    return results
+
+
+def test_worker_seed_diversity():
+    """Test that different workers produce different augmentation sequences."""
+    if sys.platform == "win32":
+        # Skip on Windows due to multiprocessing limitations
+        pytest.skip("Multiprocessing test skipped on Windows")
+
+    base_seed = 137
+    num_workers = 4
+    num_iterations = 20
+
+    # Run simulation for each worker
+    with multiprocessing.Pool(processes=num_workers) as pool:
+        worker_results = []
+        for worker_id in range(num_workers):
+            result = pool.apply_async(
+                worker_process_simulation,
+                args=(worker_id, base_seed, num_iterations)
+            )
+            worker_results.append(result)
+
+        # Collect results
+        sequences = [result.get() for result in worker_results]
+
+    # Check that workers produced different sequences
+    unique_sequences = set(tuple(seq) for seq in sequences)
+    assert len(unique_sequences) > 1, "All workers produced identical augmentation sequences"
+
+    # Each worker should have some flips and some non-flips (with high probability)
+    for worker_id, sequence in enumerate(sequences):
+        num_flips = sum(sequence)
+        assert 0 < num_flips < num_iterations, \
+            f"Worker {worker_id} produced extreme results: {num_flips}/{num_iterations} flips"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,7 +1,6 @@
 import io
 from pathlib import Path
 from typing import Any, Dict, Set
-from unittest.mock import patch
 from io import StringIO
 
 import numpy as np
@@ -715,6 +714,7 @@ def test_serialization_v2_to_dict() -> None:
         "keypoint_params": None,
         "additional_targets": {},
         "is_check_shapes": True,
+        "seed": None,
     }
 
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1126,6 +1126,11 @@ def test_change_image(augmentation_cls, params, image):
     ["augmentation_cls", "params"],
     get_2d_transforms(
         custom_arguments={
+            A.AdvancedBlur: {"blur_limit": (5, 7),
+                             "sigma_x_limit": (1, 3),
+                             "sigma_y_limit": (1, 3),
+                             "rotate_limit": (0, 0),
+                             },
         },
         except_augmentations={
             A.Crop,
@@ -1784,6 +1789,7 @@ def test_mask_dropout_bboxes(remove_invisible, expected_keypoints):
             A.OpticalDistortion,
             A.ThinPlateSpline,
             A.Mosaic,
+            A.FrequencyMasking,
         },
     ),
 )


### PR DESCRIPTION
## Summary by Sourcery

Enable worker-aware random seeding in Compose transforms to ensure reproducible augmentations across single- and multi-process DataLoader contexts.

New Features:
- Add _get_effective_seed to compute per-worker seed based on torch.initial_seed
- Override Compose.set_random_seed and __setstate__ to incorporate worker context into seeding
- Introduce _check_worker_seed to automatically synchronize RNG state in __call__ when inside DataLoader workers

Bug Fixes:
- Fix seed propagation to nested transforms for consistent reproducibility
- Correct parameter passing in OneOf and ChannelShuffle super().__init__ calls

Enhancements:
- Store original seed and include it in to_dict serialization
- Propagate RNG state updates to all transforms via set_random_state or set_random_seed

Tests:
- Add comprehensive tests for worker-aware seeding in single- and multi-worker DataLoader scenarios
- Update serialization tests to verify seed inclusion
- Include deterministic behavior and diversity tests across epochs and workers