### PR TITLE
Speedup in fpixel.grayscale_to_multichannel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
         language: system
         files: setup.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.12.0
     hooks:
       - id: ruff
         exclude: '__pycache__/'
@@ -98,7 +98,7 @@ repos:
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.0
+    rev: v1.16.1
     hooks:
       - id: mypy
         files: ^albumentations/

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -1465,7 +1465,7 @@ class GridElasticDeform(DualTransform):
                 for tile in tiles
             ],
         ).reshape(
-            self.num_grid_xy[::-1] + (4,),
+            (*self.num_grid_xy[::-1], 4),
         )  # Reshape to (grid_height, grid_width, 4)
 
         polygons = fgeometric.generate_distorted_grid_polygons(

--- a/albumentations/augmentations/pixel/functional.py
+++ b/albumentations/augmentations/pixel/functional.py
@@ -1634,8 +1634,8 @@ def grayscale_to_multichannel(
         return grayscale_image
 
     squeezed = np.squeeze(grayscale_image)
-    # For multi-channel output, stack channels
-    return np.stack([squeezed] * num_output_channels, axis=-1)
+    # For multi-channel output, use tile for better performance
+    return np.tile(squeezed[..., np.newaxis], (1,) * squeezed.ndim + (num_output_channels,))
 
 
 @preserve_channel_dim
@@ -2506,7 +2506,7 @@ def generate_noise(
     height, width = shape[:2]
     reduced_height = max(1, int(height * approximation))
     reduced_width = max(1, int(width * approximation))
-    reduced_shape = (reduced_height, reduced_width) + shape[2:]
+    reduced_shape = (reduced_height, reduced_width, *shape[2:])
 
     # Generate noise at reduced resolution
     if spatial_mode == "shared":
@@ -3469,7 +3469,7 @@ def prepare_drop_values(
         return np.full(array.shape, values[0], dtype=array.dtype)
 
     # For multichannel input, broadcast values to full shape
-    return np.full(array.shape[:2] + (len(values),), values, dtype=array.dtype)
+    return np.full((*array.shape[:2], len(values)), values, dtype=array.dtype)
 
 
 def get_mask_array(data: dict[str, Any]) -> np.ndarray | None:

--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -3607,13 +3607,52 @@ class ToRGB(ImageOnlyTransform):
             warnings.warn("The image is already an RGB.", stacklevel=2)
             return np.ascontiguousarray(img)
         if not is_grayscale_image(img):
-            msg = "ToRGB transformation expects 2-dim images or 3-dim with the last dimension equal to 1."
+            msg = "ToRGB transformation expects images with the number of channels equal to 1."
             raise TypeError(msg)
 
         return fpixel.grayscale_to_multichannel(
             img,
             num_output_channels=self.num_output_channels,
         )
+
+    def apply_to_images(self, images: np.ndarray, **params: Any) -> np.ndarray:
+        """Apply ToRGB to a batch of images.
+
+        Args:
+            images (np.ndarray): Batch of images with shape (N, H, W, C) or (N, H, W).
+            **params (Any): Additional parameters.
+
+        Returns:
+            np.ndarray: Batch of RGB images.
+
+        """
+        return self.apply(images, **params)
+
+    def apply_to_volume(self, volume: np.ndarray, **params: Any) -> np.ndarray:
+        """Apply ToRGB to a single volume.
+
+        Args:
+            volume (np.ndarray): Volume with shape (D, H, W, C) or (D, H, W).
+            **params (Any): Additional parameters.
+
+        Returns:
+            np.ndarray: Grayscale volume.
+
+        """
+        return self.apply(volume, **params)
+
+    def apply_to_volumes(self, volumes: np.ndarray, **params: Any) -> np.ndarray:
+        """Apply ToRGB to a batch of volumes.
+
+        Args:
+            volumes (np.ndarray): Batch of volumes with shape (N, D, H, W, C) or (N, D, H, W).
+            **params (Any): Additional parameters.
+
+        Returns:
+            np.ndarray: Batch of RGB volumes.
+
+        """
+        return self.apply(volumes, **params)
 
 
 class ToSepia(ImageOnlyTransform):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,7 @@ lint.ignore = [
   "FBT002",
   "FBT003",
   "G004",
+  "PLC0415",
   "PLR0911",
   "PLR0913",
   "PLR2004",


### PR DESCRIPTION
## Summary by Sourcery

Add batch and volume support to ToRGB transform, optimize grayscale-to-RGB conversion, unify shape tuple handling, bump pre-commit hook versions, and update lint configuration

New Features:
- Add apply_to_images, apply_to_volume, and apply_to_volumes methods to ToRGB transform for batch and volumetric inputs

Enhancements:
- Replace np.stack with np.tile in grayscale_to_multichannel for improved performance
- Use tuple unpacking for consistent shape tuple construction in geometric transforms and noise/drop-value generation
- Refine TypeError message for invalid channel input

Build:
- Bump ruff pre-commit hook to v0.12.0
- Upgrade mypy pre-commit hook to v1.16.1

Chores:
- Add "PLC0415" to lint ignore list in pyproject.toml